### PR TITLE
scip: Bump dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/efritz/pentimento v0.0.0-20190429011147-ade47d831101
-	github.com/sourcegraph/scip v0.2.4-0.20230404133011-b687c6adbfef
+	github.com/sourcegraph/scip v0.3.1-0.20230717142743-94fdc9215b88
 	golang.org/x/tools v0.2.0
 )
 
@@ -68,7 +68,7 @@ require (
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/exp v0.0.0-20221205204356-47842c84f3db
-	golang.org/x/mod v0.6.0 // indirect
+	golang.org/x/mod v0.6.0
 	golang.org/x/net v0.1.0 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/term v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,7 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/pprof v0.0.0-20211214055906-6f57359322fd h1:1FjCyPC+syAzJ5/2S8fqdZK1R22vvA0J7JZKcuOIQ7Y=
 github.com/google/pprof v0.0.0-20211214055906-6f57359322fd/go.mod h1:KgnwoLYCZ8IQu3XUZ8Nc/bM9CCZFOyjUNOSygVozoDg=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -304,8 +305,8 @@ github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/sourcegraph/scip v0.2.4-0.20230404133011-b687c6adbfef h1:J/nTkZEiZQgATXp4Gz3d5MPRzx+x55owWipZNRN84hk=
-github.com/sourcegraph/scip v0.2.4-0.20230404133011-b687c6adbfef/go.mod h1:ymcTuv+6D5OEZB/84TRPQvUpDK7v7zXnWBJl79hb7ns=
+github.com/sourcegraph/scip v0.3.1-0.20230717142743-94fdc9215b88 h1:GGN8BB0Gxv7r1moBVINKC2IjFHLVzS5Gg9za5DvWS7k=
+github.com/sourcegraph/scip v0.3.1-0.20230717142743-94fdc9215b88/go.mod h1:YnYpcEG5OYQ+IPN8ymsZAzs2g/SR2ghiqExk6JJyWDI=
 github.com/sourcegraph/sourcegraph/lib v0.0.0-20220511160847-5a43d3ea24eb h1:D8ciD0FEcPNnVm6BC8vg7gWJ9VxoJe6k/4j+Qxparj0=
 github.com/sourcegraph/sourcegraph/lib v0.0.0-20220511160847-5a43d3ea24eb/go.mod h1:iFiGPqnhOvQziDZkpWasU+Uo1BaEt/Au9kNK4VpqyOw=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/internal/index/scip_test.go
+++ b/internal/index/scip_test.go
@@ -49,7 +49,6 @@ func TestSnapshots(t *testing.T) {
 				ModulePath:      "sg/" + filepath.Base(inputDirectory),
 				GoStdlibVersion: "go1.19",
 			})
-
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -74,7 +73,7 @@ func TestSnapshots(t *testing.T) {
 					continue
 				}
 
-				formatted, err := testutil.FormatSnapshot(doc, &scipIndex, "//", symbolFormatter)
+				formatted, err := testutil.FormatSnapshot(doc, &scipIndex, "//", symbolFormatter, doc.RelativePath)
 				if err != nil {
 					t.Errorf("Failed to format document: %s // %s", doc.RelativePath, err)
 				}

--- a/internal/index/scip_test.go
+++ b/internal/index/scip_test.go
@@ -73,9 +73,10 @@ func TestSnapshots(t *testing.T) {
 					continue
 				}
 
-				formatted, err := testutil.FormatSnapshot(doc, &scipIndex, "//", symbolFormatter, doc.RelativePath)
+				sourcePath := filepath.Join(scipIndex.Metadata.ProjectRoot, doc.RelativePath)
+				formatted, err := testutil.FormatSnapshot(doc, &scipIndex, "//", symbolFormatter, sourcePath)
 				if err != nil {
-					t.Errorf("Failed to format document: %s // %s", doc.RelativePath, err)
+					t.Errorf("Failed to format document: %s // %s", sourcePath, err)
 				}
 
 				sourceFiles = append(sourceFiles, scip.NewSourceFile(

--- a/internal/index/scip_test.go
+++ b/internal/index/scip_test.go
@@ -3,6 +3,7 @@ package index_test
 import (
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,6 +61,8 @@ func TestSnapshots(t *testing.T) {
 				IncludePackageName:    func(name string) bool { return !strings.HasPrefix(name, "sg/") },
 				IncludePackageVersion: func(_ string) bool { return true },
 				IncludeDescriptor:     func(_ string) bool { return true },
+				IncludeRawDescriptor:  func(descriptor *scip.Descriptor) bool { return true },
+				IncludeDisambiguator:  func(_ string) bool { return true },
 			}
 
 			sourceFiles := []*scip.SourceFile{}
@@ -73,10 +76,11 @@ func TestSnapshots(t *testing.T) {
 					continue
 				}
 
-				sourcePath := filepath.Join(scipIndex.Metadata.ProjectRoot, doc.RelativePath)
-				formatted, err := testutil.FormatSnapshot(doc, &scipIndex, "//", symbolFormatter, sourcePath)
+				sourcePath, _ := url.JoinPath(scipIndex.Metadata.ProjectRoot, doc.RelativePath)
+				sourceUrl, _ := url.Parse(sourcePath)
+				formatted, err := testutil.FormatSnapshot(doc, &scipIndex, "//", symbolFormatter, sourceUrl.Path)
 				if err != nil {
-					t.Errorf("Failed to format document: %s // %s", sourcePath, err)
+					t.Errorf("Failed to format document: %s // %s", sourceUrl.Path, err)
 				}
 
 				sourceFiles = append(sourceFiles, scip.NewSourceFile(

--- a/internal/testdata/snapshots/output/embedded/embedded.go
+++ b/internal/testdata/snapshots/output/embedded/embedded.go
@@ -1,97 +1,97 @@
   package embedded
-//        ^^^^^^^^ reference 0.1.test sg/embedded/
+//        ^^^^^^^^ reference 0.1.test `sg/embedded`/
   
   import (
    "fmt"
 //  ^^^ reference github.com/golang/go/src go1.19 fmt/
    "os/exec"
-//  ^^^^^^^ reference github.com/golang/go/src go1.19 os/exec/
+//  ^^^^^^^ reference github.com/golang/go/src go1.19 `os/exec`/
   )
   
   type osExecCommand struct {
-//     ^^^^^^^^^^^^^ definition 0.1.test sg/embedded/osExecCommand#
+//     ^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/osExecCommand#
 //     documentation ```go
 //     documentation ```go
 //     relationship github.com/golang/go/src go1.19 context/stringer# implementation
 //     relationship github.com/golang/go/src go1.19 fmt/Stringer# implementation
 //     relationship github.com/golang/go/src go1.19 runtime/stringer# implementation
    *exec.Cmd
-//  ^^^^ reference github.com/golang/go/src go1.19 os/exec/
-//       ^^^ definition 0.1.test sg/embedded/osExecCommand#Cmd.
+//  ^^^^ reference github.com/golang/go/src go1.19 `os/exec`/
+//       ^^^ definition 0.1.test `sg/embedded`/osExecCommand#Cmd.
 //       documentation ```go
-//       ^^^ reference github.com/golang/go/src go1.19 os/exec/Cmd#
+//       ^^^ reference github.com/golang/go/src go1.19 `os/exec`/Cmd#
   }
   
   func wrapExecCommand(c *exec.Cmd) {
-//     ^^^^^^^^^^^^^^^ definition 0.1.test sg/embedded/wrapExecCommand().
+//     ^^^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/wrapExecCommand().
 //     documentation ```go
 //                     ^ definition local 0
-//                        ^^^^ reference github.com/golang/go/src go1.19 os/exec/
-//                             ^^^ reference github.com/golang/go/src go1.19 os/exec/Cmd#
+//                        ^^^^ reference github.com/golang/go/src go1.19 `os/exec`/
+//                             ^^^ reference github.com/golang/go/src go1.19 `os/exec`/Cmd#
    _ = &osExecCommand{Cmd: c}
-//      ^^^^^^^^^^^^^ reference 0.1.test sg/embedded/osExecCommand#
-//                    ^^^ reference 0.1.test sg/embedded/osExecCommand#Cmd.
+//      ^^^^^^^^^^^^^ reference 0.1.test `sg/embedded`/osExecCommand#
+//                    ^^^ reference 0.1.test `sg/embedded`/osExecCommand#Cmd.
 //                         ^ reference local 0
   }
   
   type Inner struct {
-//     ^^^^^ definition 0.1.test sg/embedded/Inner#
+//     ^^^^^ definition 0.1.test `sg/embedded`/Inner#
 //     documentation ```go
 //     documentation ```go
    X int
-// ^ definition 0.1.test sg/embedded/Inner#X.
+// ^ definition 0.1.test `sg/embedded`/Inner#X.
 // documentation ```go
    Y int
-// ^ definition 0.1.test sg/embedded/Inner#Y.
+// ^ definition 0.1.test `sg/embedded`/Inner#Y.
 // documentation ```go
    Z int
-// ^ definition 0.1.test sg/embedded/Inner#Z.
+// ^ definition 0.1.test `sg/embedded`/Inner#Z.
 // documentation ```go
   }
   
   type Outer struct {
-//     ^^^^^ definition 0.1.test sg/embedded/Outer#
+//     ^^^^^ definition 0.1.test `sg/embedded`/Outer#
 //     documentation ```go
 //     documentation ```go
    Inner
-// ^^^^^ definition 0.1.test sg/embedded/Outer#Inner.
+// ^^^^^ definition 0.1.test `sg/embedded`/Outer#Inner.
 // documentation ```go
-// ^^^^^ reference 0.1.test sg/embedded/Inner#
+// ^^^^^ reference 0.1.test `sg/embedded`/Inner#
    W int
-// ^ definition 0.1.test sg/embedded/Outer#W.
+// ^ definition 0.1.test `sg/embedded`/Outer#W.
 // documentation ```go
   }
   
   func useOfCompositeStructs() {
-//     ^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test sg/embedded/useOfCompositeStructs().
+//     ^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/useOfCompositeStructs().
 //     documentation ```go
    o := Outer{
 // ^ definition local 1
-//      ^^^^^ reference 0.1.test sg/embedded/Outer#
+//      ^^^^^ reference 0.1.test `sg/embedded`/Outer#
     Inner: Inner{
-//  ^^^^^ reference 0.1.test sg/embedded/Outer#Inner.
-//         ^^^^^ reference 0.1.test sg/embedded/Inner#
+//  ^^^^^ reference 0.1.test `sg/embedded`/Outer#Inner.
+//         ^^^^^ reference 0.1.test `sg/embedded`/Inner#
      X: 1,
-//   ^ reference 0.1.test sg/embedded/Inner#X.
+//   ^ reference 0.1.test `sg/embedded`/Inner#X.
      Y: 2,
-//   ^ reference 0.1.test sg/embedded/Inner#Y.
+//   ^ reference 0.1.test `sg/embedded`/Inner#Y.
      Z: 3,
-//   ^ reference 0.1.test sg/embedded/Inner#Z.
+//   ^ reference 0.1.test `sg/embedded`/Inner#Z.
     },
     W: 4,
-//  ^ reference 0.1.test sg/embedded/Outer#W.
+//  ^ reference 0.1.test `sg/embedded`/Outer#W.
    }
   
    fmt.Printf("> %d\n", o.X)
 // ^^^ reference github.com/golang/go/src go1.19 fmt/
 //     ^^^^^^ reference github.com/golang/go/src go1.19 fmt/Printf().
 //                      ^ reference local 1
-//                        ^ reference 0.1.test sg/embedded/Inner#X.
+//                        ^ reference 0.1.test `sg/embedded`/Inner#X.
    fmt.Println(o.Inner.Y)
 // ^^^ reference github.com/golang/go/src go1.19 fmt/
 //     ^^^^^^^ reference github.com/golang/go/src go1.19 fmt/Println().
 //             ^ reference local 1
-//               ^^^^^ reference 0.1.test sg/embedded/Outer#Inner.
-//                     ^ reference 0.1.test sg/embedded/Inner#Y.
+//               ^^^^^ reference 0.1.test `sg/embedded`/Outer#Inner.
+//                     ^ reference 0.1.test `sg/embedded`/Inner#Y.
   }
   

--- a/internal/testdata/snapshots/output/embedded/internal/nested.go
+++ b/internal/testdata/snapshots/output/embedded/internal/nested.go
@@ -1,34 +1,34 @@
   package nested_internal
-//        ^^^^^^^^^^^^^^^ definition 0.1.test sg/embedded/internal/
+//        ^^^^^^^^^^^^^^^ definition 0.1.test `sg/embedded/internal`/
 //        documentation package nested_internal
   
   import (
    "fmt"
 //  ^^^ reference github.com/golang/go/src go1.19 fmt/
    "sg/embedded"
-//  ^^^^^^^^^^^ reference 0.1.test sg/embedded/
+//  ^^^^^^^^^^^ reference 0.1.test `sg/embedded`/
   )
   
   func Something(recent embedded.RecentCommittersResults) {
-//     ^^^^^^^^^ definition 0.1.test sg/embedded/internal/Something().
+//     ^^^^^^^^^ definition 0.1.test `sg/embedded/internal`/Something().
 //     documentation ```go
 //               ^^^^^^ definition local 0
-//                      ^^^^^^^^ reference 0.1.test sg/embedded/
-//                               ^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test sg/embedded/RecentCommittersResults#
+//                      ^^^^^^^^ reference 0.1.test `sg/embedded`/
+//                               ^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/embedded`/RecentCommittersResults#
    for _, commit := range recent.Nodes {
 //        ^^^^^^ definition local 1
 //                        ^^^^^^ reference local 0
-//                               ^^^^^ reference 0.1.test sg/embedded/RecentCommittersResults#Nodes.
+//                               ^^^^^ reference 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.
     for _, author := range commit.Authors.Nodes {
 //         ^^^^^^ definition local 2
 //                         ^^^^^^ reference local 1
-//                                ^^^^^^^ reference 0.1.test sg/embedded/RecentCommittersResults#Nodes.Authors.
-//                                        ^^^^^ reference 0.1.test sg/embedded/RecentCommittersResults#Nodes.Authors.Nodes.
+//                                ^^^^^^^ reference 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.Authors.
+//                                        ^^^^^ reference 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.Authors.Nodes.
      fmt.Println(author.Name)
 //   ^^^ reference github.com/golang/go/src go1.19 fmt/
 //       ^^^^^^^ reference github.com/golang/go/src go1.19 fmt/Println().
 //               ^^^^^^ reference local 2
-//                      ^^^^ reference 0.1.test sg/embedded/RecentCommittersResults#Nodes.Authors.Nodes.Name.
+//                      ^^^^ reference 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.Authors.Nodes.Name.
     }
    }
   }

--- a/internal/testdata/snapshots/output/embedded/nested.go
+++ b/internal/testdata/snapshots/output/embedded/nested.go
@@ -1,41 +1,41 @@
   package embedded
-//        ^^^^^^^^ definition 0.1.test sg/embedded/
+//        ^^^^^^^^ definition 0.1.test `sg/embedded`/
 //        documentation package embedded
   
   import "net/http"
-//        ^^^^^^^^ reference github.com/golang/go/src go1.19 net/http/
+//        ^^^^^^^^ reference github.com/golang/go/src go1.19 `net/http`/
   
   type NestedHandler struct {
-//     ^^^^^^^^^^^^^ definition 0.1.test sg/embedded/NestedHandler#
+//     ^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/NestedHandler#
 //     documentation ```go
 //     documentation ```go
-//     relationship github.com/golang/go/src go1.19 net/http/Handler# implementation
+//     relationship github.com/golang/go/src go1.19 `net/http`/Handler# implementation
    http.Handler
-// ^^^^ reference github.com/golang/go/src go1.19 net/http/
-//      ^^^^^^^ definition 0.1.test sg/embedded/NestedHandler#Handler.
+// ^^^^ reference github.com/golang/go/src go1.19 `net/http`/
+//      ^^^^^^^ definition 0.1.test `sg/embedded`/NestedHandler#Handler.
 //      documentation ```go
-//      ^^^^^^^ reference github.com/golang/go/src go1.19 net/http/Handler#
+//      ^^^^^^^ reference github.com/golang/go/src go1.19 `net/http`/Handler#
   
    // Wow, a great thing for integers
    Other int
-// ^^^^^ definition 0.1.test sg/embedded/NestedHandler#Other.
+// ^^^^^ definition 0.1.test `sg/embedded`/NestedHandler#Other.
 // documentation ```go
   }
   
   func NestedExample(n NestedHandler) {
-//     ^^^^^^^^^^^^^ definition 0.1.test sg/embedded/NestedExample().
+//     ^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/NestedExample().
 //     documentation ```go
 //                   ^ definition local 0
-//                     ^^^^^^^^^^^^^ reference 0.1.test sg/embedded/NestedHandler#
+//                     ^^^^^^^^^^^^^ reference 0.1.test `sg/embedded`/NestedHandler#
    _ = n.Handler.ServeHTTP
 //     ^ reference local 0
-//       ^^^^^^^ reference 0.1.test sg/embedded/NestedHandler#Handler.
-//               ^^^^^^^^^ reference github.com/golang/go/src go1.19 net/http/Handler#ServeHTTP.
+//       ^^^^^^^ reference 0.1.test `sg/embedded`/NestedHandler#Handler.
+//               ^^^^^^^^^ reference github.com/golang/go/src go1.19 `net/http`/Handler#ServeHTTP.
    _ = n.ServeHTTP
 //     ^ reference local 0
-//       ^^^^^^^^^ reference github.com/golang/go/src go1.19 net/http/Handler#ServeHTTP.
+//       ^^^^^^^^^ reference github.com/golang/go/src go1.19 `net/http`/Handler#ServeHTTP.
    _ = n.Other
 //     ^ reference local 0
-//       ^^^^^ reference 0.1.test sg/embedded/NestedHandler#Other.
+//       ^^^^^ reference 0.1.test `sg/embedded`/NestedHandler#Other.
   }
   

--- a/internal/testdata/snapshots/output/embedded/something.go
+++ b/internal/testdata/snapshots/output/embedded/something.go
@@ -1,49 +1,49 @@
   package embedded
-//        ^^^^^^^^ reference 0.1.test sg/embedded/
+//        ^^^^^^^^ reference 0.1.test `sg/embedded`/
   
   import "fmt"
 //        ^^^ reference github.com/golang/go/src go1.19 fmt/
   
   type RecentCommittersResults struct {
-//     ^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test sg/embedded/RecentCommittersResults#
+//     ^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#
 //     documentation ```go
 //     documentation ```go
    Nodes []struct {
-// ^^^^^ definition 0.1.test sg/embedded/RecentCommittersResults#Nodes.
+// ^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.
 // documentation ```go
     Authors struct {
-//  ^^^^^^^ definition 0.1.test sg/embedded/RecentCommittersResults#Nodes.Authors.
+//  ^^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.Authors.
 //  documentation ```go
      Nodes []struct {
-//   ^^^^^ definition 0.1.test sg/embedded/RecentCommittersResults#Nodes.Authors.Nodes.
+//   ^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.Authors.Nodes.
 //   documentation ```go
       Date  string
-//    ^^^^ definition 0.1.test sg/embedded/RecentCommittersResults#Nodes.Authors.Nodes.Date.
+//    ^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.Authors.Nodes.Date.
 //    documentation ```go
       Email string
-//    ^^^^^ definition 0.1.test sg/embedded/RecentCommittersResults#Nodes.Authors.Nodes.Email.
+//    ^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.Authors.Nodes.Email.
 //    documentation ```go
       Name  string
-//    ^^^^ definition 0.1.test sg/embedded/RecentCommittersResults#Nodes.Authors.Nodes.Name.
+//    ^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.Authors.Nodes.Name.
 //    documentation ```go
       User  struct {
-//    ^^^^ definition 0.1.test sg/embedded/RecentCommittersResults#Nodes.Authors.Nodes.User.
+//    ^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.Authors.Nodes.User.
 //    documentation ```go
        Login string
-//     ^^^^^ definition 0.1.test sg/embedded/RecentCommittersResults#Nodes.Authors.Nodes.User.Login.
+//     ^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.Authors.Nodes.User.Login.
 //     documentation ```go
       }
       AvatarURL string
-//    ^^^^^^^^^ definition 0.1.test sg/embedded/RecentCommittersResults#Nodes.Authors.Nodes.AvatarURL.
+//    ^^^^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.Authors.Nodes.AvatarURL.
 //    documentation ```go
      }
     }
    }
    PageInfo struct {
-// ^^^^^^^^ definition 0.1.test sg/embedded/RecentCommittersResults#PageInfo.
+// ^^^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#PageInfo.
 // documentation ```go
     HasNextPage bool
-//  ^^^^^^^^^^^ definition 0.1.test sg/embedded/RecentCommittersResults#PageInfo.HasNextPage.
+//  ^^^^^^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#PageInfo.HasNextPage.
 //  documentation ```go
    }
   }

--- a/internal/testdata/snapshots/output/generallyeric/generallyeric.go
+++ b/internal/testdata/snapshots/output/generallyeric/generallyeric.go
@@ -1,13 +1,13 @@
   // generallyeric -> generic for short
   package generallyeric
-//        ^^^^^^^^^^^^^ definition 0.1.test sg/generallyeric/
+//        ^^^^^^^^^^^^^ definition 0.1.test `sg/generallyeric`/
 //        documentation generallyeric -> generic for short
   
   import "fmt"
 //        ^^^ reference github.com/golang/go/src go1.19 fmt/
   
   func Print[T any](s []T) {
-//     ^^^^^ definition 0.1.test sg/generallyeric/Print().
+//     ^^^^^ definition 0.1.test `sg/generallyeric`/Print().
 //     documentation ```go
 //           ^ definition local 0
 //                  ^ definition local 1

--- a/internal/testdata/snapshots/output/generallyeric/new_operators.go
+++ b/internal/testdata/snapshots/output/generallyeric/new_operators.go
@@ -1,27 +1,27 @@
   package generallyeric
-//        ^^^^^^^^^^^^^ reference 0.1.test sg/generallyeric/
+//        ^^^^^^^^^^^^^ reference 0.1.test `sg/generallyeric`/
   
   import "golang.org/x/exp/constraints"
-//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db golang.org/x/exp/constraints/
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db `golang.org/x/exp/constraints`/
   
   type Number interface {
-//     ^^^^^^ definition 0.1.test sg/generallyeric/Number#
+//     ^^^^^^ definition 0.1.test `sg/generallyeric`/Number#
 //     documentation ```go
 //     documentation ```go
    constraints.Float | constraints.Integer | constraints.Complex
-// ^^^^^^^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db golang.org/x/exp/constraints/
-//             ^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db golang.org/x/exp/constraints/Float#
-//                     ^^^^^^^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db golang.org/x/exp/constraints/
-//                                 ^^^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db golang.org/x/exp/constraints/Integer#
-//                                           ^^^^^^^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db golang.org/x/exp/constraints/
-//                                                       ^^^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db golang.org/x/exp/constraints/Complex#
+// ^^^^^^^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db `golang.org/x/exp/constraints`/
+//             ^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db `golang.org/x/exp/constraints`/Float#
+//                     ^^^^^^^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db `golang.org/x/exp/constraints`/
+//                                 ^^^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db `golang.org/x/exp/constraints`/Integer#
+//                                           ^^^^^^^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db `golang.org/x/exp/constraints`/
+//                                                       ^^^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db `golang.org/x/exp/constraints`/Complex#
   }
   
   func Double[T Number](value T) T {
-//     ^^^^^^ definition 0.1.test sg/generallyeric/Double().
+//     ^^^^^^ definition 0.1.test `sg/generallyeric`/Double().
 //     documentation ```go
 //            ^ definition local 0
-//              ^^^^^^ reference 0.1.test sg/generallyeric/Number#
+//              ^^^^^^ reference 0.1.test `sg/generallyeric`/Number#
 //                      ^^^^^ definition local 1
 //                            ^ reference local 0
 //                               ^ reference local 0
@@ -30,28 +30,28 @@
   }
   
   type Box[T any] struct {
-//     ^^^ definition 0.1.test sg/generallyeric/Box#
+//     ^^^ definition 0.1.test `sg/generallyeric`/Box#
 //     documentation ```go
 //     documentation ```go
 //         ^ definition local 2
    Something T
-// ^^^^^^^^^ definition 0.1.test sg/generallyeric/Box#Something.
+// ^^^^^^^^^ definition 0.1.test `sg/generallyeric`/Box#Something.
 // documentation ```go
 //           ^ reference local 2
   }
   
   type handler[T any] struct {
-//     ^^^^^^^ definition 0.1.test sg/generallyeric/handler#
+//     ^^^^^^^ definition 0.1.test `sg/generallyeric`/handler#
 //     documentation ```go
 //     documentation ```go
 //             ^ definition local 3
    Box[T]
-// ^^^ definition 0.1.test sg/generallyeric/handler#Box.
+// ^^^ definition 0.1.test `sg/generallyeric`/handler#Box.
 // documentation ```go
-// ^^^ reference 0.1.test sg/generallyeric/Box#
+// ^^^ reference 0.1.test `sg/generallyeric`/Box#
 //     ^ reference local 3
    Another string
-// ^^^^^^^ definition 0.1.test sg/generallyeric/handler#Another.
+// ^^^^^^^ definition 0.1.test `sg/generallyeric`/handler#Another.
 // documentation ```go
   }
   

--- a/internal/testdata/snapshots/output/generallyeric/person.go
+++ b/internal/testdata/snapshots/output/generallyeric/person.go
@@ -1,29 +1,29 @@
   package generallyeric
-//        ^^^^^^^^^^^^^ reference 0.1.test sg/generallyeric/
+//        ^^^^^^^^^^^^^ reference 0.1.test `sg/generallyeric`/
   
   import "fmt"
 //        ^^^ reference github.com/golang/go/src go1.19 fmt/
   
   type Person interface {
-//     ^^^^^^ definition 0.1.test sg/generallyeric/Person#
+//     ^^^^^^ definition 0.1.test `sg/generallyeric`/Person#
 //     documentation ```go
 //     documentation ```go
    Work()
-// ^^^^ definition 0.1.test sg/generallyeric/Person#Work.
+// ^^^^ definition 0.1.test `sg/generallyeric`/Person#Work.
 // documentation ```go
   }
   
   type worker string
-//     ^^^^^^ definition 0.1.test sg/generallyeric/worker#
+//     ^^^^^^ definition 0.1.test `sg/generallyeric`/worker#
 //     documentation ```go
-//     relationship 0.1.test sg/generallyeric/Person# implementation
+//     relationship 0.1.test `sg/generallyeric`/Person# implementation
   
   func (w worker) Work() {
 //      ^ definition local 0
-//        ^^^^^^ reference 0.1.test sg/generallyeric/worker#
-//                ^^^^ definition 0.1.test sg/generallyeric/worker#Work().
+//        ^^^^^^ reference 0.1.test `sg/generallyeric`/worker#
+//                ^^^^ definition 0.1.test `sg/generallyeric`/worker#Work().
 //                documentation ```go
-//                relationship 0.1.test sg/generallyeric/Person#Work. implementation
+//                relationship 0.1.test `sg/generallyeric`/Person#Work. implementation
    fmt.Printf("%s is working\n", w)
 // ^^^ reference github.com/golang/go/src go1.19 fmt/
 //     ^^^^^^ reference github.com/golang/go/src go1.19 fmt/Printf().
@@ -31,10 +31,10 @@
   }
   
   func DoWork[T Person](things []T) {
-//     ^^^^^^ definition 0.1.test sg/generallyeric/DoWork().
+//     ^^^^^^ definition 0.1.test `sg/generallyeric`/DoWork().
 //     documentation ```go
 //            ^ definition local 1
-//              ^^^^^^ reference 0.1.test sg/generallyeric/Person#
+//              ^^^^^^ reference 0.1.test `sg/generallyeric`/Person#
 //                      ^^^^^^ definition local 2
 //                               ^ reference local 1
    for _, v := range things {
@@ -42,18 +42,18 @@
 //                   ^^^^^^ reference local 2
     v.Work()
 //  ^ reference local 3
-//    ^^^^ reference 0.1.test sg/generallyeric/Person#Work.
+//    ^^^^ reference 0.1.test `sg/generallyeric`/Person#Work.
    }
   }
   
   func main() {
-//     ^^^^ definition 0.1.test sg/generallyeric/main().
+//     ^^^^ definition 0.1.test `sg/generallyeric`/main().
 //     documentation ```go
    var a, b, c worker
 //     ^ definition local 4
 //        ^ definition local 5
 //           ^ definition local 6
-//             ^^^^^^ reference 0.1.test sg/generallyeric/worker#
+//             ^^^^^^ reference 0.1.test `sg/generallyeric`/worker#
    a = "A"
 // ^ reference local 4
    b = "B"
@@ -61,8 +61,8 @@
    c = "C"
 // ^ reference local 6
    DoWork([]worker{a, b, c})
-// ^^^^^^ reference 0.1.test sg/generallyeric/DoWork().
-//          ^^^^^^ reference 0.1.test sg/generallyeric/worker#
+// ^^^^^^ reference 0.1.test `sg/generallyeric`/DoWork().
+//          ^^^^^^ reference 0.1.test `sg/generallyeric`/worker#
 //                 ^ reference local 4
 //                    ^ reference local 5
 //                       ^ reference local 6

--- a/internal/testdata/snapshots/output/impls/impls.go
+++ b/internal/testdata/snapshots/output/impls/impls.go
@@ -1,67 +1,67 @@
   package impls
-//        ^^^^^ definition 0.1.test sg/impls/
+//        ^^^^^ definition 0.1.test `sg/impls`/
 //        documentation package impls
   
   type I1 interface {
-//     ^^ definition 0.1.test sg/impls/I1#
+//     ^^ definition 0.1.test `sg/impls`/I1#
 //     documentation ```go
 //     documentation ```go
    F1()
-// ^^ definition 0.1.test sg/impls/I1#F1.
+// ^^ definition 0.1.test `sg/impls`/I1#F1.
 // documentation ```go
   }
   
   type I1Clone interface {
-//     ^^^^^^^ definition 0.1.test sg/impls/I1Clone#
+//     ^^^^^^^ definition 0.1.test `sg/impls`/I1Clone#
 //     documentation ```go
 //     documentation ```go
    F1()
-// ^^ definition 0.1.test sg/impls/I1Clone#F1.
+// ^^ definition 0.1.test `sg/impls`/I1Clone#F1.
 // documentation ```go
   }
   
   type IfaceOther interface {
-//     ^^^^^^^^^^ definition 0.1.test sg/impls/IfaceOther#
+//     ^^^^^^^^^^ definition 0.1.test `sg/impls`/IfaceOther#
 //     documentation ```go
 //     documentation ```go
    Something()
-// ^^^^^^^^^ definition 0.1.test sg/impls/IfaceOther#Something.
+// ^^^^^^^^^ definition 0.1.test `sg/impls`/IfaceOther#Something.
 // documentation ```go
    Another()
-// ^^^^^^^ definition 0.1.test sg/impls/IfaceOther#Another.
+// ^^^^^^^ definition 0.1.test `sg/impls`/IfaceOther#Another.
 // documentation ```go
   }
   
   type T1 int
-//     ^^ definition 0.1.test sg/impls/T1#
+//     ^^ definition 0.1.test `sg/impls`/T1#
 //     documentation ```go
-//     relationship 0.1.test sg/impls/I1# implementation
-//     relationship 0.1.test sg/impls/I1Clone# implementation
+//     relationship 0.1.test `sg/impls`/I1# implementation
+//     relationship 0.1.test `sg/impls`/I1Clone# implementation
   
   func (r T1) F1() {}
 //      ^ definition local 0
-//        ^^ reference 0.1.test sg/impls/T1#
-//            ^^ definition 0.1.test sg/impls/T1#F1().
+//        ^^ reference 0.1.test `sg/impls`/T1#
+//            ^^ definition 0.1.test `sg/impls`/T1#F1().
 //            documentation ```go
-//            relationship 0.1.test sg/impls/I1#F1. implementation
-//            relationship 0.1.test sg/impls/I1Clone#F1. implementation
+//            relationship 0.1.test `sg/impls`/I1#F1. implementation
+//            relationship 0.1.test `sg/impls`/I1Clone#F1. implementation
   
   type T2 int
-//     ^^ definition 0.1.test sg/impls/T2#
+//     ^^ definition 0.1.test `sg/impls`/T2#
 //     documentation ```go
-//     relationship 0.1.test sg/impls/I1# implementation
-//     relationship 0.1.test sg/impls/I1Clone# implementation
+//     relationship 0.1.test `sg/impls`/I1# implementation
+//     relationship 0.1.test `sg/impls`/I1Clone# implementation
   
   func (r T2) F1() {}
 //      ^ definition local 1
-//        ^^ reference 0.1.test sg/impls/T2#
-//            ^^ definition 0.1.test sg/impls/T2#F1().
+//        ^^ reference 0.1.test `sg/impls`/T2#
+//            ^^ definition 0.1.test `sg/impls`/T2#F1().
 //            documentation ```go
-//            relationship 0.1.test sg/impls/I1#F1. implementation
-//            relationship 0.1.test sg/impls/I1Clone#F1. implementation
+//            relationship 0.1.test `sg/impls`/I1#F1. implementation
+//            relationship 0.1.test `sg/impls`/I1Clone#F1. implementation
   func (r T2) F2() {}
 //      ^ definition local 2
-//        ^^ reference 0.1.test sg/impls/T2#
-//            ^^ definition 0.1.test sg/impls/T2#F2().
+//        ^^ reference 0.1.test `sg/impls`/T2#
+//            ^^ definition 0.1.test `sg/impls`/T2#F2().
 //            documentation ```go
   

--- a/internal/testdata/snapshots/output/impls/remote_impls.go
+++ b/internal/testdata/snapshots/output/impls/remote_impls.go
@@ -1,53 +1,53 @@
   package impls
-//        ^^^^^ reference 0.1.test sg/impls/
+//        ^^^^^ reference 0.1.test `sg/impls`/
   
   import "net/http"
-//        ^^^^^^^^ reference github.com/golang/go/src go1.19 net/http/
+//        ^^^^^^^^ reference github.com/golang/go/src go1.19 `net/http`/
   
   func Something(r http.ResponseWriter) {}
-//     ^^^^^^^^^ definition 0.1.test sg/impls/Something().
+//     ^^^^^^^^^ definition 0.1.test `sg/impls`/Something().
 //     documentation ```go
 //               ^ definition local 0
-//                 ^^^^ reference github.com/golang/go/src go1.19 net/http/
-//                      ^^^^^^^^^^^^^^ reference github.com/golang/go/src go1.19 net/http/ResponseWriter#
+//                 ^^^^ reference github.com/golang/go/src go1.19 `net/http`/
+//                      ^^^^^^^^^^^^^^ reference github.com/golang/go/src go1.19 `net/http`/ResponseWriter#
   
   type MyWriter struct{}
-//     ^^^^^^^^ definition 0.1.test sg/impls/MyWriter#
+//     ^^^^^^^^ definition 0.1.test `sg/impls`/MyWriter#
 //     documentation ```go
 //     documentation ```go
-//     relationship github.com/golang/go/src go1.19 crypto/tls/transcriptHash# implementation
+//     relationship github.com/golang/go/src go1.19 `crypto/tls`/transcriptHash# implementation
+//     relationship github.com/golang/go/src go1.19 `net/http`/ResponseWriter# implementation
 //     relationship github.com/golang/go/src go1.19 io/Writer# implementation
-//     relationship github.com/golang/go/src go1.19 net/http/ResponseWriter# implementation
   
   func (w MyWriter) Header() http.Header        { panic("") }
 //      ^ definition local 1
-//        ^^^^^^^^ reference 0.1.test sg/impls/MyWriter#
-//                  ^^^^^^ definition 0.1.test sg/impls/MyWriter#Header().
+//        ^^^^^^^^ reference 0.1.test `sg/impls`/MyWriter#
+//                  ^^^^^^ definition 0.1.test `sg/impls`/MyWriter#Header().
 //                  documentation ```go
-//                  relationship github.com/golang/go/src go1.19 net/http/ResponseWriter#Header. implementation
-//                           ^^^^ reference github.com/golang/go/src go1.19 net/http/
-//                                ^^^^^^ reference github.com/golang/go/src go1.19 net/http/Header#
+//                  relationship github.com/golang/go/src go1.19 `net/http`/ResponseWriter#Header. implementation
+//                           ^^^^ reference github.com/golang/go/src go1.19 `net/http`/
+//                                ^^^^^^ reference github.com/golang/go/src go1.19 `net/http`/Header#
   func (w MyWriter) Write([]byte) (int, error)  { panic("") }
 //      ^ definition local 2
-//        ^^^^^^^^ reference 0.1.test sg/impls/MyWriter#
-//                  ^^^^^ definition 0.1.test sg/impls/MyWriter#Write().
+//        ^^^^^^^^ reference 0.1.test `sg/impls`/MyWriter#
+//                  ^^^^^ definition 0.1.test `sg/impls`/MyWriter#Write().
 //                  documentation ```go
-//                  relationship github.com/golang/go/src go1.19 crypto/tls/transcriptHash#Write. implementation
+//                  relationship github.com/golang/go/src go1.19 `crypto/tls`/transcriptHash#Write. implementation
+//                  relationship github.com/golang/go/src go1.19 `net/http`/ResponseWriter#Write. implementation
 //                  relationship github.com/golang/go/src go1.19 io/Writer#Write. implementation
-//                  relationship github.com/golang/go/src go1.19 net/http/ResponseWriter#Write. implementation
   func (w MyWriter) WriteHeader(statusCode int) { panic("") }
 //      ^ definition local 3
-//        ^^^^^^^^ reference 0.1.test sg/impls/MyWriter#
-//                  ^^^^^^^^^^^ definition 0.1.test sg/impls/MyWriter#WriteHeader().
+//        ^^^^^^^^ reference 0.1.test `sg/impls`/MyWriter#
+//                  ^^^^^^^^^^^ definition 0.1.test `sg/impls`/MyWriter#WriteHeader().
 //                  documentation ```go
-//                  relationship github.com/golang/go/src go1.19 net/http/ResponseWriter#WriteHeader. implementation
+//                  relationship github.com/golang/go/src go1.19 `net/http`/ResponseWriter#WriteHeader. implementation
 //                              ^^^^^^^^^^ definition local 4
   
   func Another() {
-//     ^^^^^^^ definition 0.1.test sg/impls/Another().
+//     ^^^^^^^ definition 0.1.test `sg/impls`/Another().
 //     documentation ```go
    Something(MyWriter{})
-// ^^^^^^^^^ reference 0.1.test sg/impls/Something().
-//           ^^^^^^^^ reference 0.1.test sg/impls/MyWriter#
+// ^^^^^^^^^ reference 0.1.test `sg/impls`/Something().
+//           ^^^^^^^^ reference 0.1.test `sg/impls`/MyWriter#
   }
   

--- a/internal/testdata/snapshots/output/initial/builtin_types.go
+++ b/internal/testdata/snapshots/output/initial/builtin_types.go
@@ -1,8 +1,8 @@
   package initial
-//        ^^^^^^^ reference 0.1.test sg/initial/
+//        ^^^^^^^ reference 0.1.test `sg/initial`/
   
   func UsesBuiltin() int {
-//     ^^^^^^^^^^^ definition 0.1.test sg/initial/UsesBuiltin().
+//     ^^^^^^^^^^^ definition 0.1.test `sg/initial`/UsesBuiltin().
 //     documentation ```go
    var x int = 5
 //     ^ definition local 0

--- a/internal/testdata/snapshots/output/initial/child_symbols.go
+++ b/internal/testdata/snapshots/output/initial/child_symbols.go
@@ -1,9 +1,9 @@
   package initial
-//        ^^^^^^^ reference 0.1.test sg/initial/
+//        ^^^^^^^ reference 0.1.test `sg/initial`/
   
   // Const is a constant equal to 5. It's the best constant I've ever written. 😹
   const Const = 5
-//      ^^^^^ definition 0.1.test sg/initial/Const.
+//      ^^^^^ definition 0.1.test `sg/initial`/Const.
 //      documentation ```go
 //      documentation Const is a constant equal to 5. It's the best constant I've ever written. 😹
   
@@ -11,61 +11,61 @@
   const (
    // ConstBlock1 is a constant in a block.
    ConstBlock1 = 1
-// ^^^^^^^^^^^ definition 0.1.test sg/initial/ConstBlock1.
+// ^^^^^^^^^^^ definition 0.1.test `sg/initial`/ConstBlock1.
 // documentation ```go
 // documentation Docs for the const block itself.
   
    // ConstBlock2 is a constant in a block.
    ConstBlock2 = 2
-// ^^^^^^^^^^^ definition 0.1.test sg/initial/ConstBlock2.
+// ^^^^^^^^^^^ definition 0.1.test `sg/initial`/ConstBlock2.
 // documentation ```go
 // documentation Docs for the const block itself.
   )
   
   // Var is a variable interface.
   var Var Interface = &Struct{Field: "bar!"}
-//    ^^^ definition 0.1.test sg/initial/Var.
+//    ^^^ definition 0.1.test `sg/initial`/Var.
 //    documentation ```go
 //    documentation Var is a variable interface.
-//        ^^^^^^^^^ reference 0.1.test sg/initial/Interface#
-//                     ^^^^^^ reference 0.1.test sg/initial/Struct#
-//                            ^^^^^ reference 0.1.test sg/initial/Struct#Field.
+//        ^^^^^^^^^ reference 0.1.test `sg/initial`/Interface#
+//                     ^^^^^^ reference 0.1.test `sg/initial`/Struct#
+//                            ^^^^^ reference 0.1.test `sg/initial`/Struct#Field.
   
   // unexportedVar is an unexported variable interface.
   var unexportedVar Interface = &Struct{Field: "bar!"}
-//    ^^^^^^^^^^^^^ definition 0.1.test sg/initial/unexportedVar.
+//    ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/unexportedVar.
 //    documentation ```go
 //    documentation unexportedVar is an unexported variable interface.
-//                  ^^^^^^^^^ reference 0.1.test sg/initial/Interface#
-//                               ^^^^^^ reference 0.1.test sg/initial/Struct#
-//                                      ^^^^^ reference 0.1.test sg/initial/Struct#Field.
+//                  ^^^^^^^^^ reference 0.1.test `sg/initial`/Interface#
+//                               ^^^^^^ reference 0.1.test `sg/initial`/Struct#
+//                                      ^^^^^ reference 0.1.test `sg/initial`/Struct#Field.
   
   // x has a builtin error type
   var x error
-//    ^ definition 0.1.test sg/initial/x.
+//    ^ definition 0.1.test `sg/initial`/x.
 //    documentation ```go
 //    documentation x has a builtin error type
   
   var BigVar Interface = &Struct{
-//    ^^^^^^ definition 0.1.test sg/initial/BigVar.
+//    ^^^^^^ definition 0.1.test `sg/initial`/BigVar.
 //    documentation ```go
-//           ^^^^^^^^^ reference 0.1.test sg/initial/Interface#
-//                        ^^^^^^ reference 0.1.test sg/initial/Struct#
+//           ^^^^^^^^^ reference 0.1.test `sg/initial`/Interface#
+//                        ^^^^^^ reference 0.1.test `sg/initial`/Struct#
    Field: "bar!",
-// ^^^^^ reference 0.1.test sg/initial/Struct#Field.
+// ^^^^^ reference 0.1.test `sg/initial`/Struct#Field.
    Anonymous: struct {
-// ^^^^^^^^^ reference 0.1.test sg/initial/Struct#Anonymous.
+// ^^^^^^^^^ reference 0.1.test `sg/initial`/Struct#Anonymous.
     FieldA int
-//  ^^^^^^ definition 0.1.test sg/initial/BigVar:FieldA.
+//  ^^^^^^ definition 0.1.test `sg/initial`/BigVar:FieldA.
 //  documentation ```go
     FieldB int
-//  ^^^^^^ definition 0.1.test sg/initial/BigVar:FieldB.
+//  ^^^^^^ definition 0.1.test `sg/initial`/BigVar:FieldB.
 //  documentation ```go
     FieldC int
-//  ^^^^^^ definition 0.1.test sg/initial/BigVar:FieldC.
+//  ^^^^^^ definition 0.1.test `sg/initial`/BigVar:FieldC.
 //  documentation ```go
    }{FieldA: 1337},
-//   ^^^^^^ reference 0.1.test sg/initial/BigVar:FieldA.
+//   ^^^^^^ reference 0.1.test `sg/initial`/BigVar:FieldA.
   }
   
   // What are docs, really?
@@ -82,54 +82,54 @@
   var (
    // This has some docs
    VarBlock1 = "if you're reading this"
-// ^^^^^^^^^ definition 0.1.test sg/initial/VarBlock1.
+// ^^^^^^^^^ definition 0.1.test `sg/initial`/VarBlock1.
 // documentation ```go
 // documentation What are docs, really?
   
    VarBlock2 = "hi"
-// ^^^^^^^^^ definition 0.1.test sg/initial/VarBlock2.
+// ^^^^^^^^^ definition 0.1.test `sg/initial`/VarBlock2.
 // documentation ```go
 // documentation What are docs, really?
   )
   
   // Embedded is a struct, to be embedded in another struct.
   type Embedded struct {
-//     ^^^^^^^^ definition 0.1.test sg/initial/Embedded#
+//     ^^^^^^^^ definition 0.1.test `sg/initial`/Embedded#
 //     documentation ```go
 //     documentation Embedded is a struct, to be embedded in another struct.
 //     documentation ```go
    // EmbeddedField has some docs!
    EmbeddedField string
-// ^^^^^^^^^^^^^ definition 0.1.test sg/initial/Embedded#EmbeddedField.
+// ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/Embedded#EmbeddedField.
 // documentation ```go
    Field         string // conflicts with parent "Field"
-// ^^^^^ definition 0.1.test sg/initial/Embedded#Field.
+// ^^^^^ definition 0.1.test `sg/initial`/Embedded#Field.
 // documentation ```go
   }
   
   type Struct struct {
-//     ^^^^^^ definition 0.1.test sg/initial/Struct#
+//     ^^^^^^ definition 0.1.test `sg/initial`/Struct#
 //     documentation ```go
 //     documentation ```go
-//     relationship 0.1.test sg/initial/Interface# implementation
+//     relationship 0.1.test `sg/initial`/Interface# implementation
    *Embedded
-//  ^^^^^^^^ definition 0.1.test sg/initial/Struct#Embedded.
+//  ^^^^^^^^ definition 0.1.test `sg/initial`/Struct#Embedded.
 //  documentation ```go
-//  ^^^^^^^^ reference 0.1.test sg/initial/Embedded#
+//  ^^^^^^^^ reference 0.1.test `sg/initial`/Embedded#
    Field     string
-// ^^^^^ definition 0.1.test sg/initial/Struct#Field.
+// ^^^^^ definition 0.1.test `sg/initial`/Struct#Field.
 // documentation ```go
    Anonymous struct {
-// ^^^^^^^^^ definition 0.1.test sg/initial/Struct#Anonymous.
+// ^^^^^^^^^ definition 0.1.test `sg/initial`/Struct#Anonymous.
 // documentation ```go
     FieldA int
-//  ^^^^^^ definition 0.1.test sg/initial/Struct#Anonymous.FieldA.
+//  ^^^^^^ definition 0.1.test `sg/initial`/Struct#Anonymous.FieldA.
 //  documentation ```go
     FieldB int
-//  ^^^^^^ definition 0.1.test sg/initial/Struct#Anonymous.FieldB.
+//  ^^^^^^ definition 0.1.test `sg/initial`/Struct#Anonymous.FieldB.
 //  documentation ```go
     FieldC int
-//  ^^^^^^ definition 0.1.test sg/initial/Struct#Anonymous.FieldC.
+//  ^^^^^^ definition 0.1.test `sg/initial`/Struct#Anonymous.FieldC.
 //  documentation ```go
    }
   }
@@ -137,22 +137,22 @@
   // StructMethod has some docs!
   func (s *Struct) StructMethod() {}
 //      ^ definition local 0
-//         ^^^^^^ reference 0.1.test sg/initial/Struct#
-//                 ^^^^^^^^^^^^ definition 0.1.test sg/initial/Struct#StructMethod().
+//         ^^^^^^ reference 0.1.test `sg/initial`/Struct#
+//                 ^^^^^^^^^^^^ definition 0.1.test `sg/initial`/Struct#StructMethod().
 //                 documentation ```go
 //                 documentation StructMethod has some docs!
   
   func (s *Struct) ImplementsInterface() string { return "hi!" }
 //      ^ definition local 1
-//         ^^^^^^ reference 0.1.test sg/initial/Struct#
-//                 ^^^^^^^^^^^^^^^^^^^ definition 0.1.test sg/initial/Struct#ImplementsInterface().
+//         ^^^^^^ reference 0.1.test `sg/initial`/Struct#
+//                 ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/Struct#ImplementsInterface().
 //                 documentation ```go
-//                 relationship 0.1.test sg/initial/Interface#ImplementsInterface. implementation
+//                 relationship 0.1.test `sg/initial`/Interface#ImplementsInterface. implementation
   
   func (s *Struct) MachineLearning(
 //      ^ definition local 2
-//         ^^^^^^ reference 0.1.test sg/initial/Struct#
-//                 ^^^^^^^^^^^^^^^ definition 0.1.test sg/initial/Struct#MachineLearning().
+//         ^^^^^^ reference 0.1.test `sg/initial`/Struct#
+//                 ^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/Struct#MachineLearning().
 //                 documentation ```go
    param1 float32, // It's ML, I can't describe what this param is.
 // ^^^^^^ definition local 3
@@ -202,30 +202,30 @@
   
   // Interface has docs too
   type Interface interface {
-//     ^^^^^^^^^ definition 0.1.test sg/initial/Interface#
+//     ^^^^^^^^^ definition 0.1.test `sg/initial`/Interface#
 //     documentation ```go
 //     documentation Interface has docs too
 //     documentation ```go
    ImplementsInterface() string
-// ^^^^^^^^^^^^^^^^^^^ definition 0.1.test sg/initial/Interface#ImplementsInterface.
+// ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/Interface#ImplementsInterface.
 // documentation ```go
   }
   
   func NewInterface() Interface { return nil }
-//     ^^^^^^^^^^^^ definition 0.1.test sg/initial/NewInterface().
+//     ^^^^^^^^^^^^ definition 0.1.test `sg/initial`/NewInterface().
 //     documentation ```go
-//                    ^^^^^^^^^ reference 0.1.test sg/initial/Interface#
+//                    ^^^^^^^^^ reference 0.1.test `sg/initial`/Interface#
   
   var SortExportedFirst = 1
-//    ^^^^^^^^^^^^^^^^^ definition 0.1.test sg/initial/SortExportedFirst.
+//    ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/SortExportedFirst.
 //    documentation ```go
   
   var sortUnexportedSecond = 2
-//    ^^^^^^^^^^^^^^^^^^^^ definition 0.1.test sg/initial/sortUnexportedSecond.
+//    ^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/sortUnexportedSecond.
 //    documentation ```go
   
   var _sortUnderscoreLast = 3
-//    ^^^^^^^^^^^^^^^^^^^ definition 0.1.test sg/initial/_sortUnderscoreLast.
+//    ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/_sortUnderscoreLast.
 //    documentation ```go
   
   // Yeah this is some Go magic incantation which is common.
@@ -241,8 +241,8 @@
   //  || |-_\__   /
   // ((_/`(____,-'
   var _ = Interface(&Struct{})
-//        ^^^^^^^^^ reference 0.1.test sg/initial/Interface#
-//                   ^^^^^^ reference 0.1.test sg/initial/Struct#
+//        ^^^^^^^^^ reference 0.1.test `sg/initial`/Interface#
+//                   ^^^^^^ reference 0.1.test `sg/initial`/Struct#
   
   type _ = struct{}
   
@@ -254,22 +254,22 @@
   type (
    // And confusing
    X struct {
-// ^ definition 0.1.test sg/initial/X#
+// ^ definition 0.1.test `sg/initial`/X#
 // documentation ```go
 // documentation Go can be fun
 // documentation ```go
     bar string
-//  ^^^ definition 0.1.test sg/initial/X#bar.
+//  ^^^ definition 0.1.test `sg/initial`/X#bar.
 //  documentation ```go
    }
   
    Y struct {
-// ^ definition 0.1.test sg/initial/Y#
+// ^ definition 0.1.test `sg/initial`/Y#
 // documentation ```go
 // documentation Go can be fun
 // documentation ```go
     baz float64
-//  ^^^ definition 0.1.test sg/initial/Y#baz.
+//  ^^^ definition 0.1.test `sg/initial`/Y#baz.
 //  documentation ```go
    }
   )

--- a/internal/testdata/snapshots/output/initial/func_declarations.go
+++ b/internal/testdata/snapshots/output/initial/func_declarations.go
@@ -1,14 +1,14 @@
   package initial
-//        ^^^^^^^ reference 0.1.test sg/initial/
+//        ^^^^^^^ reference 0.1.test `sg/initial`/
   
   func UsesLater() {
-//     ^^^^^^^^^ definition 0.1.test sg/initial/UsesLater().
+//     ^^^^^^^^^ definition 0.1.test `sg/initial`/UsesLater().
 //     documentation ```go
    DefinedLater()
-// ^^^^^^^^^^^^ reference 0.1.test sg/initial/DefinedLater().
+// ^^^^^^^^^^^^ reference 0.1.test `sg/initial`/DefinedLater().
   }
   
   func DefinedLater() {}
-//     ^^^^^^^^^^^^ definition 0.1.test sg/initial/DefinedLater().
+//     ^^^^^^^^^^^^ definition 0.1.test `sg/initial`/DefinedLater().
 //     documentation ```go
   

--- a/internal/testdata/snapshots/output/initial/methods_and_receivers.go
+++ b/internal/testdata/snapshots/output/initial/methods_and_receivers.go
@@ -1,35 +1,35 @@
   package initial
-//        ^^^^^^^ reference 0.1.test sg/initial/
+//        ^^^^^^^ reference 0.1.test `sg/initial`/
   
   import "fmt"
 //        ^^^ reference github.com/golang/go/src go1.19 fmt/
   
   type MyStruct struct{ f, y int }
-//     ^^^^^^^^ definition 0.1.test sg/initial/MyStruct#
+//     ^^^^^^^^ definition 0.1.test `sg/initial`/MyStruct#
 //     documentation ```go
 //     documentation ```go
-//                      ^ definition 0.1.test sg/initial/MyStruct#f.
+//                      ^ definition 0.1.test `sg/initial`/MyStruct#f.
 //                      documentation ```go
-//                         ^ definition 0.1.test sg/initial/MyStruct#y.
+//                         ^ definition 0.1.test `sg/initial`/MyStruct#y.
 //                         documentation ```go
   
   func (m MyStruct) RecvFunction(b int) int { return m.f + b }
 //      ^ definition local 0
-//        ^^^^^^^^ reference 0.1.test sg/initial/MyStruct#
-//                  ^^^^^^^^^^^^ definition 0.1.test sg/initial/MyStruct#RecvFunction().
+//        ^^^^^^^^ reference 0.1.test `sg/initial`/MyStruct#
+//                  ^^^^^^^^^^^^ definition 0.1.test `sg/initial`/MyStruct#RecvFunction().
 //                  documentation ```go
 //                               ^ definition local 1
 //                                                   ^ reference local 0
-//                                                     ^ reference 0.1.test sg/initial/MyStruct#f.
+//                                                     ^ reference 0.1.test `sg/initial`/MyStruct#f.
 //                                                         ^ reference local 1
   
   func SomethingElse() {
-//     ^^^^^^^^^^^^^ definition 0.1.test sg/initial/SomethingElse().
+//     ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/SomethingElse().
 //     documentation ```go
    s := MyStruct{f: 0}
 // ^ definition local 2
-//      ^^^^^^^^ reference 0.1.test sg/initial/MyStruct#
-//               ^ reference 0.1.test sg/initial/MyStruct#f.
+//      ^^^^^^^^ reference 0.1.test `sg/initial`/MyStruct#
+//               ^ reference 0.1.test `sg/initial`/MyStruct#f.
    fmt.Println(s)
 // ^^^ reference github.com/golang/go/src go1.19 fmt/
 //     ^^^^^^^ reference github.com/golang/go/src go1.19 fmt/Println().

--- a/internal/testdata/snapshots/output/initial/package_definition.go
+++ b/internal/testdata/snapshots/output/initial/package_definition.go
@@ -1,6 +1,6 @@
   // This is a module for testing purposes.
   // This should now be the place that has a definition
   package initial
-//        ^^^^^^^ definition 0.1.test sg/initial/
+//        ^^^^^^^ definition 0.1.test `sg/initial`/
 //        documentation This is a module for testing purposes.
   

--- a/internal/testdata/snapshots/output/initial/toplevel_decls.go
+++ b/internal/testdata/snapshots/output/initial/toplevel_decls.go
@@ -1,22 +1,22 @@
   package initial
-//        ^^^^^^^ reference 0.1.test sg/initial/
+//        ^^^^^^^ reference 0.1.test `sg/initial`/
   
   const MY_THING = 10
-//      ^^^^^^^^ definition 0.1.test sg/initial/MY_THING.
+//      ^^^^^^^^ definition 0.1.test `sg/initial`/MY_THING.
 //      documentation ```go
   const OTHER_THING = MY_THING
-//      ^^^^^^^^^^^ definition 0.1.test sg/initial/OTHER_THING.
+//      ^^^^^^^^^^^ definition 0.1.test `sg/initial`/OTHER_THING.
 //      documentation ```go
-//                    ^^^^^^^^ reference 0.1.test sg/initial/MY_THING.
+//                    ^^^^^^^^ reference 0.1.test `sg/initial`/MY_THING.
   
   func usesMyThing() {
-//     ^^^^^^^^^^^ definition 0.1.test sg/initial/usesMyThing().
+//     ^^^^^^^^^^^ definition 0.1.test `sg/initial`/usesMyThing().
 //     documentation ```go
    _ = MY_THING
-//     ^^^^^^^^ reference 0.1.test sg/initial/MY_THING.
+//     ^^^^^^^^ reference 0.1.test `sg/initial`/MY_THING.
   }
   
   var initFunctions = map[string]int{}
-//    ^^^^^^^^^^^^^ definition 0.1.test sg/initial/initFunctions.
+//    ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/initFunctions.
 //    documentation ```go
   

--- a/internal/testdata/snapshots/output/initial/type_declarations.go
+++ b/internal/testdata/snapshots/output/initial/type_declarations.go
@@ -1,66 +1,66 @@
   package initial
-//        ^^^^^^^ reference 0.1.test sg/initial/
+//        ^^^^^^^ reference 0.1.test `sg/initial`/
   
   type LiteralType int
-//     ^^^^^^^^^^^ definition 0.1.test sg/initial/LiteralType#
+//     ^^^^^^^^^^^ definition 0.1.test `sg/initial`/LiteralType#
 //     documentation ```go
   
   type FuncType func(LiteralType, int) bool
-//     ^^^^^^^^ definition 0.1.test sg/initial/FuncType#
+//     ^^^^^^^^ definition 0.1.test `sg/initial`/FuncType#
 //     documentation ```go
-//                   ^^^^^^^^^^^ reference 0.1.test sg/initial/LiteralType#
+//                   ^^^^^^^^^^^ reference 0.1.test `sg/initial`/LiteralType#
   
   type IfaceType interface {
-//     ^^^^^^^^^ definition 0.1.test sg/initial/IfaceType#
+//     ^^^^^^^^^ definition 0.1.test `sg/initial`/IfaceType#
 //     documentation ```go
 //     documentation ```go
    Method() LiteralType
-// ^^^^^^ definition 0.1.test sg/initial/IfaceType#Method.
+// ^^^^^^ definition 0.1.test `sg/initial`/IfaceType#Method.
 // documentation ```go
-//          ^^^^^^^^^^^ reference 0.1.test sg/initial/LiteralType#
+//          ^^^^^^^^^^^ reference 0.1.test `sg/initial`/LiteralType#
   }
   
   type StructType struct {
-//     ^^^^^^^^^^ definition 0.1.test sg/initial/StructType#
+//     ^^^^^^^^^^ definition 0.1.test `sg/initial`/StructType#
 //     documentation ```go
 //     documentation ```go
    m IfaceType
-// ^ definition 0.1.test sg/initial/StructType#m.
+// ^ definition 0.1.test `sg/initial`/StructType#m.
 // documentation ```go
-//   ^^^^^^^^^ reference 0.1.test sg/initial/IfaceType#
+//   ^^^^^^^^^ reference 0.1.test `sg/initial`/IfaceType#
    f LiteralType
-// ^ definition 0.1.test sg/initial/StructType#f.
+// ^ definition 0.1.test `sg/initial`/StructType#f.
 // documentation ```go
-//   ^^^^^^^^^^^ reference 0.1.test sg/initial/LiteralType#
+//   ^^^^^^^^^^^ reference 0.1.test `sg/initial`/LiteralType#
   
    // anonymous struct
    anon struct {
-// ^^^^ definition 0.1.test sg/initial/StructType#anon.
+// ^^^^ definition 0.1.test `sg/initial`/StructType#anon.
 // documentation ```go
     sub int
-//  ^^^ definition 0.1.test sg/initial/StructType#anon.sub.
+//  ^^^ definition 0.1.test `sg/initial`/StructType#anon.sub.
 //  documentation ```go
    }
   
    // interface within struct
    i interface {
-// ^ definition 0.1.test sg/initial/StructType#i.
+// ^ definition 0.1.test `sg/initial`/StructType#i.
 // documentation ```go
     AnonMethod() bool
-//  ^^^^^^^^^^ definition 0.1.test sg/initial/StructType#i.AnonMethod.
+//  ^^^^^^^^^^ definition 0.1.test `sg/initial`/StructType#i.AnonMethod.
 //  documentation ```go
    }
   }
   
   type DeclaredBefore struct{ DeclaredAfter }
-//     ^^^^^^^^^^^^^^ definition 0.1.test sg/initial/DeclaredBefore#
+//     ^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/DeclaredBefore#
 //     documentation ```go
 //     documentation ```go
-//                            ^^^^^^^^^^^^^ definition 0.1.test sg/initial/DeclaredBefore#DeclaredAfter.
+//                            ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/DeclaredBefore#DeclaredAfter.
 //                            documentation ```go
-//                            ^^^^^^^^^^^^^ reference 0.1.test sg/initial/DeclaredAfter#
+//                            ^^^^^^^^^^^^^ reference 0.1.test `sg/initial`/DeclaredAfter#
   type DeclaredAfter struct{}
-//     ^^^^^^^^^^^^^ definition 0.1.test sg/initial/DeclaredAfter#
+//     ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/DeclaredAfter#
 //     documentation ```go
 //     documentation ```go
   

--- a/internal/testdata/snapshots/output/initial/type_hovers.go
+++ b/internal/testdata/snapshots/output/initial/type_hovers.go
@@ -1,17 +1,17 @@
   package initial
-//        ^^^^^^^ reference 0.1.test sg/initial/
+//        ^^^^^^^ reference 0.1.test `sg/initial`/
   
   type (
    // HoverTypeList is a cool struct
    HoverTypeList struct{}
-// ^^^^^^^^^^^^^ definition 0.1.test sg/initial/HoverTypeList#
+// ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/HoverTypeList#
 // documentation ```go
 // documentation ```go
   )
   
   // This should show up as well
   type HoverType struct{}
-//     ^^^^^^^^^ definition 0.1.test sg/initial/HoverType#
+//     ^^^^^^^^^ definition 0.1.test `sg/initial`/HoverType#
 //     documentation ```go
 //     documentation This should show up as well
 //     documentation ```go

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct.go
@@ -1,37 +1,37 @@
   package inlinestruct
-//        ^^^^^^^^^^^^ definition 0.1.test sg/inlinestruct/
+//        ^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/
 //        documentation package inlinestruct
   
   type FieldInterface interface {
-//     ^^^^^^^^^^^^^^ definition 0.1.test sg/inlinestruct/FieldInterface#
+//     ^^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/FieldInterface#
 //     documentation ```go
 //     documentation ```go
    SomeMethod() string
-// ^^^^^^^^^^ definition 0.1.test sg/inlinestruct/FieldInterface#SomeMethod.
+// ^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/FieldInterface#SomeMethod.
 // documentation ```go
   }
   
   var MyInline = struct {
-//    ^^^^^^^^ definition 0.1.test sg/inlinestruct/MyInline.
+//    ^^^^^^^^ definition 0.1.test `sg/inlinestruct`/MyInline.
 //    documentation ```go
    privateField FieldInterface
-// ^^^^^^^^^^^^ definition 0.1.test sg/inlinestruct/MyInline:privateField.
+// ^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/MyInline:privateField.
 // documentation ```go
-//              ^^^^^^^^^^^^^^ reference 0.1.test sg/inlinestruct/FieldInterface#
+//              ^^^^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/FieldInterface#
    PublicField  FieldInterface
-// ^^^^^^^^^^^ definition 0.1.test sg/inlinestruct/MyInline:PublicField.
+// ^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/MyInline:PublicField.
 // documentation ```go
-//              ^^^^^^^^^^^^^^ reference 0.1.test sg/inlinestruct/FieldInterface#
+//              ^^^^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/FieldInterface#
   }{}
   
   func MyFunc() {
-//     ^^^^^^ definition 0.1.test sg/inlinestruct/MyFunc().
+//     ^^^^^^ definition 0.1.test `sg/inlinestruct`/MyFunc().
 //     documentation ```go
    _ = MyInline.privateField
-//     ^^^^^^^^ reference 0.1.test sg/inlinestruct/MyInline.
-//              ^^^^^^^^^^^^ reference 0.1.test sg/inlinestruct/MyInline:privateField.
+//     ^^^^^^^^ reference 0.1.test `sg/inlinestruct`/MyInline.
+//              ^^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/MyInline:privateField.
    _ = MyInline.PublicField
-//     ^^^^^^^^ reference 0.1.test sg/inlinestruct/MyInline.
-//              ^^^^^^^^^^^ reference 0.1.test sg/inlinestruct/MyInline:PublicField.
+//     ^^^^^^^^ reference 0.1.test `sg/inlinestruct`/MyInline.
+//              ^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/MyInline:PublicField.
   }
   

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_func.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_func.go
@@ -1,17 +1,17 @@
   package inlinestruct
-//        ^^^^^^^^^^^^ reference 0.1.test sg/inlinestruct/
+//        ^^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/
   
   type InFuncSig struct {
-//     ^^^^^^^^^ definition 0.1.test sg/inlinestruct/InFuncSig#
+//     ^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/InFuncSig#
 //     documentation ```go
 //     documentation ```go
    value bool
-// ^^^^^ definition 0.1.test sg/inlinestruct/InFuncSig#value.
+// ^^^^^ definition 0.1.test `sg/inlinestruct`/InFuncSig#value.
 // documentation ```go
   }
   
   var rowsCloseHook = func() func(InFuncSig, *error) { return nil }
-//    ^^^^^^^^^^^^^ definition 0.1.test sg/inlinestruct/rowsCloseHook.
+//    ^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/rowsCloseHook.
 //    documentation ```go
-//                                ^^^^^^^^^ reference 0.1.test sg/inlinestruct/InFuncSig#
+//                                ^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/InFuncSig#
   

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_genericindex.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_genericindex.go
@@ -1,45 +1,45 @@
   package inlinestruct
-//        ^^^^^^^^^^^^ reference 0.1.test sg/inlinestruct/
+//        ^^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/
   
   type Processor[T any] interface {
-//     ^^^^^^^^^ definition 0.1.test sg/inlinestruct/Processor#
+//     ^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/Processor#
 //     documentation ```go
 //     documentation ```go
 //               ^ definition local 0
    Process(payload T)
-// ^^^^^^^ definition 0.1.test sg/inlinestruct/Processor#Process.
+// ^^^^^^^ definition 0.1.test `sg/inlinestruct`/Processor#Process.
 // documentation ```go
 //         ^^^^^^^ definition local 1
 //                 ^ reference local 0
    ProcessorType() string
-// ^^^^^^^^^^^^^ definition 0.1.test sg/inlinestruct/Processor#ProcessorType.
+// ^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/Processor#ProcessorType.
 // documentation ```go
   }
   
   type Limit int
-//     ^^^^^ definition 0.1.test sg/inlinestruct/Limit#
+//     ^^^^^ definition 0.1.test `sg/inlinestruct`/Limit#
 //     documentation ```go
   
   type ProcessImpl struct{}
-//     ^^^^^^^^^^^ definition 0.1.test sg/inlinestruct/ProcessImpl#
+//     ^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/ProcessImpl#
 //     documentation ```go
 //     documentation ```go
   
   func (p *ProcessImpl) Process(payload Limit) { panic("not implemented") }
 //      ^ definition local 2
-//         ^^^^^^^^^^^ reference 0.1.test sg/inlinestruct/ProcessImpl#
-//                      ^^^^^^^ definition 0.1.test sg/inlinestruct/ProcessImpl#Process().
+//         ^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/ProcessImpl#
+//                      ^^^^^^^ definition 0.1.test `sg/inlinestruct`/ProcessImpl#Process().
 //                      documentation ```go
 //                              ^^^^^^^ definition local 3
-//                                      ^^^^^ reference 0.1.test sg/inlinestruct/Limit#
+//                                      ^^^^^ reference 0.1.test `sg/inlinestruct`/Limit#
   func (p *ProcessImpl) ProcessorType() string { panic("not implemented") }
 //      ^ definition local 4
-//         ^^^^^^^^^^^ reference 0.1.test sg/inlinestruct/ProcessImpl#
-//                      ^^^^^^^^^^^^^ definition 0.1.test sg/inlinestruct/ProcessImpl#ProcessorType().
+//         ^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/ProcessImpl#
+//                      ^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/ProcessImpl#ProcessorType().
 //                      documentation ```go
   
   var _ Processor[Limit] = &ProcessImpl{}
-//      ^^^^^^^^^ reference 0.1.test sg/inlinestruct/Processor#
-//                ^^^^^ reference 0.1.test sg/inlinestruct/Limit#
-//                          ^^^^^^^^^^^ reference 0.1.test sg/inlinestruct/ProcessImpl#
+//      ^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/Processor#
+//                ^^^^^ reference 0.1.test `sg/inlinestruct`/Limit#
+//                          ^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/ProcessImpl#
   

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_interface.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_interface.go
@@ -1,29 +1,29 @@
   package inlinestruct
-//        ^^^^^^^^^^^^ reference 0.1.test sg/inlinestruct/
+//        ^^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/
   
   import "context"
 //        ^^^^^^^ reference github.com/golang/go/src go1.19 context/
   
   func Target() interface {
-//     ^^^^^^ definition 0.1.test sg/inlinestruct/Target().
+//     ^^^^^^ definition 0.1.test `sg/inlinestruct`/Target().
 //     documentation ```go
    OID(context.Context) (int, error)
-// ^^^ definition 0.1.test sg/inlinestruct/func:Target:OID().
+// ^^^ definition 0.1.test `sg/inlinestruct`/func:Target:OID().
 // documentation ```go
 //     ^^^^^^^ reference github.com/golang/go/src go1.19 context/
 //             ^^^^^^^ reference github.com/golang/go/src go1.19 context/Context#
    AbbreviatedOID(context.Context) (string, error)
-// ^^^^^^^^^^^^^^ definition 0.1.test sg/inlinestruct/func:Target:AbbreviatedOID().
+// ^^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/func:Target:AbbreviatedOID().
 // documentation ```go
 //                ^^^^^^^ reference github.com/golang/go/src go1.19 context/
 //                        ^^^^^^^ reference github.com/golang/go/src go1.19 context/Context#
    Commit(context.Context) (string, error)
-// ^^^^^^ definition 0.1.test sg/inlinestruct/func:Target:Commit().
+// ^^^^^^ definition 0.1.test `sg/inlinestruct`/func:Target:Commit().
 // documentation ```go
 //        ^^^^^^^ reference github.com/golang/go/src go1.19 context/
 //                ^^^^^^^ reference github.com/golang/go/src go1.19 context/Context#
    Type(context.Context) (int, error)
-// ^^^^ definition 0.1.test sg/inlinestruct/func:Target:Type().
+// ^^^^ definition 0.1.test `sg/inlinestruct`/func:Target:Type().
 // documentation ```go
 //      ^^^^^^^ reference github.com/golang/go/src go1.19 context/
 //              ^^^^^^^ reference github.com/golang/go/src go1.19 context/Context#
@@ -32,14 +32,14 @@
   }
   
   func something() {
-//     ^^^^^^^^^ definition 0.1.test sg/inlinestruct/something().
+//     ^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/something().
 //     documentation ```go
    x := Target()
 // ^ definition local 0
-//      ^^^^^^ reference 0.1.test sg/inlinestruct/Target().
+//      ^^^^^^ reference 0.1.test `sg/inlinestruct`/Target().
    x.OID(context.Background())
 // ^ reference local 0
-//   ^^^ reference 0.1.test sg/inlinestruct/func:Target:OID().
+//   ^^^ reference 0.1.test `sg/inlinestruct`/func:Target:OID().
 //       ^^^^^^^ reference github.com/golang/go/src go1.19 context/
 //               ^^^^^^^^^^ reference github.com/golang/go/src go1.19 context/Background().
   }

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_map.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_map.go
@@ -1,7 +1,7 @@
   package inlinestruct
-//        ^^^^^^^^^^^^ reference 0.1.test sg/inlinestruct/
+//        ^^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/
   
   var testHook = func(map[string]string) {}
-//    ^^^^^^^^ definition 0.1.test sg/inlinestruct/testHook.
+//    ^^^^^^^^ definition 0.1.test `sg/inlinestruct`/testHook.
 //    documentation ```go
   

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_multivar.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_multivar.go
@@ -1,51 +1,51 @@
   package inlinestruct
-//        ^^^^^^^^^^^^ reference 0.1.test sg/inlinestruct/
+//        ^^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/
   
   type Params struct{}
-//     ^^^^^^ definition 0.1.test sg/inlinestruct/Params#
+//     ^^^^^^ definition 0.1.test `sg/inlinestruct`/Params#
 //     documentation ```go
 //     documentation ```go
   type HighlightedCode struct{}
-//     ^^^^^^^^^^^^^^^ definition 0.1.test sg/inlinestruct/HighlightedCode#
+//     ^^^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/HighlightedCode#
 //     documentation ```go
 //     documentation ```go
   
   var Mocks, emptyMocks struct {
-//    ^^^^^ definition 0.1.test sg/inlinestruct/Mocks.
+//    ^^^^^ definition 0.1.test `sg/inlinestruct`/Mocks.
 //    documentation ```go
-//           ^^^^^^^^^^ definition 0.1.test sg/inlinestruct/emptyMocks.
+//           ^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/emptyMocks.
 //           documentation ```go
    Code func(p Params) (response *HighlightedCode, aborted bool, err error)
-// ^^^^ definition 0.1.test sg/inlinestruct/inline-30:Code.
+// ^^^^ definition 0.1.test `sg/inlinestruct`/inline-30:Code.
 // documentation ```go
 //           ^ definition local 0
-//             ^^^^^^ reference 0.1.test sg/inlinestruct/Params#
+//             ^^^^^^ reference 0.1.test `sg/inlinestruct`/Params#
 //                      ^^^^^^^^ definition local 1
-//                                ^^^^^^^^^^^^^^^ reference 0.1.test sg/inlinestruct/HighlightedCode#
+//                                ^^^^^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/HighlightedCode#
 //                                                 ^^^^^^^ definition local 2
 //                                                               ^^^ definition local 3
   }
   
   var MocksSingle struct {
-//    ^^^^^^^^^^^ definition 0.1.test sg/inlinestruct/MocksSingle.
+//    ^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/MocksSingle.
 //    documentation ```go
    Code func(p Params) (response *HighlightedCode, aborted bool, err error)
-// ^^^^ definition 0.1.test sg/inlinestruct/MocksSingle:Code.
+// ^^^^ definition 0.1.test `sg/inlinestruct`/MocksSingle:Code.
 // documentation ```go
 //           ^ definition local 4
-//             ^^^^^^ reference 0.1.test sg/inlinestruct/Params#
+//             ^^^^^^ reference 0.1.test `sg/inlinestruct`/Params#
 //                      ^^^^^^^^ definition local 5
-//                                ^^^^^^^^^^^^^^^ reference 0.1.test sg/inlinestruct/HighlightedCode#
+//                                ^^^^^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/HighlightedCode#
 //                                                 ^^^^^^^ definition local 6
 //                                                               ^^^ definition local 7
   }
   
   var (
    okReply   interface{} = "OK"
-// ^^^^^^^ definition 0.1.test sg/inlinestruct/okReply.
+// ^^^^^^^ definition 0.1.test `sg/inlinestruct`/okReply.
 // documentation ```go
    pongReply interface{} = "PONG"
-// ^^^^^^^^^ definition 0.1.test sg/inlinestruct/pongReply.
+// ^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/pongReply.
 // documentation ```go
   )
   

--- a/internal/testdata/snapshots/output/package-documentation/primary.go
+++ b/internal/testdata/snapshots/output/package-documentation/primary.go
@@ -1,9 +1,9 @@
   // This is documentation for this package.
   package packagedocumentation
-//        ^^^^^^^^^^^^^^^^^^^^ definition github.com/sourcegraph/scip-go github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/package-documentation/
+//        ^^^^^^^^^^^^^^^^^^^^ definition github.com/sourcegraph/scip-go . `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/package-documentation`/
 //        documentation This is documentation for this package.
   
   func Exported() {}
-//     ^^^^^^^^ definition github.com/sourcegraph/scip-go github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/package-documentation/Exported().
+//     ^^^^^^^^ definition github.com/sourcegraph/scip-go . `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/package-documentation`/Exported().
 //     documentation ```go
   

--- a/internal/testdata/snapshots/output/package-documentation/secondary.go
+++ b/internal/testdata/snapshots/output/package-documentation/secondary.go
@@ -1,7 +1,7 @@
   package packagedocumentation
-//        ^^^^^^^^^^^^^^^^^^^^ reference github.com/sourcegraph/scip-go github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/package-documentation/
+//        ^^^^^^^^^^^^^^^^^^^^ reference github.com/sourcegraph/scip-go . `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/package-documentation`/
   
   func AlsoExporter() {}
-//     ^^^^^^^^^^^^ definition github.com/sourcegraph/scip-go github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/package-documentation/AlsoExporter().
+//     ^^^^^^^^^^^^ definition github.com/sourcegraph/scip-go . `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/package-documentation`/AlsoExporter().
 //     documentation ```go
   

--- a/internal/testdata/snapshots/output/replace-directives/replace_directives.go
+++ b/internal/testdata/snapshots/output/replace-directives/replace_directives.go
@@ -1,5 +1,5 @@
   package replacers
-//        ^^^^^^^^^ definition 0.1.test sg/replace-directives/
+//        ^^^^^^^^^ definition 0.1.test `sg/replace-directives`/
 //        documentation package replacers
   
   import (
@@ -7,16 +7,16 @@
 //  ^^^ reference github.com/golang/go/src go1.19 fmt/
   
    "github.com/dghubble/gologin"
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8 github.com/dghubble/gologin/
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8 `github.com/dghubble/gologin`/
   )
   
   func Something() {
-//     ^^^^^^^^^ definition 0.1.test sg/replace-directives/Something().
+//     ^^^^^^^^^ definition 0.1.test `sg/replace-directives`/Something().
 //     documentation ```go
    fmt.Println(gologin.DefaultCookieConfig)
 // ^^^ reference github.com/golang/go/src go1.19 fmt/
 //     ^^^^^^^ reference github.com/golang/go/src go1.19 fmt/Println().
-//             ^^^^^^^ reference github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8 github.com/dghubble/gologin/
-//                     ^^^^^^^^^^^^^^^^^^^ reference github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8 github.com/dghubble/gologin/DefaultCookieConfig.
+//             ^^^^^^^ reference github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8 `github.com/dghubble/gologin`/
+//                     ^^^^^^^^^^^^^^^^^^^ reference github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8 `github.com/dghubble/gologin`/DefaultCookieConfig.
   }
   

--- a/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/cleanup.go
+++ b/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/cleanup.go
@@ -1,7 +1,7 @@
   package server
-//        ^^^^^^ reference 0.1.test sg/sharedtestmodule/cmd/gitserver/server/
+//        ^^^^^^ reference 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/
   
   func LiterallyAnything() {}
-//     ^^^^^^^^^^^^^^^^^ definition 0.1.test sg/sharedtestmodule/cmd/gitserver/server/LiterallyAnything().
+//     ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/LiterallyAnything().
 //     documentation ```go
   

--- a/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/server.go
+++ b/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/server.go
@@ -1,8 +1,8 @@
   package server
-//        ^^^^^^ definition 0.1.test sg/sharedtestmodule/cmd/gitserver/server/
+//        ^^^^^^ definition 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/
 //        documentation package server
   
   func AnythingAtAll() {}
-//     ^^^^^^^^^^^^^ definition 0.1.test sg/sharedtestmodule/cmd/gitserver/server/AnythingAtAll().
+//     ^^^^^^^^^^^^^ definition 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/AnythingAtAll().
 //     documentation ```go
   

--- a/internal/testdata/snapshots/output/switches/switches.go
+++ b/internal/testdata/snapshots/output/switches/switches.go
@@ -1,10 +1,10 @@
   package switches
-//        ^^^^^^^^ definition 0.1.test sg/switches/
+//        ^^^^^^^^ definition 0.1.test `sg/switches`/
 //        documentation package switches
   
   // CustomSwitch does the things in a switch
   type CustomSwitch struct{}
-//     ^^^^^^^^^^^^ definition 0.1.test sg/switches/CustomSwitch#
+//     ^^^^^^^^^^^^ definition 0.1.test `sg/switches`/CustomSwitch#
 //     documentation ```go
 //     documentation CustomSwitch does the things in a switch
 //     documentation ```go
@@ -12,13 +12,13 @@
   // Something does some things... and stuff
   func (c *CustomSwitch) Something() bool { return false }
 //      ^ definition local 0
-//         ^^^^^^^^^^^^ reference 0.1.test sg/switches/CustomSwitch#
-//                       ^^^^^^^^^ definition 0.1.test sg/switches/CustomSwitch#Something().
+//         ^^^^^^^^^^^^ reference 0.1.test `sg/switches`/CustomSwitch#
+//                       ^^^^^^^^^ definition 0.1.test `sg/switches`/CustomSwitch#Something().
 //                       documentation ```go
 //                       documentation Something does some things... and stuff
   
   func Switch(interfaceValue interface{}) bool {
-//     ^^^^^^ definition 0.1.test sg/switches/Switch().
+//     ^^^^^^ definition 0.1.test `sg/switches`/Switch().
 //     documentation ```go
 //            ^^^^^^^^^^^^^^ definition local 1
    switch concreteValue := interfaceValue.(type) {
@@ -33,11 +33,11 @@
 //          ^^^^^^^^^^^^^ reference local 2
 //          override_documentation ```go
    case CustomSwitch:
-//      ^^^^^^^^^^^^ reference 0.1.test sg/switches/CustomSwitch#
+//      ^^^^^^^^^^^^ reference 0.1.test `sg/switches`/CustomSwitch#
     return concreteValue.Something()
 //         ^^^^^^^^^^^^^ reference local 2
 //         override_documentation ```go
-//                       ^^^^^^^^^ reference 0.1.test sg/switches/CustomSwitch#Something().
+//                       ^^^^^^^^^ reference 0.1.test `sg/switches`/CustomSwitch#Something().
    default:
     return false
    }

--- a/internal/testdata/snapshots/output/testdata/cmd/minimal_main/minimal_main.go
+++ b/internal/testdata/snapshots/output/testdata/cmd/minimal_main/minimal_main.go
@@ -1,24 +1,24 @@
   package main
-//        ^^^^ definition 0.1.test sg/testdata/cmd/minimal_main/
+//        ^^^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/
 //        documentation package main
   
   type User struct {
-//     ^^^^ definition 0.1.test sg/testdata/cmd/minimal_main/User#
+//     ^^^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/User#
 //     documentation ```go
 //     documentation ```go
    Id, Name string
-// ^^ definition 0.1.test sg/testdata/cmd/minimal_main/User#Id.
+// ^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/User#Id.
 // documentation ```go
-//     ^^^^ definition 0.1.test sg/testdata/cmd/minimal_main/User#Name.
+//     ^^^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/User#Name.
 //     documentation ```go
   }
   
   type UserResource struct{}
-//     ^^^^^^^^^^^^ definition 0.1.test sg/testdata/cmd/minimal_main/UserResource#
+//     ^^^^^^^^^^^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/UserResource#
 //     documentation ```go
 //     documentation ```go
   
   func main() {}
-//     ^^^^ definition 0.1.test sg/testdata/cmd/minimal_main/main().
+//     ^^^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/main().
 //     documentation ```go
   

--- a/internal/testdata/snapshots/output/testdata/data.go
+++ b/internal/testdata/snapshots/output/testdata/data.go
@@ -1,5 +1,5 @@
   package testdata
-//        ^^^^^^^^ definition 0.1.test sg/testdata/
+//        ^^^^^^^^ definition 0.1.test `sg/testdata`/
 //        documentation package testdata
   
   import (
@@ -7,18 +7,18 @@
 //  ^^^^^^^ reference github.com/golang/go/src go1.19 context/
   
    "sg/testdata/internal/secret"
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test sg/testdata/internal/secret/
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/
   )
   
   // TestInterface is an interface used for testing.
   type TestInterface interface {
-//     ^^^^^^^^^^^^^ definition 0.1.test sg/testdata/TestInterface#
+//     ^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestInterface#
 //     documentation ```go
 //     documentation TestInterface is an interface used for testing.
 //     documentation ```go
    // Do does a test thing.
    Do(ctx context.Context, data string) (score int, _ error)
-// ^^ definition 0.1.test sg/testdata/TestInterface#Do.
+// ^^ definition 0.1.test `sg/testdata`/TestInterface#Do.
 // documentation ```go
 //    ^^^ definition local 0
 //        ^^^^^^^ reference github.com/golang/go/src go1.19 context/
@@ -30,86 +30,86 @@
   type (
    // TestStruct is a struct used for testing.
    TestStruct struct {
-// ^^^^^^^^^^ definition 0.1.test sg/testdata/TestStruct#
+// ^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#
 // documentation ```go
 // documentation ```go
     // SimpleA docs
     SimpleA int
-//  ^^^^^^^ definition 0.1.test sg/testdata/TestStruct#SimpleA.
+//  ^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#SimpleA.
 //  documentation ```go
     // SimpleB docs
     SimpleB int
-//  ^^^^^^^ definition 0.1.test sg/testdata/TestStruct#SimpleB.
+//  ^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#SimpleB.
 //  documentation ```go
     // SimpleC docs
     SimpleC int
-//  ^^^^^^^ definition 0.1.test sg/testdata/TestStruct#SimpleC.
+//  ^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#SimpleC.
 //  documentation ```go
   
     FieldWithTag           string `json:"tag"`
-//  ^^^^^^^^^^^^ definition 0.1.test sg/testdata/TestStruct#FieldWithTag.
+//  ^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#FieldWithTag.
 //  documentation ```go
     FieldWithAnonymousType struct {
-//  ^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/TestStruct#FieldWithAnonymousType.
+//  ^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#FieldWithAnonymousType.
 //  documentation ```go
      NestedA string
-//   ^^^^^^^ definition 0.1.test sg/testdata/TestStruct#FieldWithAnonymousType.NestedA.
+//   ^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#FieldWithAnonymousType.NestedA.
 //   documentation ```go
      NestedB string
-//   ^^^^^^^ definition 0.1.test sg/testdata/TestStruct#FieldWithAnonymousType.NestedB.
+//   ^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#FieldWithAnonymousType.NestedB.
 //   documentation ```go
      // NestedC docs
      NestedC string
-//   ^^^^^^^ definition 0.1.test sg/testdata/TestStruct#FieldWithAnonymousType.NestedC.
+//   ^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#FieldWithAnonymousType.NestedC.
 //   documentation ```go
     }
   
     EmptyStructField struct{}
-//  ^^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/TestStruct#EmptyStructField.
+//  ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#EmptyStructField.
 //  documentation ```go
    }
   
    TestEmptyStruct struct{}
-// ^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/TestEmptyStruct#
+// ^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestEmptyStruct#
 // documentation ```go
 // documentation ```go
   )
   
   // Score is just a hardcoded number.
   const Score = uint64(42)
-//      ^^^^^ definition 0.1.test sg/testdata/Score.
+//      ^^^^^ definition 0.1.test `sg/testdata`/Score.
 //      documentation ```go
 //      documentation Score is just a hardcoded number.
   const secretScore = secret.SecretScore
-//      ^^^^^^^^^^^ definition 0.1.test sg/testdata/secretScore.
+//      ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/secretScore.
 //      documentation ```go
-//                    ^^^^^^ reference 0.1.test sg/testdata/internal/secret/
-//                           ^^^^^^^^^^^ reference 0.1.test sg/testdata/internal/secret/SecretScore.
+//                    ^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/
+//                           ^^^^^^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/SecretScore.
   
   const SomeString = "foobar"
-//      ^^^^^^^^^^ definition 0.1.test sg/testdata/SomeString.
+//      ^^^^^^^^^^ definition 0.1.test `sg/testdata`/SomeString.
 //      documentation ```go
   const LongString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed tincidunt viverra aliquam. Phasellus finibus, arcu eu commodo porta, dui quam dictum ante, nec porta enim leo quis felis. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Curabitur luctus orci tortor, non condimentum arcu bibendum ut. Proin sit amet vulputate lorem, ut egestas arcu. Curabitur quis sagittis mi. Aenean elit sem, imperdiet ut risus eget, varius varius erat.\nNullam lobortis tortor sed sodales consectetur. Aenean condimentum vehicula elit, eget interdum ante finibus nec. Mauris mollis, nulla eu vehicula rhoncus, eros lectus viverra tellus, ac hendrerit quam massa et felis. Nunc vestibulum diam a facilisis sollicitudin. Aenean nec varius metus. Sed nec diam nibh. Ut erat erat, suscipit et ante eget, tincidunt condimentum orci. Aenean nec facilisis augue, ac sodales ex. Nulla dictum hendrerit tempus. Aliquam fringilla tortor in massa molestie, quis bibendum nulla ullamcorper. Suspendisse congue laoreet elit, vitae consectetur orci facilisis non. Aliquam tempus ultricies sapien, rhoncus tincidunt nisl tincidunt eget. Aliquam nisi ante, rutrum eget viverra imperdiet, congue ut nunc. Donec mollis sed tellus vel placerat. Sed mi ex, fringilla a fermentum a, tincidunt eget lectus.\nPellentesque lacus nibh, accumsan eget feugiat nec, gravida eget urna. Donec quam velit, imperdiet in consequat eget, ultricies eget nunc. Curabitur interdum vel sem et euismod. Donec sed vulputate odio, sit amet bibendum tellus. Integer pellentesque nunc eu turpis cursus, vestibulum sodales ipsum posuere. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Ut at vestibulum sapien. In hac habitasse platea dictumst. Nullam sed lobortis urna, non bibendum ipsum. Sed in sapien quis purus semper fringilla. Integer ut egestas nulla, eu ornare lectus. Maecenas quis sapien condimentum, dignissim urna quis, hendrerit neque. Donec cursus sit amet metus eu mollis.\nSed scelerisque vitae odio non egestas. Cras hendrerit tortor mauris. Aenean quis imperdiet nulla, a viverra purus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Praesent finibus faucibus orci, sed ultrices justo iaculis ut. Ut libero massa, condimentum at elit non, fringilla iaculis quam. Sed sit amet ipsum placerat, tincidunt sem in, efficitur lacus. Curabitur ligula orci, tempus ut magna eget, sodales tristique odio.\nPellentesque in libero ac risus pretium ultrices. In hac habitasse platea dictumst. Curabitur a quam sed orci tempus luctus. Integer commodo nec odio quis consequat. Aenean vitae dapibus augue, nec dictum lectus. Etiam sit amet leo diam. Duis eu ligula venenatis, fermentum lacus vel, interdum odio. Vivamus sit amet libero vitae elit interdum cursus et eu erat. Cras interdum augue sit amet ex aliquet tempor. Praesent dolor nisl, convallis bibendum mauris a, euismod commodo ante. Phasellus non ipsum condimentum, molestie dolor quis, pretium nisi. Mauris augue urna, fermentum ut lacinia a, efficitur vitae odio. Praesent finibus nisl et dolor luctus faucibus. Donec eget lectus sed mi porttitor placerat ac eu odio."
-//      ^^^^^^^^^^ definition 0.1.test sg/testdata/LongString.
+//      ^^^^^^^^^^ definition 0.1.test `sg/testdata`/LongString.
 //      documentation ```go
   const ConstMath = 1 + (2+3)*5
-//      ^^^^^^^^^ definition 0.1.test sg/testdata/ConstMath.
+//      ^^^^^^^^^ definition 0.1.test `sg/testdata`/ConstMath.
 //      documentation ```go
   
   type StringAlias string
-//     ^^^^^^^^^^^ definition 0.1.test sg/testdata/StringAlias#
+//     ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/StringAlias#
 //     documentation ```go
   
   const AliasedString StringAlias = "foobar"
-//      ^^^^^^^^^^^^^ definition 0.1.test sg/testdata/AliasedString.
+//      ^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/AliasedString.
 //      documentation ```go
-//                    ^^^^^^^^^^^ reference 0.1.test sg/testdata/StringAlias#
+//                    ^^^^^^^^^^^ reference 0.1.test `sg/testdata`/StringAlias#
   
   // Doer is similar to the test interface (but not the same).
   func (ts *TestStruct) Doer(ctx context.Context, data string) (score int, err error) {
 //      ^^ definition local 3
-//          ^^^^^^^^^^ reference 0.1.test sg/testdata/TestStruct#
-//                      ^^^^ definition 0.1.test sg/testdata/TestStruct#Doer().
+//          ^^^^^^^^^^ reference 0.1.test `sg/testdata`/TestStruct#
+//                      ^^^^ definition 0.1.test `sg/testdata`/TestStruct#Doer().
 //                      documentation ```go
 //                      documentation Doer is similar to the test interface (but not the same).
 //                           ^^^ definition local 4
@@ -119,7 +119,7 @@
 //                                                              ^^^^^ definition local 6
 //                                                                         ^^^ definition local 7
    return Score, nil
-//        ^^^^^ reference 0.1.test sg/testdata/Score.
+//        ^^^^^ reference 0.1.test `sg/testdata`/Score.
   }
   
   // StructTagRegression is a struct that caused panic in the wild. Added here to
@@ -127,40 +127,40 @@
   //
   // See https://github.com/tal-tech/go-zero/blob/11dd3d75ecceaa3f5772024fb3f26dec1ada8e9c/core/mapping/unmarshaler_test.go#L2272.
   type StructTagRegression struct {
-//     ^^^^^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/StructTagRegression#
+//     ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/StructTagRegression#
 //     documentation ```go
 //     documentation StructTagRegression is a struct that caused panic in the wild. Added here to
 //     documentation ```go
    Value int `key:",range=[:}"`
-// ^^^^^ definition 0.1.test sg/testdata/StructTagRegression#Value.
+// ^^^^^ definition 0.1.test `sg/testdata`/StructTagRegression#Value.
 // documentation ```go
   }
   
   type TestEqualsStruct = struct {
-//     ^^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/TestEqualsStruct#
+//     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestEqualsStruct#
 //     documentation ```go
 //     documentation ```go
    Value int
-// ^^^^^ definition 0.1.test sg/testdata/TestEqualsStruct#Value.
+// ^^^^^ definition 0.1.test `sg/testdata`/TestEqualsStruct#Value.
 // documentation ```go
   }
   
   type ShellStruct struct {
-//     ^^^^^^^^^^^ definition 0.1.test sg/testdata/ShellStruct#
+//     ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/ShellStruct#
 //     documentation ```go
 //     documentation ```go
    // Ensure this field comes before the definition
    // so that we grab the correct one in our unit
    // tests.
    InnerStruct
-// ^^^^^^^^^^^ definition 0.1.test sg/testdata/ShellStruct#InnerStruct.
+// ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/ShellStruct#InnerStruct.
 // documentation ```go
 // documentation Ensure this field comes before the definition
-// ^^^^^^^^^^^ reference 0.1.test sg/testdata/InnerStruct#
+// ^^^^^^^^^^^ reference 0.1.test `sg/testdata`/InnerStruct#
   }
   
   type InnerStruct struct{}
-//     ^^^^^^^^^^^ definition 0.1.test sg/testdata/InnerStruct#
+//     ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InnerStruct#
 //     documentation ```go
 //     documentation ```go
   

--- a/internal/testdata/snapshots/output/testdata/duplicate_path_id/main.go
+++ b/internal/testdata/snapshots/output/testdata/duplicate_path_id/main.go
@@ -1,31 +1,31 @@
   package gosrc
-//        ^^^^^ reference 0.1.test sg/testdata/duplicate_path_id/
+//        ^^^^^ reference 0.1.test `sg/testdata/duplicate_path_id`/
   
   type importMeta struct{}
-//     ^^^^^^^^^^ definition 0.1.test sg/testdata/duplicate_path_id/importMeta#
+//     ^^^^^^^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/importMeta#
 //     documentation ```go
 //     documentation ```go
   
   type sourceMeta struct{}
-//     ^^^^^^^^^^ definition 0.1.test sg/testdata/duplicate_path_id/sourceMeta#
+//     ^^^^^^^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/sourceMeta#
 //     documentation ```go
 //     documentation ```go
   
   func fetchMeta() (string, *importMeta, *sourceMeta) {
-//     ^^^^^^^^^ definition 0.1.test sg/testdata/duplicate_path_id/fetchMeta().
+//     ^^^^^^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/fetchMeta().
 //     documentation ```go
-//                           ^^^^^^^^^^ reference 0.1.test sg/testdata/duplicate_path_id/importMeta#
-//                                        ^^^^^^^^^^ reference 0.1.test sg/testdata/duplicate_path_id/sourceMeta#
+//                           ^^^^^^^^^^ reference 0.1.test `sg/testdata/duplicate_path_id`/importMeta#
+//                                        ^^^^^^^^^^ reference 0.1.test `sg/testdata/duplicate_path_id`/sourceMeta#
    panic("hmm")
   }
   
   func init() {}
-//     ^^^^ definition 0.1.test sg/testdata/duplicate_path_id/init().
+//     ^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/init().
 //     documentation ```go
   func init() {}
-//     ^^^^ definition 0.1.test sg/testdata/duplicate_path_id/init().
+//     ^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/init().
 //     documentation ```go
   func init() {}
-//     ^^^^ definition 0.1.test sg/testdata/duplicate_path_id/init().
+//     ^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/init().
 //     documentation ```go
   

--- a/internal/testdata/snapshots/output/testdata/duplicate_path_id/two.go
+++ b/internal/testdata/snapshots/output/testdata/duplicate_path_id/two.go
@@ -1,8 +1,8 @@
   package gosrc
-//        ^^^^^ definition 0.1.test sg/testdata/duplicate_path_id/
+//        ^^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/
 //        documentation package gosrc
   
   func init() {}
-//     ^^^^ definition 0.1.test sg/testdata/duplicate_path_id/init().
+//     ^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/init().
 //     documentation ```go
   

--- a/internal/testdata/snapshots/output/testdata/external_composite.go
+++ b/internal/testdata/snapshots/output/testdata/external_composite.go
@@ -1,21 +1,21 @@
   package testdata
-//        ^^^^^^^^ reference 0.1.test sg/testdata/
+//        ^^^^^^^^ reference 0.1.test `sg/testdata`/
   
   import "net/http"
-//        ^^^^^^^^ reference github.com/golang/go/src go1.19 net/http/
+//        ^^^^^^^^ reference github.com/golang/go/src go1.19 `net/http`/
   
   type NestedHandler struct {
-//     ^^^^^^^^^^^^^ definition 0.1.test sg/testdata/NestedHandler#
+//     ^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/NestedHandler#
 //     documentation ```go
 //     documentation ```go
-//     relationship github.com/golang/go/src go1.19 net/http/Handler# implementation
+//     relationship github.com/golang/go/src go1.19 `net/http`/Handler# implementation
    http.Handler
-// ^^^^ reference github.com/golang/go/src go1.19 net/http/
-//      ^^^^^^^ definition 0.1.test sg/testdata/NestedHandler#Handler.
+// ^^^^ reference github.com/golang/go/src go1.19 `net/http`/
+//      ^^^^^^^ definition 0.1.test `sg/testdata`/NestedHandler#Handler.
 //      documentation ```go
-//      ^^^^^^^ reference github.com/golang/go/src go1.19 net/http/Handler#
+//      ^^^^^^^ reference github.com/golang/go/src go1.19 `net/http`/Handler#
    Other int
-// ^^^^^ definition 0.1.test sg/testdata/NestedHandler#Other.
+// ^^^^^ definition 0.1.test `sg/testdata`/NestedHandler#Other.
 // documentation ```go
   }
   

--- a/internal/testdata/snapshots/output/testdata/implementations.go
+++ b/internal/testdata/snapshots/output/testdata/implementations.go
@@ -1,174 +1,174 @@
   package testdata
-//        ^^^^^^^^ reference 0.1.test sg/testdata/
+//        ^^^^^^^^ reference 0.1.test `sg/testdata`/
   
   type I0 interface{}
-//     ^^ definition 0.1.test sg/testdata/I0#
+//     ^^ definition 0.1.test `sg/testdata`/I0#
 //     documentation ```go
 //     documentation ```go
   
   type I1 interface {
-//     ^^ definition 0.1.test sg/testdata/I1#
+//     ^^ definition 0.1.test `sg/testdata`/I1#
 //     documentation ```go
 //     documentation ```go
    F1()
-// ^^ definition 0.1.test sg/testdata/I1#F1.
+// ^^ definition 0.1.test `sg/testdata`/I1#F1.
 // documentation ```go
   }
   
   type I2 interface {
-//     ^^ definition 0.1.test sg/testdata/I2#
+//     ^^ definition 0.1.test `sg/testdata`/I2#
 //     documentation ```go
 //     documentation ```go
    F2()
-// ^^ definition 0.1.test sg/testdata/I2#F2.
+// ^^ definition 0.1.test `sg/testdata`/I2#F2.
 // documentation ```go
   }
   
   type T1 int
-//     ^^ definition 0.1.test sg/testdata/T1#
+//     ^^ definition 0.1.test `sg/testdata`/T1#
 //     documentation ```go
-//     relationship 0.1.test sg/testdata/I1# implementation
+//     relationship 0.1.test `sg/testdata`/I1# implementation
   
   func (r T1) F1() {}
 //      ^ definition local 0
-//        ^^ reference 0.1.test sg/testdata/T1#
-//            ^^ definition 0.1.test sg/testdata/T1#F1().
+//        ^^ reference 0.1.test `sg/testdata`/T1#
+//            ^^ definition 0.1.test `sg/testdata`/T1#F1().
 //            documentation ```go
-//            relationship 0.1.test sg/testdata/I1#F1. implementation
-//            relationship 0.1.test sg/testdata/I1#F1. implementation
-//            relationship 0.1.test sg/testdata/I1#F1. implementation
+//            relationship 0.1.test `sg/testdata`/I1#F1. implementation
+//            relationship 0.1.test `sg/testdata`/I1#F1. implementation
+//            relationship 0.1.test `sg/testdata`/I1#F1. implementation
   
   type T2 int
-//     ^^ definition 0.1.test sg/testdata/T2#
+//     ^^ definition 0.1.test `sg/testdata`/T2#
 //     documentation ```go
-//     relationship 0.1.test sg/testdata/I1# implementation
-//     relationship 0.1.test sg/testdata/I2# implementation
+//     relationship 0.1.test `sg/testdata`/I1# implementation
+//     relationship 0.1.test `sg/testdata`/I2# implementation
   
   func (r T2) F1() {}
 //      ^ definition local 1
-//        ^^ reference 0.1.test sg/testdata/T2#
-//            ^^ definition 0.1.test sg/testdata/T2#F1().
+//        ^^ reference 0.1.test `sg/testdata`/T2#
+//            ^^ definition 0.1.test `sg/testdata`/T2#F1().
 //            documentation ```go
-//            relationship 0.1.test sg/testdata/I1#F1. implementation
+//            relationship 0.1.test `sg/testdata`/I1#F1. implementation
   func (r T2) F2() {}
 //      ^ definition local 2
-//        ^^ reference 0.1.test sg/testdata/T2#
-//            ^^ definition 0.1.test sg/testdata/T2#F2().
+//        ^^ reference 0.1.test `sg/testdata`/T2#
+//            ^^ definition 0.1.test `sg/testdata`/T2#F2().
 //            documentation ```go
-//            relationship 0.1.test sg/testdata/I2#F2. implementation
+//            relationship 0.1.test `sg/testdata`/I2#F2. implementation
   
   type A1 = T1
-//     ^^ definition 0.1.test sg/testdata/A1#
+//     ^^ definition 0.1.test `sg/testdata`/A1#
 //     documentation ```go
-//     relationship 0.1.test sg/testdata/I1# implementation
-//          ^^ reference 0.1.test sg/testdata/T1#
+//     relationship 0.1.test `sg/testdata`/I1# implementation
+//          ^^ reference 0.1.test `sg/testdata`/T1#
   type A12 = A1
-//     ^^^ definition 0.1.test sg/testdata/A12#
+//     ^^^ definition 0.1.test `sg/testdata`/A12#
 //     documentation ```go
-//     relationship 0.1.test sg/testdata/I1# implementation
-//           ^^ reference 0.1.test sg/testdata/A1#
+//     relationship 0.1.test `sg/testdata`/I1# implementation
+//           ^^ reference 0.1.test `sg/testdata`/A1#
   
   type InterfaceWithNonExportedMethod interface {
-//     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/InterfaceWithNonExportedMethod#
+//     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithNonExportedMethod#
 //     documentation ```go
 //     documentation ```go
    nonExportedMethod()
-// ^^^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/InterfaceWithNonExportedMethod#nonExportedMethod.
+// ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithNonExportedMethod#nonExportedMethod.
 // documentation ```go
   }
   
   type InterfaceWithExportedMethod interface {
-//     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/InterfaceWithExportedMethod#
+//     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithExportedMethod#
 //     documentation ```go
 //     documentation ```go
    ExportedMethod()
-// ^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/InterfaceWithExportedMethod#ExportedMethod.
+// ^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithExportedMethod#ExportedMethod.
 // documentation ```go
   }
   
   type Foo int
-//     ^^^ definition 0.1.test sg/testdata/Foo#
+//     ^^^ definition 0.1.test `sg/testdata`/Foo#
 //     documentation ```go
 //     relationship github.com/golang/go/src go1.19 io/Closer# implementation
-//     relationship 0.1.test sg/testdata/I3# implementation
-//     relationship 0.1.test sg/testdata/InterfaceWithExportedMethod# implementation
-//     relationship 0.1.test sg/testdata/InterfaceWithNonExportedMethod# implementation
+//     relationship 0.1.test `sg/testdata`/I3# implementation
+//     relationship 0.1.test `sg/testdata`/InterfaceWithExportedMethod# implementation
+//     relationship 0.1.test `sg/testdata`/InterfaceWithNonExportedMethod# implementation
   
   func (r Foo) nonExportedMethod() {}
 //      ^ definition local 3
-//        ^^^ reference 0.1.test sg/testdata/Foo#
-//             ^^^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/Foo#nonExportedMethod().
+//        ^^^ reference 0.1.test `sg/testdata`/Foo#
+//             ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/Foo#nonExportedMethod().
 //             documentation ```go
-//             relationship 0.1.test sg/testdata/InterfaceWithNonExportedMethod#nonExportedMethod. implementation
+//             relationship 0.1.test `sg/testdata`/InterfaceWithNonExportedMethod#nonExportedMethod. implementation
   func (r Foo) ExportedMethod()    {}
 //      ^ definition local 4
-//        ^^^ reference 0.1.test sg/testdata/Foo#
-//             ^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/Foo#ExportedMethod().
+//        ^^^ reference 0.1.test `sg/testdata`/Foo#
+//             ^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/Foo#ExportedMethod().
 //             documentation ```go
-//             relationship 0.1.test sg/testdata/InterfaceWithExportedMethod#ExportedMethod. implementation
+//             relationship 0.1.test `sg/testdata`/InterfaceWithExportedMethod#ExportedMethod. implementation
   func (r Foo) Close() error       { return nil }
 //      ^ definition local 5
-//        ^^^ reference 0.1.test sg/testdata/Foo#
-//             ^^^^^ definition 0.1.test sg/testdata/Foo#Close().
+//        ^^^ reference 0.1.test `sg/testdata`/Foo#
+//             ^^^^^ definition 0.1.test `sg/testdata`/Foo#Close().
 //             documentation ```go
 //             relationship github.com/golang/go/src go1.19 io/Closer#Close. implementation
-//             relationship 0.1.test sg/testdata/I3#Close. implementation
+//             relationship 0.1.test `sg/testdata`/I3#Close. implementation
   
   type SharedOne interface {
-//     ^^^^^^^^^ definition 0.1.test sg/testdata/SharedOne#
+//     ^^^^^^^^^ definition 0.1.test `sg/testdata`/SharedOne#
 //     documentation ```go
 //     documentation ```go
    Shared()
-// ^^^^^^ definition 0.1.test sg/testdata/SharedOne#Shared.
+// ^^^^^^ definition 0.1.test `sg/testdata`/SharedOne#Shared.
 // documentation ```go
    Distinct()
-// ^^^^^^^^ definition 0.1.test sg/testdata/SharedOne#Distinct.
+// ^^^^^^^^ definition 0.1.test `sg/testdata`/SharedOne#Distinct.
 // documentation ```go
   }
   
   type SharedTwo interface {
-//     ^^^^^^^^^ definition 0.1.test sg/testdata/SharedTwo#
+//     ^^^^^^^^^ definition 0.1.test `sg/testdata`/SharedTwo#
 //     documentation ```go
 //     documentation ```go
    Shared()
-// ^^^^^^ definition 0.1.test sg/testdata/SharedTwo#Shared.
+// ^^^^^^ definition 0.1.test `sg/testdata`/SharedTwo#Shared.
 // documentation ```go
    Unique()
-// ^^^^^^ definition 0.1.test sg/testdata/SharedTwo#Unique.
+// ^^^^^^ definition 0.1.test `sg/testdata`/SharedTwo#Unique.
 // documentation ```go
   }
   
   type Between struct{}
-//     ^^^^^^^ definition 0.1.test sg/testdata/Between#
+//     ^^^^^^^ definition 0.1.test `sg/testdata`/Between#
 //     documentation ```go
 //     documentation ```go
-//     relationship 0.1.test sg/testdata/SharedOne# implementation
-//     relationship 0.1.test sg/testdata/SharedTwo# implementation
+//     relationship 0.1.test `sg/testdata`/SharedOne# implementation
+//     relationship 0.1.test `sg/testdata`/SharedTwo# implementation
   
   func (Between) Shared()   {}
-//      ^^^^^^^ reference 0.1.test sg/testdata/Between#
-//               ^^^^^^ definition 0.1.test sg/testdata/Between#Shared().
+//      ^^^^^^^ reference 0.1.test `sg/testdata`/Between#
+//               ^^^^^^ definition 0.1.test `sg/testdata`/Between#Shared().
 //               documentation ```go
-//               relationship 0.1.test sg/testdata/SharedOne#Shared. implementation
-//               relationship 0.1.test sg/testdata/SharedTwo#Shared. implementation
+//               relationship 0.1.test `sg/testdata`/SharedOne#Shared. implementation
+//               relationship 0.1.test `sg/testdata`/SharedTwo#Shared. implementation
   func (Between) Distinct() {}
-//      ^^^^^^^ reference 0.1.test sg/testdata/Between#
-//               ^^^^^^^^ definition 0.1.test sg/testdata/Between#Distinct().
+//      ^^^^^^^ reference 0.1.test `sg/testdata`/Between#
+//               ^^^^^^^^ definition 0.1.test `sg/testdata`/Between#Distinct().
 //               documentation ```go
-//               relationship 0.1.test sg/testdata/SharedOne#Distinct. implementation
+//               relationship 0.1.test `sg/testdata`/SharedOne#Distinct. implementation
   func (Between) Unique()   {}
-//      ^^^^^^^ reference 0.1.test sg/testdata/Between#
-//               ^^^^^^ definition 0.1.test sg/testdata/Between#Unique().
+//      ^^^^^^^ reference 0.1.test `sg/testdata`/Between#
+//               ^^^^^^ definition 0.1.test `sg/testdata`/Between#Unique().
 //               documentation ```go
-//               relationship 0.1.test sg/testdata/SharedTwo#Unique. implementation
+//               relationship 0.1.test `sg/testdata`/SharedTwo#Unique. implementation
   
   func shouldShow(shared SharedOne) {
-//     ^^^^^^^^^^ definition 0.1.test sg/testdata/shouldShow().
+//     ^^^^^^^^^^ definition 0.1.test `sg/testdata`/shouldShow().
 //     documentation ```go
 //                ^^^^^^ definition local 6
-//                       ^^^^^^^^^ reference 0.1.test sg/testdata/SharedOne#
+//                       ^^^^^^^^^ reference 0.1.test `sg/testdata`/SharedOne#
    shared.Shared()
 // ^^^^^^ reference local 6
-//        ^^^^^^ reference 0.1.test sg/testdata/SharedOne#Shared.
+//        ^^^^^^ reference 0.1.test `sg/testdata`/SharedOne#Shared.
   }
   

--- a/internal/testdata/snapshots/output/testdata/implementations_embedded.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_embedded.go
@@ -1,27 +1,27 @@
   package testdata
-//        ^^^^^^^^ reference 0.1.test sg/testdata/
+//        ^^^^^^^^ reference 0.1.test `sg/testdata`/
   
   import "io"
 //        ^^ reference github.com/golang/go/src go1.19 io/
   
   type I3 interface {
-//     ^^ definition 0.1.test sg/testdata/I3#
+//     ^^ definition 0.1.test `sg/testdata`/I3#
 //     documentation ```go
 //     documentation ```go
    Close() error
-// ^^^^^ definition 0.1.test sg/testdata/I3#Close.
+// ^^^^^ definition 0.1.test `sg/testdata`/I3#Close.
 // documentation ```go
   }
   
   type TClose struct {
-//     ^^^^^^ definition 0.1.test sg/testdata/TClose#
+//     ^^^^^^ definition 0.1.test `sg/testdata`/TClose#
 //     documentation ```go
 //     documentation ```go
 //     relationship github.com/golang/go/src go1.19 io/Closer# implementation
-//     relationship 0.1.test sg/testdata/I3# implementation
+//     relationship 0.1.test `sg/testdata`/I3# implementation
    io.Closer
 // ^^ reference github.com/golang/go/src go1.19 io/
-//    ^^^^^^ definition 0.1.test sg/testdata/TClose#Closer.
+//    ^^^^^^ definition 0.1.test `sg/testdata`/TClose#Closer.
 //    documentation ```go
 //    ^^^^^^ reference github.com/golang/go/src go1.19 io/Closer#
   }

--- a/internal/testdata/snapshots/output/testdata/implementations_methods.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_methods.go
@@ -1,61 +1,61 @@
   package testdata
-//        ^^^^^^^^ reference 0.1.test sg/testdata/
+//        ^^^^^^^^ reference 0.1.test `sg/testdata`/
   
   type InterfaceWithSingleMethod interface {
-//     ^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/InterfaceWithSingleMethod#
+//     ^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithSingleMethod#
 //     documentation ```go
 //     documentation ```go
    SingleMethod() float64
-// ^^^^^^^^^^^^ definition 0.1.test sg/testdata/InterfaceWithSingleMethod#SingleMethod.
+// ^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithSingleMethod#SingleMethod.
 // documentation ```go
   }
   
   type StructWithMethods struct{}
-//     ^^^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/StructWithMethods#
+//     ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/StructWithMethods#
 //     documentation ```go
 //     documentation ```go
-//     relationship 0.1.test sg/testdata/InterfaceWithSingleMethod# implementation
+//     relationship 0.1.test `sg/testdata`/InterfaceWithSingleMethod# implementation
   
   func (StructWithMethods) SingleMethod() float64 { return 5.0 }
-//      ^^^^^^^^^^^^^^^^^ reference 0.1.test sg/testdata/StructWithMethods#
-//                         ^^^^^^^^^^^^ definition 0.1.test sg/testdata/StructWithMethods#SingleMethod().
+//      ^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/StructWithMethods#
+//                         ^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/StructWithMethods#SingleMethod().
 //                         documentation ```go
-//                         relationship 0.1.test sg/testdata/InterfaceWithSingleMethod#SingleMethod. implementation
+//                         relationship 0.1.test `sg/testdata`/InterfaceWithSingleMethod#SingleMethod. implementation
   
   type InterfaceWithSingleMethodTwoImplementers interface {
-//     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/InterfaceWithSingleMethodTwoImplementers#
+//     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithSingleMethodTwoImplementers#
 //     documentation ```go
 //     documentation ```go
    SingleMethodTwoImpl() float64
-// ^^^^^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/InterfaceWithSingleMethodTwoImplementers#SingleMethodTwoImpl.
+// ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithSingleMethodTwoImplementers#SingleMethodTwoImpl.
 // documentation ```go
   }
   
   type TwoImplOne struct{}
-//     ^^^^^^^^^^ definition 0.1.test sg/testdata/TwoImplOne#
+//     ^^^^^^^^^^ definition 0.1.test `sg/testdata`/TwoImplOne#
 //     documentation ```go
 //     documentation ```go
-//     relationship 0.1.test sg/testdata/InterfaceWithSingleMethodTwoImplementers# implementation
+//     relationship 0.1.test `sg/testdata`/InterfaceWithSingleMethodTwoImplementers# implementation
   
   func (TwoImplOne) SingleMethodTwoImpl() float64 { return 5.0 }
-//      ^^^^^^^^^^ reference 0.1.test sg/testdata/TwoImplOne#
-//                  ^^^^^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/TwoImplOne#SingleMethodTwoImpl().
+//      ^^^^^^^^^^ reference 0.1.test `sg/testdata`/TwoImplOne#
+//                  ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TwoImplOne#SingleMethodTwoImpl().
 //                  documentation ```go
-//                  relationship 0.1.test sg/testdata/InterfaceWithSingleMethodTwoImplementers#SingleMethodTwoImpl. implementation
+//                  relationship 0.1.test `sg/testdata`/InterfaceWithSingleMethodTwoImplementers#SingleMethodTwoImpl. implementation
   
   type TwoImplTwo struct{}
-//     ^^^^^^^^^^ definition 0.1.test sg/testdata/TwoImplTwo#
+//     ^^^^^^^^^^ definition 0.1.test `sg/testdata`/TwoImplTwo#
 //     documentation ```go
 //     documentation ```go
-//     relationship 0.1.test sg/testdata/InterfaceWithSingleMethodTwoImplementers# implementation
+//     relationship 0.1.test `sg/testdata`/InterfaceWithSingleMethodTwoImplementers# implementation
   
   func (TwoImplTwo) SingleMethodTwoImpl() float64         { return 5.0 }
-//      ^^^^^^^^^^ reference 0.1.test sg/testdata/TwoImplTwo#
-//                  ^^^^^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/TwoImplTwo#SingleMethodTwoImpl().
+//      ^^^^^^^^^^ reference 0.1.test `sg/testdata`/TwoImplTwo#
+//                  ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TwoImplTwo#SingleMethodTwoImpl().
 //                  documentation ```go
-//                  relationship 0.1.test sg/testdata/InterfaceWithSingleMethodTwoImplementers#SingleMethodTwoImpl. implementation
+//                  relationship 0.1.test `sg/testdata`/InterfaceWithSingleMethodTwoImplementers#SingleMethodTwoImpl. implementation
   func (TwoImplTwo) RandomThingThatDoesntMatter() float64 { return 5.0 }
-//      ^^^^^^^^^^ reference 0.1.test sg/testdata/TwoImplTwo#
-//                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/TwoImplTwo#RandomThingThatDoesntMatter().
+//      ^^^^^^^^^^ reference 0.1.test `sg/testdata`/TwoImplTwo#
+//                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TwoImplTwo#RandomThingThatDoesntMatter().
 //                  documentation ```go
   

--- a/internal/testdata/snapshots/output/testdata/implementations_remote.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_remote.go
@@ -1,46 +1,46 @@
   package testdata
-//        ^^^^^^^^ reference 0.1.test sg/testdata/
+//        ^^^^^^^^ reference 0.1.test `sg/testdata`/
   
   import "net/http"
-//        ^^^^^^^^ reference github.com/golang/go/src go1.19 net/http/
+//        ^^^^^^^^ reference github.com/golang/go/src go1.19 `net/http`/
   
   type implementsWriter struct{}
-//     ^^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/implementsWriter#
+//     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/implementsWriter#
 //     documentation ```go
 //     documentation ```go
-//     relationship github.com/golang/go/src go1.19 crypto/tls/transcriptHash# implementation
+//     relationship github.com/golang/go/src go1.19 `crypto/tls`/transcriptHash# implementation
+//     relationship github.com/golang/go/src go1.19 `net/http`/ResponseWriter# implementation
 //     relationship github.com/golang/go/src go1.19 io/Writer# implementation
-//     relationship github.com/golang/go/src go1.19 net/http/ResponseWriter# implementation
   
   func (implementsWriter) Header() http.Header        { panic("Just for how") }
-//      ^^^^^^^^^^^^^^^^ reference 0.1.test sg/testdata/implementsWriter#
-//                        ^^^^^^ definition 0.1.test sg/testdata/implementsWriter#Header().
+//      ^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/implementsWriter#
+//                        ^^^^^^ definition 0.1.test `sg/testdata`/implementsWriter#Header().
 //                        documentation ```go
-//                        relationship github.com/golang/go/src go1.19 net/http/ResponseWriter#Header. implementation
-//                                 ^^^^ reference github.com/golang/go/src go1.19 net/http/
-//                                      ^^^^^^ reference github.com/golang/go/src go1.19 net/http/Header#
+//                        relationship github.com/golang/go/src go1.19 `net/http`/ResponseWriter#Header. implementation
+//                                 ^^^^ reference github.com/golang/go/src go1.19 `net/http`/
+//                                      ^^^^^^ reference github.com/golang/go/src go1.19 `net/http`/Header#
   func (implementsWriter) Write([]byte) (int, error)  { panic("Just for show") }
-//      ^^^^^^^^^^^^^^^^ reference 0.1.test sg/testdata/implementsWriter#
-//                        ^^^^^ definition 0.1.test sg/testdata/implementsWriter#Write().
+//      ^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/implementsWriter#
+//                        ^^^^^ definition 0.1.test `sg/testdata`/implementsWriter#Write().
 //                        documentation ```go
-//                        relationship github.com/golang/go/src go1.19 crypto/tls/transcriptHash#Write. implementation
+//                        relationship github.com/golang/go/src go1.19 `crypto/tls`/transcriptHash#Write. implementation
+//                        relationship github.com/golang/go/src go1.19 `net/http`/ResponseWriter#Write. implementation
 //                        relationship github.com/golang/go/src go1.19 io/Writer#Write. implementation
-//                        relationship github.com/golang/go/src go1.19 net/http/ResponseWriter#Write. implementation
   func (implementsWriter) WriteHeader(statusCode int) {}
-//      ^^^^^^^^^^^^^^^^ reference 0.1.test sg/testdata/implementsWriter#
-//                        ^^^^^^^^^^^ definition 0.1.test sg/testdata/implementsWriter#WriteHeader().
+//      ^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/implementsWriter#
+//                        ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/implementsWriter#WriteHeader().
 //                        documentation ```go
-//                        relationship github.com/golang/go/src go1.19 net/http/ResponseWriter#WriteHeader. implementation
+//                        relationship github.com/golang/go/src go1.19 `net/http`/ResponseWriter#WriteHeader. implementation
 //                                    ^^^^^^^^^^ definition local 0
   
   func ShowsInSignature(respWriter http.ResponseWriter) {
-//     ^^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/ShowsInSignature().
+//     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/ShowsInSignature().
 //     documentation ```go
 //                      ^^^^^^^^^^ definition local 1
-//                                 ^^^^ reference github.com/golang/go/src go1.19 net/http/
-//                                      ^^^^^^^^^^^^^^ reference github.com/golang/go/src go1.19 net/http/ResponseWriter#
+//                                 ^^^^ reference github.com/golang/go/src go1.19 `net/http`/
+//                                      ^^^^^^^^^^^^^^ reference github.com/golang/go/src go1.19 `net/http`/ResponseWriter#
    respWriter.WriteHeader(1)
 // ^^^^^^^^^^ reference local 1
-//            ^^^^^^^^^^^ reference github.com/golang/go/src go1.19 net/http/ResponseWriter#WriteHeader.
+//            ^^^^^^^^^^^ reference github.com/golang/go/src go1.19 `net/http`/ResponseWriter#WriteHeader.
   }
   

--- a/internal/testdata/snapshots/output/testdata/internal/secret/doc.go
+++ b/internal/testdata/snapshots/output/testdata/internal/secret/doc.go
@@ -1,5 +1,5 @@
   // secret is a package that holds secrets.
   package secret
-//        ^^^^^^ definition 0.1.test sg/testdata/internal/secret/
+//        ^^^^^^ definition 0.1.test `sg/testdata/internal/secret`/
 //        documentation secret is a package that holds secrets.
   

--- a/internal/testdata/snapshots/output/testdata/internal/secret/secret.go
+++ b/internal/testdata/snapshots/output/testdata/internal/secret/secret.go
@@ -1,20 +1,20 @@
   package secret
-//        ^^^^^^ reference 0.1.test sg/testdata/internal/secret/
+//        ^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/
   
   // SecretScore is like score but _secret_.
   const SecretScore = uint64(43)
-//      ^^^^^^^^^^^ definition 0.1.test sg/testdata/internal/secret/SecretScore.
+//      ^^^^^^^^^^^ definition 0.1.test `sg/testdata/internal/secret`/SecretScore.
 //      documentation ```go
 //      documentation SecretScore is like score but _secret_.
   
   // Original doc
   type Burger struct {
-//     ^^^^^^ definition 0.1.test sg/testdata/internal/secret/Burger#
+//     ^^^^^^ definition 0.1.test `sg/testdata/internal/secret`/Burger#
 //     documentation ```go
 //     documentation Original doc
 //     documentation ```go
    Field int
-// ^^^^^ definition 0.1.test sg/testdata/internal/secret/Burger#Field.
+// ^^^^^ definition 0.1.test `sg/testdata/internal/secret`/Burger#Field.
 // documentation ```go
   }
   

--- a/internal/testdata/snapshots/output/testdata/named_import.go
+++ b/internal/testdata/snapshots/output/testdata/named_import.go
@@ -1,20 +1,20 @@
   package testdata
-//        ^^^^^^^^ reference 0.1.test sg/testdata/
+//        ^^^^^^^^ reference 0.1.test `sg/testdata`/
   
   import (
    . "fmt"
 //    ^^^ reference github.com/golang/go/src go1.19 fmt/
    h "net/http"
 // ^ definition local 0
-//    ^^^^^^^^ reference github.com/golang/go/src go1.19 net/http/
+//    ^^^^^^^^ reference github.com/golang/go/src go1.19 `net/http`/
   )
   
   func Example() {
-//     ^^^^^^^ definition 0.1.test sg/testdata/Example().
+//     ^^^^^^^ definition 0.1.test `sg/testdata`/Example().
 //     documentation ```go
    Println(h.CanonicalHeaderKey("accept-encoding"))
 // ^^^^^^^ reference github.com/golang/go/src go1.19 fmt/Println().
 //         ^ reference local 0
-//           ^^^^^^^^^^^^^^^^^^ reference github.com/golang/go/src go1.19 net/http/CanonicalHeaderKey().
+//           ^^^^^^^^^^^^^^^^^^ reference github.com/golang/go/src go1.19 `net/http`/CanonicalHeaderKey().
   }
   

--- a/internal/testdata/snapshots/output/testdata/parallel.go
+++ b/internal/testdata/snapshots/output/testdata/parallel.go
@@ -1,5 +1,5 @@
   package testdata
-//        ^^^^^^^^ reference 0.1.test sg/testdata/
+//        ^^^^^^^^ reference 0.1.test `sg/testdata`/
   
   import (
    "context"
@@ -11,7 +11,7 @@
   // ParallelizableFunc is a function that can be called concurrently with other instances
   // of this function type.
   type ParallelizableFunc func(ctx context.Context) error
-//     ^^^^^^^^^^^^^^^^^^ definition 0.1.test sg/testdata/ParallelizableFunc#
+//     ^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/ParallelizableFunc#
 //     documentation ParallelizableFunc is a function that can be called concurrently with other instances
 //     documentation ```go
 //                             ^^^ definition local 0
@@ -21,14 +21,14 @@
   // Parallel invokes each of the given parallelizable functions in their own goroutines and
   // returns the first error to occur. This method will block until all goroutines have returned.
   func Parallel(ctx context.Context, fns ...ParallelizableFunc) error {
-//     ^^^^^^^^ definition 0.1.test sg/testdata/Parallel().
+//     ^^^^^^^^ definition 0.1.test `sg/testdata`/Parallel().
 //     documentation ```go
 //     documentation Parallel invokes each of the given parallelizable functions in their own goroutines and
 //              ^^^ definition local 1
 //                  ^^^^^^^ reference github.com/golang/go/src go1.19 context/
 //                          ^^^^^^^ reference github.com/golang/go/src go1.19 context/Context#
 //                                   ^^^ definition local 2
-//                                          ^^^^^^^^^^^^^^^^^^ reference 0.1.test sg/testdata/ParallelizableFunc#
+//                                          ^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/ParallelizableFunc#
    var wg sync.WaitGroup
 //     ^^ definition local 3
 //        ^^^^ reference github.com/golang/go/src go1.19 sync/
@@ -46,7 +46,7 @@
   
     go func(fn ParallelizableFunc) {
 //          ^^ definition local 6
-//             ^^^^^^^^^^^^^^^^^^ reference 0.1.test sg/testdata/ParallelizableFunc#
+//             ^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/ParallelizableFunc#
      errs <- fn(ctx)
 //   ^^^^ reference local 4
 //           ^^ reference local 6

--- a/internal/testdata/snapshots/output/testdata/typealias.go
+++ b/internal/testdata/snapshots/output/testdata/typealias.go
@@ -1,26 +1,26 @@
   package testdata
-//        ^^^^^^^^ reference 0.1.test sg/testdata/
+//        ^^^^^^^^ reference 0.1.test `sg/testdata`/
   
   import (
    "sg/testdata/internal/secret"
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test sg/testdata/internal/secret/
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/
   )
   
   // Type aliased doc
   type SecretBurger = secret.Burger
-//     ^^^^^^^^^^^^ definition 0.1.test sg/testdata/SecretBurger#
+//     ^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/SecretBurger#
 //     documentation ```go
 //     documentation Type aliased doc
 //     documentation ```go
-//                    ^^^^^^ reference 0.1.test sg/testdata/internal/secret/
-//                           ^^^^^^ reference 0.1.test sg/testdata/internal/secret/Burger#
+//                    ^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/
+//                           ^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/Burger#
   
   type BadBurger = struct {
-//     ^^^^^^^^^ definition 0.1.test sg/testdata/BadBurger#
+//     ^^^^^^^^^ definition 0.1.test `sg/testdata`/BadBurger#
 //     documentation ```go
 //     documentation ```go
    Field string
-// ^^^^^ definition 0.1.test sg/testdata/BadBurger#Field.
+// ^^^^^ definition 0.1.test `sg/testdata`/BadBurger#Field.
 // documentation ```go
   }
   

--- a/internal/testdata/snapshots/output/testdata/typeswitch.go
+++ b/internal/testdata/snapshots/output/testdata/typeswitch.go
@@ -1,8 +1,8 @@
   package testdata
-//        ^^^^^^^^ reference 0.1.test sg/testdata/
+//        ^^^^^^^^ reference 0.1.test `sg/testdata`/
   
   func Switch(interfaceValue interface{}) bool {
-//     ^^^^^^ definition 0.1.test sg/testdata/Switch().
+//     ^^^^^^ definition 0.1.test `sg/testdata`/Switch().
 //     documentation ```go
 //            ^^^^^^^^^^^^^^ definition local 0
    switch concreteValue := interfaceValue.(type) {


### PR DESCRIPTION
Fixes output formatting. All namespaces were unquoted previously, which was making the marshal <> unmarshal process a non-identity.