### PR TITLE
fix: Convert loading panic -> error & delete index

### DIFF
--- a/cmd/scip-go/main.go
+++ b/cmd/scip-go/main.go
@@ -207,7 +207,20 @@ func mainErr() error {
 		}
 	}
 
+	removeOutFileIfPresent := func() {
+		if fileInfo, err := os.Stat(outFile); err == nil && fileInfo.Mode().IsRegular() {
+			os.RemoveAll(outFile)
+		}
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			removeOutFileIfPresent()
+		}
+	}()
+
 	if err := index.Index(writer, options); err != nil {
+		removeOutFileIfPresent()
 		return err
 	}
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/scip-go/issues/59

With this patch, the panic example in #59 becomes

```
Loading Packages
error: during package loading: Should not be possible to have nil module for userland package: git.taservs.net/ljohnston/example2/ex git.taservs.net/ljohnston/example2/ex
```

And there is no `index.scip` file in the output.