### PR TITLE
cleanup: Remove NeedFiles from loadMode

### DIFF
--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -16,7 +16,6 @@ import (
 type PackageLookup map[newtypes.PackageID]*packages.Package
 
 var loadMode = packages.NeedDeps |
-	packages.NeedFiles |
 	packages.NeedImports |
 	packages.NeedSyntax |
 	packages.NeedTypes |


### PR DESCRIPTION
According to the docs, it should only be needed if we access
the GoFiles or OtherFiles fields. But neither of these fields
is read in our code.
