### PR TITLE
fix: Adjust channel size to not hang on error

### DIFF
--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -14,8 +14,9 @@ func Run(ch <-chan func() error) (*sync.WaitGroup, chan error, *uint64) {
 	var count uint64
 	var wg sync.WaitGroup
 
-	errCh := make(chan error)
-	for i := 0; i < runtime.GOMAXPROCS(0); i++ {
+	maxRoutines := runtime.GOMAXPROCS(0)
+	errCh := make(chan error, maxRoutines) // each goroutine returns at most one error
+	for i := 0; i < maxRoutines; i++ {
 		wg.Add(1)
 
 		go func() {


### PR DESCRIPTION
Unsized channels will block senders until a receiver arrives.
However, this error channel is meant to be a concurrent vector,
not a synchronization point.

Fixes #53