### PR TITLE
Fix cross repo Go references when not pointing at a tagged version

### DIFF
--- a/internal/git/infer_module_version.go
+++ b/internal/git/infer_module_version.go
@@ -8,7 +8,7 @@ import (
 
 // InferModuleVersion returns the version of the module declared in the given
 // directory. This will be either the work tree commit's tag, or it will be the
-// most recent tag with a short revhash appended to it.
+// short revhash of the HEAD commit.
 func InferModuleVersion(dir string) (string, error) {
 	version, err := command.Run(dir, "git", "tag", "-l", "--points-at", "HEAD")
 	if err != nil {

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -239,6 +239,9 @@ func normalizePackage(opts *config.IndexOpts, pkg *packages.Package) *packages.P
 			pkg.Module.Version = rev
 		}
 	} else if build := semver.Build(pkg.Module.Version); build != "" {
+		// The revision can also have build metadata following a `+`. Drop that,
+		// similar to official Go tooling. (https://go.dev/ref/mod#versions)
+		// > The build metadata suffix is ignored for the purpose of comparing versions
 		pkg.Module.Version = strings.TrimSuffix(pkg.Module.Version, build)
 	}
 

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -220,11 +220,13 @@ func normalizePackage(opts *config.IndexOpts, pkg *packages.Package) *packages.P
 
 			pkg.Module.Version = "."
 		}
-	}
-
-	// Check if the module version is a pseudo-version.
-	// If it is, we will grab just the sha from it
-	if module.IsPseudoVersion(pkg.Module.Version) {
+	} else if module.IsPseudoVersion(pkg.Module.Version) {
+		// Check if the module version is a pseudo-version.
+		// If it is, we will grab just the sha from it
+		// Note: According to the go mod spec (https://go.dev/ref/mod#versions) we expect
+		// versions to always follow semantic versions (either tagged version or pseudo-version).
+		// Go tidy will ensure that the version is a valid semantic version
+		// and replace non-canonical versions with v0.0.0
 		rev, err := module.PseudoVersionRev(pkg.Module.Version)
 		if err != nil {
 			// Only panic when running in debug mode.
@@ -233,7 +235,6 @@ func normalizePackage(opts *config.IndexOpts, pkg *packages.Package) *packages.P
 				pkg.Module.Path,
 				pkg.Module.Version,
 			))
-
 		} else {
 			pkg.Module.Version = rev
 		}

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/scip-go/internal/newtypes"
 	"github.com/sourcegraph/scip-go/internal/output"
 	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/module"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -218,6 +219,23 @@ func normalizePackage(opts *config.IndexOpts, pkg *packages.Package) *packages.P
 			))
 
 			pkg.Module.Version = "."
+		}
+	}
+
+	// Check if the module version is a pseudo-version.
+	// If it is, we will grab just the sha from it
+	if module.IsPseudoVersion(pkg.Module.Version) {
+		rev, err := module.PseudoVersionRev(pkg.Module.Version)
+		if err != nil {
+			// Only panic when running in debug mode.
+			fmt.Println(handler.ErrOrPanic(
+				"Unable to find rev from pseudo-version: %s %s",
+				pkg.Module.Path,
+				pkg.Module.Version,
+			))
+
+		} else {
+			pkg.Module.Version = rev
 		}
 	}
 

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -222,7 +222,6 @@ func normalizePackage(opts *config.IndexOpts, pkg *packages.Package) *packages.P
 			pkg.Module.Version = "."
 		}
 	} else if module.IsPseudoVersion(pkg.Module.Version) {
-
 		// Unpublished versions of dependencies have pseudo-versions in go.mod.
 		// When the dependency itself is indexed, only the revision will be used.
 		// For correct cross-repo navigation to such dependencies, only use

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -238,14 +238,8 @@ func normalizePackage(opts *config.IndexOpts, pkg *packages.Package) *packages.P
 		} else {
 			pkg.Module.Version = rev
 		}
-	} else {
-		// The revision can also have build metadata following a `+`. Drop that,
-		// similar to official Go tooling. (https://go.dev/ref/mod#versions)
-		// > The build metadata suffix is ignored for the purpose of comparing versions
-		build := semver.Build(pkg.Module.Version)
-		if build != "" {
-			pkg.Module.Version = strings.TrimSuffix(pkg.Module.Version, build)
-		}
+	} else if build := semver.Build(pkg.Module.Version); build != "" {
+		pkg.Module.Version = strings.TrimSuffix(pkg.Module.Version, build)
 	}
 
 	return pkg

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -243,7 +243,9 @@ func normalizePackage(opts *config.IndexOpts, pkg *packages.Package) *packages.P
 		// similar to official Go tooling. (https://go.dev/ref/mod#versions)
 		// > The build metadata suffix is ignored for the purpose of comparing versions
 		build := semver.Build(pkg.Module.Version)
-		pkg.Module.Version = strings.TrimSuffix(pkg.Module.Version, build)
+		if build != "" {
+			pkg.Module.Version = strings.TrimSuffix(pkg.Module.Version, build)
+		}
 	}
 
 	return pkg

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -40,7 +40,63 @@ func TestBuiltinFormat(t *testing.T) {
 	}
 }
 
-func TestPseudoVersion(t *testing.T) {
+type normalizeTestCase struct {
+	Raw        string
+	Normalized string
+}
+
+func TestNormalizePackageModuleVersion(t *testing.T) {
+	cases := []normalizeTestCase{
+		{
+			Raw:        "v0.0.0-20180920160851-f15b22f93c73",
+			Normalized: "f15b22f93c73",
+		},
+		{
+			Raw:        "v0.3.1-0.20230414160720-beea233bdc0b",
+			Normalized: "beea233bdc0b",
+		},
+		{
+			Raw:        "v2.0.0-20180818164646-67afb5ed74ec",
+			Normalized: "67afb5ed74ec",
+		},
+		{
+			Raw:        "v1.1.1",
+			Normalized: "v1.1.1",
+		},
+		{
+			Raw:        "v1.0.0-beta.1",
+			Normalized: "v1.0.0-beta.1",
+		},
+		{
+			Raw:        "v0.0.0",
+			Normalized: "v0.0.0",
+		},
+		{
+			Raw:        "v2.0.0+incompatible",
+			Normalized: "v2.0.0+incompatible",
+		},
+		{
+			Raw:        "",
+			Normalized: ".",
+		},
+	}
+
+	for _, testCase := range cases {
+		pkg := &packages.Package{
+			PkgPath: "github.com/fake_name/fake_module/fake_package",
+			Module: &packages.Module{
+				Path:    "github.com/fake_name/fake_module",
+				Version: testCase.Raw,
+			},
+		}
+		normalizePackage(&config.IndexOpts{}, pkg)
+		if pkg.Module.Version != testCase.Normalized {
+			t.Errorf("Got: %s, Expected: %s", pkg.Module.Version, testCase.Normalized)
+		}
+	}
+}
+
+func TestPackagePseudoVersion(t *testing.T) {
 	wd, _ := os.Getwd()
 	root, _ := filepath.Abs(filepath.Join(wd, "../../"))
 	pkgConfig := getConfig(root, config.IndexOpts{})

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -74,7 +74,7 @@ func TestNormalizePackageModuleVersion(t *testing.T) {
 		},
 		{
 			Raw:        "v2.0.0+incompatible",
-			Normalized: "v2.0.0+incompatible",
+			Normalized: "v2.0.0",
 		},
 		{
 			Raw:        "",

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/scip-go/internal/config"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/mod/module"
 	"golang.org/x/tools/go/packages"
 )
@@ -90,9 +91,8 @@ func TestNormalizePackageModuleVersion(t *testing.T) {
 			},
 		}
 		normalizePackage(&config.IndexOpts{}, pkg)
-		if pkg.Module.Version != testCase.Normalized {
-			t.Errorf("Got: %s, Expected: %s", pkg.Module.Version, testCase.Normalized)
-		}
+
+		require.Equal(t, testCase.Normalized, pkg.Module.Version)
 	}
 }
 
@@ -103,25 +103,17 @@ func TestPackagePseudoVersion(t *testing.T) {
 	pkgConfig.Tests = false
 
 	pkgs, err := packages.Load(pkgConfig, "github.com/efritz/pentimento")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 
-	if len(pkgs) != 1 {
-		t.Fatalf("Too many packages: %s", pkgs)
-	}
+	require.Equal(t, 1, len(pkgs), "Too many packages")
 
 	pkg := pkgs[0]
 
-	if !module.IsPseudoVersion(pkg.Module.Version) {
-		t.Fatal("Package did not have a pseudo version: pre ensure")
-	}
+	require.True(t, module.IsPseudoVersion(pkg.Module.Version), "Package did not have a pseudo version: pre ensure")
 
 	normalizePackage(&config.IndexOpts{}, pkg)
 
-	if pkg.Module.Version != "ade47d831101" {
-		t.Fatal("Package pseudo-version was not extracted into a sha: post ensure")
-	}
+	require.Equal(t, "ade47d831101", pkg.Module.Version, "Package pseudo-version was not extracted into a sha: post ensure")
 }
 
 func TestPackageWithinModule(t *testing.T) {

--- a/internal/testdata/snapshots/output/generallyeric/new_operators.go
+++ b/internal/testdata/snapshots/output/generallyeric/new_operators.go
@@ -2,19 +2,19 @@
 //        ^^^^^^^^^^^^^ reference 0.1.test `sg/generallyeric`/
   
   import "golang.org/x/exp/constraints"
-//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db `golang.org/x/exp/constraints`/
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference golang.org/x/exp 47842c84f3db `golang.org/x/exp/constraints`/
   
   type Number interface {
 //     ^^^^^^ definition 0.1.test `sg/generallyeric`/Number#
 //     documentation ```go
 //     documentation ```go
    constraints.Float | constraints.Integer | constraints.Complex
-// ^^^^^^^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db `golang.org/x/exp/constraints`/
-//             ^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db `golang.org/x/exp/constraints`/Float#
-//                     ^^^^^^^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db `golang.org/x/exp/constraints`/
-//                                 ^^^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db `golang.org/x/exp/constraints`/Integer#
-//                                           ^^^^^^^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db `golang.org/x/exp/constraints`/
-//                                                       ^^^^^^^ reference golang.org/x/exp v0.0.0-20221205204356-47842c84f3db `golang.org/x/exp/constraints`/Complex#
+// ^^^^^^^^^^^ reference golang.org/x/exp 47842c84f3db `golang.org/x/exp/constraints`/
+//             ^^^^^ reference golang.org/x/exp 47842c84f3db `golang.org/x/exp/constraints`/Float#
+//                     ^^^^^^^^^^^ reference golang.org/x/exp 47842c84f3db `golang.org/x/exp/constraints`/
+//                                 ^^^^^^^ reference golang.org/x/exp 47842c84f3db `golang.org/x/exp/constraints`/Integer#
+//                                           ^^^^^^^^^^^ reference golang.org/x/exp 47842c84f3db `golang.org/x/exp/constraints`/
+//                                                       ^^^^^^^ reference golang.org/x/exp 47842c84f3db `golang.org/x/exp/constraints`/Complex#
   }
   
   func Double[T Number](value T) T {

--- a/internal/testdata/snapshots/output/replace-directives/replace_directives.go
+++ b/internal/testdata/snapshots/output/replace-directives/replace_directives.go
@@ -7,7 +7,7 @@
 //  ^^^ reference github.com/golang/go/src go1.22 fmt/
   
    "github.com/dghubble/gologin"
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8 `github.com/dghubble/gologin`/
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference github.com/sourcegraph/gologin c6f1b62954d8 `github.com/dghubble/gologin`/
   )
   
   func Something() {
@@ -16,7 +16,7 @@
    fmt.Println(gologin.DefaultCookieConfig)
 // ^^^ reference github.com/golang/go/src go1.22 fmt/
 //     ^^^^^^^ reference github.com/golang/go/src go1.22 fmt/Println().
-//             ^^^^^^^ reference github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8 `github.com/dghubble/gologin`/
-//                     ^^^^^^^^^^^^^^^^^^^ reference github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8 `github.com/dghubble/gologin`/DefaultCookieConfig.
+//             ^^^^^^^ reference github.com/sourcegraph/gologin c6f1b62954d8 `github.com/dghubble/gologin`/
+//                     ^^^^^^^^^^^^^^^^^^^ reference github.com/sourcegraph/gologin c6f1b62954d8 `github.com/dghubble/gologin`/DefaultCookieConfig.
   }
   


### PR DESCRIPTION
Fixes GRAPH-129

This PR resolves a mismatch with how scip-go would generate the version string when not pointing at a tagged module version string. This mismatch would break cross-repo references. 

# Background
When indexing a repo who's head commit was not tagged, scip-go sets the version as the first 12 characters of the HEAD commit sha. However, when referencing a module at that same non-tagged commit, scip-go would just set the version to the pseudo-version string.  

To fix this, we will consistently use the sha1 when pointing at a non-tagged commit. If you point at a tagged commit (e.g. v1.2.3) then we do not change anything and still just use the proper version string. 



# Result
Below are the generated version strings when pointing at the latest commit on github.com/sourcegraph/conc


**Definition**
```
definition scip-go gomod github.com/sourcegraph/conc 5f936abd7ae8 `github.com/sourcegraph/conc/pool`/NewWithResults().
```

**Reference**
```
reference scip-go gomod github.com/sourcegraph/conc 5f936abd7ae8 `github.com/sourcegraph/conc/pool`/NewWithResults().
```