### PR TITLE
emit SymbolInformation with documentation for function parameters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/exp v0.0.0-20221205204356-47842c84f3db
-	golang.org/x/mod v0.6.0 // indirect
+	golang.org/x/mod v0.6.0
 	golang.org/x/net v0.1.0 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/term v0.1.0 // indirect

--- a/internal/document/document.go
+++ b/internal/document/document.go
@@ -71,7 +71,7 @@ func (d *Document) SetNewSymbol(
 
 // SetNewSymbolForPos declares a new symbol and tracks it within a Document
 // but allows for an override of the position. Generally speaking, you should use
-// DeclareNewSymbol instead (since it will calculate the pos for most cases)
+// SetNewSymbol instead (since it will calculate the pos for most cases)
 //
 // NOTE: Does NOT emit a new occurrence
 func (d *Document) SetNewSymbolForPos(

--- a/internal/funk/funk.go
+++ b/internal/funk/funk.go
@@ -1,23 +1,5 @@
 package funk
 
-import (
-	"sort"
-
-	"golang.org/x/exp/constraints"
-)
-
-func Keys[K constraints.Ordered, V any](m map[K]V) []K {
-	keys := make([]K, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-
-	// Always give back a sorted list
-	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
-
-	return keys
-}
-
 func Map[T any, V any](l []T, f func(T) V) []V {
 	vals := make([]V, len(l))
 	for i, v := range l {

--- a/internal/index/scip.go
+++ b/internal/index/scip.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/sourcegraph/scip-go/internal/config"
 	"github.com/sourcegraph/scip-go/internal/document"
-	"github.com/sourcegraph/scip-go/internal/funk"
 	"github.com/sourcegraph/scip-go/internal/handler"
 	impls "github.com/sourcegraph/scip-go/internal/implementations"
 	"github.com/sourcegraph/scip-go/internal/loader"
@@ -20,6 +19,8 @@ import (
 	"github.com/sourcegraph/scip-go/internal/symbols"
 	"github.com/sourcegraph/scip-go/internal/visitors"
 	"github.com/sourcegraph/scip/bindings/go/scip"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -61,13 +62,15 @@ func ListMissing(opts config.IndexOpts) (missing []string, err error) {
 		return nil, err
 	}
 
-	lookupNames := funk.Keys(pkgLookup)
+	lookupNames := maps.Keys(pkgLookup)
+	slices.Sort(lookupNames)
 	for _, pkgName := range lookupNames {
 		pkg := pkgLookup[pkgName]
 		visitors.VisitPackageSyntax(opts.ModuleRoot, pkg, pathToDocuments, globalSymbols)
 	}
 
-	pkgNames := funk.Keys(pkgs)
+	pkgNames := maps.Keys(pkgs)
+	slices.Sort(pkgNames)
 	for _, name := range pkgNames {
 		pkg := pkgs[name]
 		for _, f := range pkg.Syntax {
@@ -111,7 +114,8 @@ func Index(writer func(proto.Message), opts config.IndexOpts) error {
 		impls.AddImplementationRelationships(pkgs, allPackages, globalSymbols)
 	}
 
-	pkgIDs := funk.Keys(pkgs)
+	pkgIDs := maps.Keys(pkgs)
+	slices.Sort(pkgIDs)
 	pkgLen := len(pkgIDs)
 
 	var count uint64
@@ -173,7 +177,8 @@ func indexVisitPackages(
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	lookupIDs := funk.Keys(pkgLookup)
+	lookupIDs := maps.Keys(pkgLookup)
+	slices.Sort(lookupIDs)
 
 	// We have to visit all the packages to get the definition sites
 	// for all the symbols.

--- a/internal/lookup/lookup.go
+++ b/internal/lookup/lookup.go
@@ -119,8 +119,10 @@ func (p *Global) GetPackage(pkg *packages.Package) *Package {
 	return p.symbols[newtypes.GetID(pkg)]
 }
 
-var skippedTypes = map[string]struct{}{}
-var builtinSymbols = map[string]*scip.SymbolInformation{}
+var (
+	skippedTypes   = map[string]struct{}{}
+	builtinSymbols = map[string]*scip.SymbolInformation{}
+)
 
 // GetSymbolOfObject returns a symbol and whether we were successful at finding.
 //
@@ -188,13 +190,13 @@ func (p *Global) GetSymbolOfObject(obj types.Object) (*scip.SymbolInformation, b
 	// 	))
 	// }
 
-	return nil, false, errors.New(fmt.Sprintf(
+	return nil, false, fmt.Errorf(
 		"failed to create symbol for obj: %T %+v\n%s",
 		obj,
 		obj,
 		// pkgFields.pkg.Fset.Position(obj.Pos()),
 		pkgPath,
-	))
+	)
 }
 
 func (p *Global) getSymbolInformationByPath(pkgID newtypes.PackageID, pos token.Pos) (*scip.SymbolInformation, *Package, bool) {

--- a/internal/testdata/snapshots/input/inlinestruct/inlinestruct_interface.go
+++ b/internal/testdata/snapshots/input/inlinestruct/inlinestruct_interface.go
@@ -2,12 +2,12 @@ package inlinestruct
 
 import "context"
 
-func Target() interface {
+func Target() (bananas interface {
 	OID(context.Context) (int, error)
 	AbbreviatedOID(context.Context) (string, error)
 	Commit(context.Context) (string, error)
 	Type(context.Context) (int, error)
-} {
+}) {
 	panic("not implemented")
 }
 

--- a/internal/testdata/snapshots/output/embedded/embedded.go
+++ b/internal/testdata/snapshots/output/embedded/embedded.go
@@ -25,13 +25,14 @@
   func wrapExecCommand(c *exec.Cmd) {
 //     ^^^^^^^^^^^^^^^ definition 0.1.test sg/embedded/wrapExecCommand().
 //     documentation ```go
-//                     ^ definition local 0
+//                     ^ definition 0.1.test sg/embedded/wrapExecCommand().(c)
+//                     documentation ```go
 //                        ^^^^ reference github.com/golang/go/src go1.19 os/exec/
 //                             ^^^ reference github.com/golang/go/src go1.19 os/exec/Cmd#
    _ = &osExecCommand{Cmd: c}
 //      ^^^^^^^^^^^^^ reference 0.1.test sg/embedded/osExecCommand#
 //                    ^^^ reference 0.1.test sg/embedded/osExecCommand#Cmd.
-//                         ^ reference local 0
+//                         ^ reference 0.1.test sg/embedded/wrapExecCommand().(c)
   }
   
   type Inner struct {
@@ -66,7 +67,7 @@
 //     ^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test sg/embedded/useOfCompositeStructs().
 //     documentation ```go
    o := Outer{
-// ^ definition local 1
+// ^ definition local 0
 //      ^^^^^ reference 0.1.test sg/embedded/Outer#
     Inner: Inner{
 //  ^^^^^ reference 0.1.test sg/embedded/Outer#Inner.
@@ -85,12 +86,12 @@
    fmt.Printf("> %d\n", o.X)
 // ^^^ reference github.com/golang/go/src go1.19 fmt/
 //     ^^^^^^ reference github.com/golang/go/src go1.19 fmt/Printf().
-//                      ^ reference local 1
+//                      ^ reference local 0
 //                        ^ reference 0.1.test sg/embedded/Inner#X.
    fmt.Println(o.Inner.Y)
 // ^^^ reference github.com/golang/go/src go1.19 fmt/
 //     ^^^^^^^ reference github.com/golang/go/src go1.19 fmt/Println().
-//             ^ reference local 1
+//             ^ reference local 0
 //               ^^^^^ reference 0.1.test sg/embedded/Outer#Inner.
 //                     ^ reference 0.1.test sg/embedded/Inner#Y.
   }

--- a/internal/testdata/snapshots/output/embedded/internal/nested.go
+++ b/internal/testdata/snapshots/output/embedded/internal/nested.go
@@ -12,22 +12,23 @@
   func Something(recent embedded.RecentCommittersResults) {
 //     ^^^^^^^^^ definition 0.1.test sg/embedded/internal/Something().
 //     documentation ```go
-//               ^^^^^^ definition local 0
+//               ^^^^^^ definition 0.1.test sg/embedded/internal/Something().(recent)
+//               documentation ```go
 //                      ^^^^^^^^ reference 0.1.test sg/embedded/
 //                               ^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test sg/embedded/RecentCommittersResults#
    for _, commit := range recent.Nodes {
-//        ^^^^^^ definition local 1
-//                        ^^^^^^ reference local 0
+//        ^^^^^^ definition local 0
+//                        ^^^^^^ reference 0.1.test sg/embedded/internal/Something().(recent)
 //                               ^^^^^ reference 0.1.test sg/embedded/RecentCommittersResults#Nodes.
     for _, author := range commit.Authors.Nodes {
-//         ^^^^^^ definition local 2
-//                         ^^^^^^ reference local 1
+//         ^^^^^^ definition local 1
+//                         ^^^^^^ reference local 0
 //                                ^^^^^^^ reference 0.1.test sg/embedded/RecentCommittersResults#Nodes.Authors.
 //                                        ^^^^^ reference 0.1.test sg/embedded/RecentCommittersResults#Nodes.Authors.Nodes.
      fmt.Println(author.Name)
 //   ^^^ reference github.com/golang/go/src go1.19 fmt/
 //       ^^^^^^^ reference github.com/golang/go/src go1.19 fmt/Println().
-//               ^^^^^^ reference local 2
+//               ^^^^^^ reference local 1
 //                      ^^^^ reference 0.1.test sg/embedded/RecentCommittersResults#Nodes.Authors.Nodes.Name.
     }
    }

--- a/internal/testdata/snapshots/output/embedded/nested.go
+++ b/internal/testdata/snapshots/output/embedded/nested.go
@@ -25,17 +25,18 @@
   func NestedExample(n NestedHandler) {
 //     ^^^^^^^^^^^^^ definition 0.1.test sg/embedded/NestedExample().
 //     documentation ```go
-//                   ^ definition local 0
+//                   ^ definition 0.1.test sg/embedded/NestedExample().(n)
+//                   documentation ```go
 //                     ^^^^^^^^^^^^^ reference 0.1.test sg/embedded/NestedHandler#
    _ = n.Handler.ServeHTTP
-//     ^ reference local 0
+//     ^ reference 0.1.test sg/embedded/NestedExample().(n)
 //       ^^^^^^^ reference 0.1.test sg/embedded/NestedHandler#Handler.
 //               ^^^^^^^^^ reference github.com/golang/go/src go1.19 net/http/Handler#ServeHTTP.
    _ = n.ServeHTTP
-//     ^ reference local 0
+//     ^ reference 0.1.test sg/embedded/NestedExample().(n)
 //       ^^^^^^^^^ reference github.com/golang/go/src go1.19 net/http/Handler#ServeHTTP.
    _ = n.Other
-//     ^ reference local 0
+//     ^ reference 0.1.test sg/embedded/NestedExample().(n)
 //       ^^^^^ reference 0.1.test sg/embedded/NestedHandler#Other.
   }
   

--- a/internal/testdata/snapshots/output/generallyeric/generallyeric.go
+++ b/internal/testdata/snapshots/output/generallyeric/generallyeric.go
@@ -10,15 +10,16 @@
 //     ^^^^^ definition 0.1.test sg/generallyeric/Print().
 //     documentation ```go
 //           ^ definition local 0
-//                  ^ definition local 1
+//                  ^ definition 0.1.test sg/generallyeric/Print().(s)
+//                  documentation ```go
 //                      ^ reference local 0
    for _, v := range s {
-//        ^ definition local 2
-//                   ^ reference local 1
+//        ^ definition local 1
+//                   ^ reference 0.1.test sg/generallyeric/Print().(s)
     fmt.Print(v)
 //  ^^^ reference github.com/golang/go/src go1.19 fmt/
 //      ^^^^^ reference github.com/golang/go/src go1.19 fmt/Print().
-//            ^ reference local 2
+//            ^ reference local 1
    }
   }
   

--- a/internal/testdata/snapshots/output/generallyeric/new_operators.go
+++ b/internal/testdata/snapshots/output/generallyeric/new_operators.go
@@ -22,34 +22,35 @@
 //     documentation ```go
 //            ^ definition local 0
 //              ^^^^^^ reference 0.1.test sg/generallyeric/Number#
-//                      ^^^^^ definition local 1
+//                      ^^^^^ definition 0.1.test sg/generallyeric/Double().(value)
+//                      documentation ```go
 //                            ^ reference local 0
 //                               ^ reference local 0
    return value * 2
-//        ^^^^^ reference local 1
+//        ^^^^^ reference 0.1.test sg/generallyeric/Double().(value)
   }
   
   type Box[T any] struct {
 //     ^^^ definition 0.1.test sg/generallyeric/Box#
 //     documentation ```go
 //     documentation ```go
-//         ^ definition local 2
+//         ^ definition local 1
    Something T
 // ^^^^^^^^^ definition 0.1.test sg/generallyeric/Box#Something.
 // documentation ```go
-//           ^ reference local 2
+//           ^ reference local 1
   }
   
   type handler[T any] struct {
 //     ^^^^^^^ definition 0.1.test sg/generallyeric/handler#
 //     documentation ```go
 //     documentation ```go
-//             ^ definition local 3
+//             ^ definition local 2
    Box[T]
 // ^^^ definition 0.1.test sg/generallyeric/handler#Box.
 // documentation ```go
 // ^^^ reference 0.1.test sg/generallyeric/Box#
-//     ^ reference local 3
+//     ^ reference local 2
    Another string
 // ^^^^^^^ definition 0.1.test sg/generallyeric/handler#Another.
 // documentation ```go

--- a/internal/testdata/snapshots/output/generallyeric/person.go
+++ b/internal/testdata/snapshots/output/generallyeric/person.go
@@ -35,13 +35,14 @@
 //     documentation ```go
 //            ^ definition local 1
 //              ^^^^^^ reference 0.1.test sg/generallyeric/Person#
-//                      ^^^^^^ definition local 2
+//                      ^^^^^^ definition 0.1.test sg/generallyeric/DoWork().(things)
+//                      documentation ```go
 //                               ^ reference local 1
    for _, v := range things {
-//        ^ definition local 3
-//                   ^^^^^^ reference local 2
+//        ^ definition local 2
+//                   ^^^^^^ reference 0.1.test sg/generallyeric/DoWork().(things)
     v.Work()
-//  ^ reference local 3
+//  ^ reference local 2
 //    ^^^^ reference 0.1.test sg/generallyeric/Person#Work.
    }
   }
@@ -50,21 +51,21 @@
 //     ^^^^ definition 0.1.test sg/generallyeric/main().
 //     documentation ```go
    var a, b, c worker
-//     ^ definition local 4
-//        ^ definition local 5
-//           ^ definition local 6
+//     ^ definition local 3
+//        ^ definition local 4
+//           ^ definition local 5
 //             ^^^^^^ reference 0.1.test sg/generallyeric/worker#
    a = "A"
-// ^ reference local 4
+// ^ reference local 3
    b = "B"
-// ^ reference local 5
+// ^ reference local 4
    c = "C"
-// ^ reference local 6
+// ^ reference local 5
    DoWork([]worker{a, b, c})
 // ^^^^^^ reference 0.1.test sg/generallyeric/DoWork().
 //          ^^^^^^ reference 0.1.test sg/generallyeric/worker#
-//                 ^ reference local 4
-//                    ^ reference local 5
-//                       ^ reference local 6
+//                 ^ reference local 3
+//                    ^ reference local 4
+//                       ^ reference local 5
   }
   

--- a/internal/testdata/snapshots/output/impls/remote_impls.go
+++ b/internal/testdata/snapshots/output/impls/remote_impls.go
@@ -7,7 +7,8 @@
   func Something(r http.ResponseWriter) {}
 //     ^^^^^^^^^ definition 0.1.test sg/impls/Something().
 //     documentation ```go
-//               ^ definition local 0
+//               ^ definition 0.1.test sg/impls/Something().(r)
+//               documentation ```go
 //                 ^^^^ reference github.com/golang/go/src go1.19 net/http/
 //                      ^^^^^^^^^^^^^^ reference github.com/golang/go/src go1.19 net/http/ResponseWriter#
   
@@ -20,7 +21,7 @@
 //     relationship github.com/golang/go/src go1.19 net/http/ResponseWriter# implementation
   
   func (w MyWriter) Header() http.Header        { panic("") }
-//      ^ definition local 1
+//      ^ definition local 0
 //        ^^^^^^^^ reference 0.1.test sg/impls/MyWriter#
 //                  ^^^^^^ definition 0.1.test sg/impls/MyWriter#Header().
 //                  documentation ```go
@@ -28,7 +29,7 @@
 //                           ^^^^ reference github.com/golang/go/src go1.19 net/http/
 //                                ^^^^^^ reference github.com/golang/go/src go1.19 net/http/Header#
   func (w MyWriter) Write([]byte) (int, error)  { panic("") }
-//      ^ definition local 2
+//      ^ definition local 1
 //        ^^^^^^^^ reference 0.1.test sg/impls/MyWriter#
 //                  ^^^^^ definition 0.1.test sg/impls/MyWriter#Write().
 //                  documentation ```go
@@ -36,12 +37,13 @@
 //                  relationship github.com/golang/go/src go1.19 io/Writer#Write. implementation
 //                  relationship github.com/golang/go/src go1.19 net/http/ResponseWriter#Write. implementation
   func (w MyWriter) WriteHeader(statusCode int) { panic("") }
-//      ^ definition local 3
+//      ^ definition local 2
 //        ^^^^^^^^ reference 0.1.test sg/impls/MyWriter#
 //                  ^^^^^^^^^^^ definition 0.1.test sg/impls/MyWriter#WriteHeader().
 //                  documentation ```go
 //                  relationship github.com/golang/go/src go1.19 net/http/ResponseWriter#WriteHeader. implementation
-//                              ^^^^^^^^^^ definition local 4
+//                              ^^^^^^^^^^ definition 0.1.test sg/impls/MyWriter#WriteHeader().(statusCode)
+//                              documentation ```go
   
   func Another() {
 //     ^^^^^^^ definition 0.1.test sg/impls/Another().

--- a/internal/testdata/snapshots/output/initial/child_symbols.go
+++ b/internal/testdata/snapshots/output/initial/child_symbols.go
@@ -155,7 +155,8 @@
 //                 ^^^^^^^^^^^^^^^ definition 0.1.test sg/initial/Struct#MachineLearning().
 //                 documentation ```go
    param1 float32, // It's ML, I can't describe what this param is.
-// ^^^^^^ definition local 3
+// ^^^^^^ definition 0.1.test sg/initial/Struct#MachineLearning().(param1)
+// documentation ```go
   
    // We call the below hyperparameters because, uhh, well:
    //
@@ -172,32 +173,34 @@
    //     `--'   `--'
    //
    hyperparam2 float32,
-// ^^^^^^^^^^^ definition local 4
+// ^^^^^^^^^^^ definition 0.1.test sg/initial/Struct#MachineLearning().(hyperparam2)
+// documentation ```go
    hyperparam3 float32,
-// ^^^^^^^^^^^ definition local 5
+// ^^^^^^^^^^^ definition 0.1.test sg/initial/Struct#MachineLearning().(hyperparam3)
+// documentation ```go
   ) float32 {
    // varShouldNotHaveDocs is in a function, should not have docs emitted.
    var varShouldNotHaveDocs int32
-//     ^^^^^^^^^^^^^^^^^^^^ definition local 6
+//     ^^^^^^^^^^^^^^^^^^^^ definition local 3
   
    // constShouldNotHaveDocs is in a function, should not have docs emitted.
    const constShouldNotHaveDocs = 5
-//       ^^^^^^^^^^^^^^^^^^^^^^ definition local 7
+//       ^^^^^^^^^^^^^^^^^^^^^^ definition local 4
   
    // typeShouldNotHaveDocs is in a function, should not have docs emitted.
    type typeShouldNotHaveDocs struct{ a string }
-//      ^^^^^^^^^^^^^^^^^^^^^ definition local 8
-//                                    ^ definition local 9
+//      ^^^^^^^^^^^^^^^^^^^^^ definition local 5
+//                                    ^ definition local 6
   
    // funcShouldNotHaveDocs is in a function, should not have docs emitted.
    funcShouldNotHaveDocs := func(a string) string { return "hello" }
-// ^^^^^^^^^^^^^^^^^^^^^ definition local 10
-//                               ^ definition local 11
+// ^^^^^^^^^^^^^^^^^^^^^ definition local 7
+//                               ^ definition local 8
   
    return param1 + (hyperparam2 * *hyperparam3) // lol is this all ML is? I'm gonna be rich
-//        ^^^^^^ reference local 3
-//                  ^^^^^^^^^^^ reference local 4
-//                                 ^^^^^^^^^^^ reference local 5
+//        ^^^^^^ reference 0.1.test sg/initial/Struct#MachineLearning().(param1)
+//                  ^^^^^^^^^^^ reference 0.1.test sg/initial/Struct#MachineLearning().(hyperparam2)
+//                                 ^^^^^^^^^^^ reference 0.1.test sg/initial/Struct#MachineLearning().(hyperparam3)
   }
   
   // Interface has docs too

--- a/internal/testdata/snapshots/output/initial/methods_and_receivers.go
+++ b/internal/testdata/snapshots/output/initial/methods_and_receivers.go
@@ -18,21 +18,22 @@
 //        ^^^^^^^^ reference 0.1.test sg/initial/MyStruct#
 //                  ^^^^^^^^^^^^ definition 0.1.test sg/initial/MyStruct#RecvFunction().
 //                  documentation ```go
-//                               ^ definition local 1
+//                               ^ definition 0.1.test sg/initial/MyStruct#RecvFunction().(b)
+//                               documentation ```go
 //                                                   ^ reference local 0
 //                                                     ^ reference 0.1.test sg/initial/MyStruct#f.
-//                                                         ^ reference local 1
+//                                                         ^ reference 0.1.test sg/initial/MyStruct#RecvFunction().(b)
   
   func SomethingElse() {
 //     ^^^^^^^^^^^^^ definition 0.1.test sg/initial/SomethingElse().
 //     documentation ```go
    s := MyStruct{f: 0}
-// ^ definition local 2
+// ^ definition local 1
 //      ^^^^^^^^ reference 0.1.test sg/initial/MyStruct#
 //               ^ reference 0.1.test sg/initial/MyStruct#f.
    fmt.Println(s)
 // ^^^ reference github.com/golang/go/src go1.19 fmt/
 //     ^^^^^^^ reference github.com/golang/go/src go1.19 fmt/Println().
-//             ^ reference local 2
+//             ^ reference local 1
   }
   

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_genericindex.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_genericindex.go
@@ -30,10 +30,11 @@
 //         ^^^^^^^^^^^ reference 0.1.test sg/inlinestruct/ProcessImpl#
 //                      ^^^^^^^ definition 0.1.test sg/inlinestruct/ProcessImpl#Process().
 //                      documentation ```go
-//                              ^^^^^^^ definition local 3
+//                              ^^^^^^^ definition 0.1.test sg/inlinestruct/ProcessImpl#Process().(payload)
+//                              documentation ```go
 //                                      ^^^^^ reference 0.1.test sg/inlinestruct/Limit#
   func (p *ProcessImpl) ProcessorType() string { panic("not implemented") }
-//      ^ definition local 4
+//      ^ definition local 3
 //         ^^^^^^^^^^^ reference 0.1.test sg/inlinestruct/ProcessImpl#
 //                      ^^^^^^^^^^^^^ definition 0.1.test sg/inlinestruct/ProcessImpl#ProcessorType().
 //                      documentation ```go

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_interface.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_interface.go
@@ -4,9 +4,10 @@
   import "context"
 //        ^^^^^^^ reference github.com/golang/go/src go1.19 context/
   
-  func Target() interface {
+  func Target() (bananas interface {
 //     ^^^^^^ definition 0.1.test sg/inlinestruct/Target().
 //     documentation ```go
+//               ^^^^^^^ definition local 0
    OID(context.Context) (int, error)
 // ^^^ definition 0.1.test sg/inlinestruct/Target().OID().
 // documentation ```go
@@ -27,7 +28,7 @@
 // documentation ```go
 //      ^^^^^^^ reference github.com/golang/go/src go1.19 context/
 //              ^^^^^^^ reference github.com/golang/go/src go1.19 context/Context#
-  } {
+  }) {
    panic("not implemented")
   }
   
@@ -35,10 +36,10 @@
 //     ^^^^^^^^^ definition 0.1.test sg/inlinestruct/something().
 //     documentation ```go
    x := Target()
-// ^ definition local 0
+// ^ definition local 1
 //      ^^^^^^ reference 0.1.test sg/inlinestruct/Target().
    x.OID(context.Background())
-// ^ reference local 0
+// ^ reference local 1
 //   ^^^ reference 0.1.test sg/inlinestruct/Target().OID().
 //       ^^^^^^^ reference github.com/golang/go/src go1.19 context/
 //               ^^^^^^^^^^ reference github.com/golang/go/src go1.19 context/Background().

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_interface.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_interface.go
@@ -8,22 +8,22 @@
 //     ^^^^^^ definition 0.1.test sg/inlinestruct/Target().
 //     documentation ```go
    OID(context.Context) (int, error)
-// ^^^ definition 0.1.test sg/inlinestruct/func:Target:OID().
+// ^^^ definition 0.1.test sg/inlinestruct/Target().OID().
 // documentation ```go
 //     ^^^^^^^ reference github.com/golang/go/src go1.19 context/
 //             ^^^^^^^ reference github.com/golang/go/src go1.19 context/Context#
    AbbreviatedOID(context.Context) (string, error)
-// ^^^^^^^^^^^^^^ definition 0.1.test sg/inlinestruct/func:Target:AbbreviatedOID().
+// ^^^^^^^^^^^^^^ definition 0.1.test sg/inlinestruct/Target().AbbreviatedOID().
 // documentation ```go
 //                ^^^^^^^ reference github.com/golang/go/src go1.19 context/
 //                        ^^^^^^^ reference github.com/golang/go/src go1.19 context/Context#
    Commit(context.Context) (string, error)
-// ^^^^^^ definition 0.1.test sg/inlinestruct/func:Target:Commit().
+// ^^^^^^ definition 0.1.test sg/inlinestruct/Target().Commit().
 // documentation ```go
 //        ^^^^^^^ reference github.com/golang/go/src go1.19 context/
 //                ^^^^^^^ reference github.com/golang/go/src go1.19 context/Context#
    Type(context.Context) (int, error)
-// ^^^^ definition 0.1.test sg/inlinestruct/func:Target:Type().
+// ^^^^ definition 0.1.test sg/inlinestruct/Target().Type().
 // documentation ```go
 //      ^^^^^^^ reference github.com/golang/go/src go1.19 context/
 //              ^^^^^^^ reference github.com/golang/go/src go1.19 context/Context#
@@ -39,7 +39,7 @@
 //      ^^^^^^ reference 0.1.test sg/inlinestruct/Target().
    x.OID(context.Background())
 // ^ reference local 0
-//   ^^^ reference 0.1.test sg/inlinestruct/func:Target:OID().
+//   ^^^ reference 0.1.test sg/inlinestruct/Target().OID().
 //       ^^^^^^^ reference github.com/golang/go/src go1.19 context/
 //               ^^^^^^^^^^ reference github.com/golang/go/src go1.19 context/Background().
   }

--- a/internal/testdata/snapshots/output/switches/switches.go
+++ b/internal/testdata/snapshots/output/switches/switches.go
@@ -20,22 +20,23 @@
   func Switch(interfaceValue interface{}) bool {
 //     ^^^^^^ definition 0.1.test sg/switches/Switch().
 //     documentation ```go
-//            ^^^^^^^^^^^^^^ definition local 1
+//            ^^^^^^^^^^^^^^ definition 0.1.test sg/switches/Switch().(interfaceValue)
+//            documentation ```go
    switch concreteValue := interfaceValue.(type) {
-//        ^^^^^^^^^^^^^ definition local 2
-//                         ^^^^^^^^^^^^^^ reference local 1
+//        ^^^^^^^^^^^^^ definition local 1
+//                         ^^^^^^^^^^^^^^ reference 0.1.test sg/switches/Switch().(interfaceValue)
    case int:
     return concreteValue*3 > 10
-//         ^^^^^^^^^^^^^ reference local 2
+//         ^^^^^^^^^^^^^ reference local 1
 //         override_documentation ```go
    case bool:
     return !concreteValue
-//          ^^^^^^^^^^^^^ reference local 2
+//          ^^^^^^^^^^^^^ reference local 1
 //          override_documentation ```go
    case CustomSwitch:
 //      ^^^^^^^^^^^^ reference 0.1.test sg/switches/CustomSwitch#
     return concreteValue.Something()
-//         ^^^^^^^^^^^^^ reference local 2
+//         ^^^^^^^^^^^^^ reference local 1
 //         override_documentation ```go
 //                       ^^^^^^^^^ reference 0.1.test sg/switches/CustomSwitch#Something().
    default:

--- a/internal/testdata/snapshots/output/testdata/data.go
+++ b/internal/testdata/snapshots/output/testdata/data.go
@@ -118,10 +118,8 @@
 //                                       ^^^^^^^ reference github.com/golang/go/src go1.19 context/Context#
 //                                                ^^^^ definition 0.1.test sg/testdata/TestStruct#Doer().(data)
 //                                                documentation ```go
-//                                                              ^^^^^ definition 0.1.test sg/testdata/TestStruct#Doer().(score)
-//                                                              documentation ```go
-//                                                                         ^^^ definition 0.1.test sg/testdata/TestStruct#Doer().(err)
-//                                                                         documentation ```go
+//                                                              ^^^^^ definition local 4
+//                                                                         ^^^ definition local 5
    return Score, nil
 //        ^^^^^ reference 0.1.test sg/testdata/Score.
   }

--- a/internal/testdata/snapshots/output/testdata/data.go
+++ b/internal/testdata/snapshots/output/testdata/data.go
@@ -112,12 +112,16 @@
 //                      ^^^^ definition 0.1.test sg/testdata/TestStruct#Doer().
 //                      documentation ```go
 //                      documentation Doer is similar to the test interface (but not the same).
-//                           ^^^ definition local 4
+//                           ^^^ definition 0.1.test sg/testdata/TestStruct#Doer().(ctx)
+//                           documentation ```go
 //                               ^^^^^^^ reference github.com/golang/go/src go1.19 context/
 //                                       ^^^^^^^ reference github.com/golang/go/src go1.19 context/Context#
-//                                                ^^^^ definition local 5
-//                                                              ^^^^^ definition local 6
-//                                                                         ^^^ definition local 7
+//                                                ^^^^ definition 0.1.test sg/testdata/TestStruct#Doer().(data)
+//                                                documentation ```go
+//                                                              ^^^^^ definition 0.1.test sg/testdata/TestStruct#Doer().(score)
+//                                                              documentation ```go
+//                                                                         ^^^ definition 0.1.test sg/testdata/TestStruct#Doer().(err)
+//                                                                         documentation ```go
    return Score, nil
 //        ^^^^^ reference 0.1.test sg/testdata/Score.
   }

--- a/internal/testdata/snapshots/output/testdata/implementations.go
+++ b/internal/testdata/snapshots/output/testdata/implementations.go
@@ -165,10 +165,11 @@
   func shouldShow(shared SharedOne) {
 //     ^^^^^^^^^^ definition 0.1.test sg/testdata/shouldShow().
 //     documentation ```go
-//                ^^^^^^ definition local 6
+//                ^^^^^^ definition 0.1.test sg/testdata/shouldShow().(shared)
+//                documentation ```go
 //                       ^^^^^^^^^ reference 0.1.test sg/testdata/SharedOne#
    shared.Shared()
-// ^^^^^^ reference local 6
+// ^^^^^^ reference 0.1.test sg/testdata/shouldShow().(shared)
 //        ^^^^^^ reference 0.1.test sg/testdata/SharedOne#Shared.
   }
   

--- a/internal/testdata/snapshots/output/testdata/implementations_remote.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_remote.go
@@ -31,16 +31,18 @@
 //                        ^^^^^^^^^^^ definition 0.1.test sg/testdata/implementsWriter#WriteHeader().
 //                        documentation ```go
 //                        relationship github.com/golang/go/src go1.19 net/http/ResponseWriter#WriteHeader. implementation
-//                                    ^^^^^^^^^^ definition local 0
+//                                    ^^^^^^^^^^ definition 0.1.test sg/testdata/implementsWriter#WriteHeader().(statusCode)
+//                                    documentation ```go
   
   func ShowsInSignature(respWriter http.ResponseWriter) {
 //     ^^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/ShowsInSignature().
 //     documentation ```go
-//                      ^^^^^^^^^^ definition local 1
+//                      ^^^^^^^^^^ definition 0.1.test sg/testdata/ShowsInSignature().(respWriter)
+//                      documentation ```go
 //                                 ^^^^ reference github.com/golang/go/src go1.19 net/http/
 //                                      ^^^^^^^^^^^^^^ reference github.com/golang/go/src go1.19 net/http/ResponseWriter#
    respWriter.WriteHeader(1)
-// ^^^^^^^^^^ reference local 1
+// ^^^^^^^^^^ reference 0.1.test sg/testdata/ShowsInSignature().(respWriter)
 //            ^^^^^^^^^^^ reference github.com/golang/go/src go1.19 net/http/ResponseWriter#WriteHeader.
   }
   

--- a/internal/testdata/snapshots/output/testdata/parallel.go
+++ b/internal/testdata/snapshots/output/testdata/parallel.go
@@ -24,51 +24,53 @@
 //     ^^^^^^^^ definition 0.1.test sg/testdata/Parallel().
 //     documentation ```go
 //     documentation Parallel invokes each of the given parallelizable functions in their own goroutines and
-//              ^^^ definition local 1
+//              ^^^ definition 0.1.test sg/testdata/Parallel().(ctx)
+//              documentation ```go
 //                  ^^^^^^^ reference github.com/golang/go/src go1.19 context/
 //                          ^^^^^^^ reference github.com/golang/go/src go1.19 context/Context#
-//                                   ^^^ definition local 2
+//                                   ^^^ definition 0.1.test sg/testdata/Parallel().(fns)
+//                                   documentation ```go
 //                                          ^^^^^^^^^^^^^^^^^^ reference 0.1.test sg/testdata/ParallelizableFunc#
    var wg sync.WaitGroup
-//     ^^ definition local 3
+//     ^^ definition local 1
 //        ^^^^ reference github.com/golang/go/src go1.19 sync/
 //             ^^^^^^^^^ reference github.com/golang/go/src go1.19 sync/WaitGroup#
    errs := make(chan error, len(fns))
-// ^^^^ definition local 4
-//                              ^^^ reference local 2
+// ^^^^ definition local 2
+//                              ^^^ reference 0.1.test sg/testdata/Parallel().(fns)
   
    for _, fn := range fns {
-//        ^^ definition local 5
-//                    ^^^ reference local 2
+//        ^^ definition local 3
+//                    ^^^ reference 0.1.test sg/testdata/Parallel().(fns)
     wg.Add(1)
-//  ^^ reference local 3
+//  ^^ reference local 1
 //     ^^^ reference github.com/golang/go/src go1.19 sync/WaitGroup#Add().
   
     go func(fn ParallelizableFunc) {
-//          ^^ definition local 6
+//          ^^ definition local 4
 //             ^^^^^^^^^^^^^^^^^^ reference 0.1.test sg/testdata/ParallelizableFunc#
      errs <- fn(ctx)
-//   ^^^^ reference local 4
-//           ^^ reference local 6
-//              ^^^ reference local 1
+//   ^^^^ reference local 2
+//           ^^ reference local 4
+//              ^^^ reference 0.1.test sg/testdata/Parallel().(ctx)
      wg.Done()
-//   ^^ reference local 3
+//   ^^ reference local 1
 //      ^^^^ reference github.com/golang/go/src go1.19 sync/WaitGroup#Done().
     }(fn)
-//    ^^ reference local 5
+//    ^^ reference local 3
    }
   
    wg.Wait()
-// ^^ reference local 3
+// ^^ reference local 1
 //    ^^^^ reference github.com/golang/go/src go1.19 sync/WaitGroup#Wait().
   
    for err := range errs {
-//     ^^^ definition local 7
-//                  ^^^^ reference local 4
+//     ^^^ definition local 5
+//                  ^^^^ reference local 2
     if err != nil {
-//     ^^^ reference local 7
+//     ^^^ reference local 5
      return err
-//          ^^^ reference local 7
+//          ^^^ reference local 5
     }
    }
   

--- a/internal/testdata/snapshots/output/testdata/typeswitch.go
+++ b/internal/testdata/snapshots/output/testdata/typeswitch.go
@@ -4,17 +4,18 @@
   func Switch(interfaceValue interface{}) bool {
 //     ^^^^^^ definition 0.1.test sg/testdata/Switch().
 //     documentation ```go
-//            ^^^^^^^^^^^^^^ definition local 0
+//            ^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/Switch().(interfaceValue)
+//            documentation ```go
    switch concreteValue := interfaceValue.(type) {
-//        ^^^^^^^^^^^^^ definition local 1
-//                         ^^^^^^^^^^^^^^ reference local 0
+//        ^^^^^^^^^^^^^ definition local 0
+//                         ^^^^^^^^^^^^^^ reference 0.1.test sg/testdata/Switch().(interfaceValue)
    case int:
     return concreteValue*3 > 10
-//         ^^^^^^^^^^^^^ reference local 1
+//         ^^^^^^^^^^^^^ reference local 0
 //         override_documentation ```go
    case bool:
     return !concreteValue
-//          ^^^^^^^^^^^^^ reference local 1
+//          ^^^^^^^^^^^^^ reference local 0
 //          override_documentation ```go
    default:
     return false

--- a/internal/visitors/visitor_file.go
+++ b/internal/visitors/visitor_file.go
@@ -17,9 +17,6 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
-const symbolDefinition = int32(scip.SymbolRole_Definition)
-const symbolReference = int32(scip.SymbolRole_ReadAccess)
-
 func NewFileVisitor(
 	doc *document.Document,
 	pkg *packages.Package,
@@ -302,12 +299,12 @@ func (v *fileVisitor) emitImportReference(
 }
 
 // NewDefinition emits a scip.Occurence ONLY. This will not emit a
-// new symbol. You must do that using DeclareNewSymbol[ForPos]
+// new symbol. You must do that using SetNewSymbol[ForPos]
 func (v *fileVisitor) NewDefinition(symbol string, rng []int32) {
 	v.occurrences = append(v.occurrences, &scip.Occurrence{
 		Range:       rng,
 		Symbol:      symbol,
-		SymbolRoles: symbolDefinition,
+		SymbolRoles: int32(scip.SymbolRole_Definition),
 	})
 }
 
@@ -323,7 +320,7 @@ func (v *fileVisitor) AppendSymbolReference(symbol string, rng []int32, override
 	v.occurrences = append(v.occurrences, &scip.Occurrence{
 		Range:                 rng,
 		Symbol:                symbol,
-		SymbolRoles:           symbolReference,
+		SymbolRoles:           int32(scip.SymbolRole_ReadAccess),
 		OverrideDocumentation: documentation,
 	})
 }

--- a/internal/visitors/visitor_func.go
+++ b/internal/visitors/visitor_func.go
@@ -32,8 +32,7 @@ func (v funcVisitor) Visit(n ast.Node) ast.Visitor {
 		v.doc.SetNewSymbol(symbol, node, node.Name)
 
 		// Any associated declarations should be generated with the scope of this method
-		v.scope.push("func", scip.Descriptor_Meta)
-		v.scope.push(node.Name.Name, scip.Descriptor_Meta)
+		v.scope.push(node.Name.Name, scip.Descriptor_Method)
 		ast.Walk(v, node.Type)
 		v.scope.pop()
 
@@ -56,6 +55,10 @@ func (v funcVisitor) Visit(n ast.Node) ast.Visitor {
 			ast.Walk(v, node.Results)
 		}
 
+		if node.Params != nil {
+			ast.Walk(v, node.Params)
+		}
+
 		return nil
 
 	case *ast.BlockStmt:
@@ -72,10 +75,15 @@ func (v funcVisitor) Visit(n ast.Node) ast.Visitor {
 
 		return nil
 
+	case *ast.Field:
+		for _, name := range node.Names {
+			symbol := v.scope.makeSymbol(v.pkg, name.Name, scip.Descriptor_Parameter)
+			v.doc.SetNewSymbol(symbol, name, name)
+		}
+		return v
 	default:
 		return v
 	}
-
 }
 
 func visitFunctionDefinition(doc *document.Document, pkg *packages.Package, node *ast.FuncDecl) {

--- a/internal/visitors/visitor_func.go
+++ b/internal/visitors/visitor_func.go
@@ -41,18 +41,28 @@ func (v funcVisitor) Visit(n ast.Node) ast.Visitor {
 	case *ast.FuncType:
 		// Should not need to declare any non-local definitions in the type params
 		// if node.TypeParams != nil {
-		// 	Walk(v, node.TypeParams)
-		// }
-
-		// Should not need to declare any non-local definitions in the params
-		// if node.Params != nil {
-		// 	Walk(v, node.Params)
+		// 	ast.Walk(v, node.TypeParams)
 		// }
 
 		// Types can create new interfaces and/or types,
 		// so we need to visit them and potentially declare new non-local symbols
 		if node.Results != nil {
-			ast.Walk(v, node.Results)
+			// TODO: for now skip named return idents as theyre not modeled in SCIP,
+			// but we also don't have handeling for attaching hovers to locals in scip-go yet.
+			for _, field := range node.Results.List {
+				if field.Doc != nil {
+					ast.Walk(v, field.Doc)
+				}
+				if field.Type != nil {
+					ast.Walk(v, field.Type)
+				}
+				if field.Tag != nil {
+					ast.Walk(v, field.Tag)
+				}
+				if field.Comment != nil {
+					ast.Walk(v, field.Comment)
+				}
+			}
 		}
 
 		if node.Params != nil {

--- a/internal/visitors/visitor_var.go
+++ b/internal/visitors/visitor_var.go
@@ -157,7 +157,6 @@ func (v *varVisitor) Visit(n ast.Node) (w ast.Visitor) {
 			}
 		}
 		return nil
-
 	default:
 		return v
 	}

--- a/internal/visitors/visitors.go
+++ b/internal/visitors/visitors.go
@@ -69,7 +69,6 @@ func visitSyntax(pkg *packages.Package, pkgSymbols *lookup.Package, f *ast.File,
 		case *ast.FuncDecl:
 			visitFunctionDefinition(doc, pkg, decl)
 		}
-
 	}
 
 	return doc


### PR DESCRIPTION
:sunglasses: 
![image](https://github.com/sourcegraph/scip-go/assets/18282288/44c12da5-8a98-431f-807a-188f3fd50e59)

---

Also updates the symbol names for function/method parameter names to be more correct according to SCIP (to my understanding). 

named returns are locals for now, see comment I added on this