### PR TITLE
fix: Work around Go bug 68877 until Go 1.23.1 is released

### DIFF
--- a/internal/index/scip.go
+++ b/internal/index/scip.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"fmt"
 	"go/ast"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -87,6 +88,12 @@ func ListMissing(opts config.IndexOpts) (missing []string, err error) {
 }
 
 func Index(writer func(proto.Message), opts config.IndexOpts) error {
+	if os.Getenv("GODEBUG") == "" {
+		// TODO: Remove this after upgrading to Go 1.23.1
+		// See https://github.com/golang/go/issues/68894
+		os.Setenv("GODEBUG", "gotypesalias=0")
+	}
+
 	// Emit Metadata.
 	//   NOTE: Must be the first field emitted
 	writer(&scip.Metadata{

--- a/internal/testdata/snapshots/input/alias/main.go
+++ b/internal/testdata/snapshots/input/alias/main.go
@@ -1,0 +1,9 @@
+package main
+
+// Check that we don't panic
+// Copied from https://github.com/golang/go/issues/68877#issuecomment-2290000187
+type (
+	T struct{}
+	U = T
+	S U
+)

--- a/internal/testdata/snapshots/output/alias/main.go
+++ b/internal/testdata/snapshots/output/alias/main.go
@@ -1,0 +1,51 @@
+  package main
+//        ^^^^ definition github.com/sourcegraph/scip-go . `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/
+//        documentation
+//        > package main
+  
+  // Check that we don't panic
+  // Copied from https://github.com/golang/go/issues/68877#issuecomment-2290000187
+  type (
+   T struct{}
+// ^ definition github.com/sourcegraph/scip-go . `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/T#
+// documentation
+// > ```go
+// > type T struct
+// > ```
+// documentation
+// > Check that we don't panic
+// > Copied from https://github.com/golang/go/issues/68877#issuecomment-2290000187
+// documentation
+// > ```go
+// > struct{}
+// > ```
+   U = T
+// ^ definition github.com/sourcegraph/scip-go . `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/U#
+// documentation
+// > ```go
+// > type U = T
+// > ```
+// documentation
+// > Check that we don't panic
+// > Copied from https://github.com/golang/go/issues/68877#issuecomment-2290000187
+// documentation
+// > ```go
+// > struct{}
+// > ```
+//     ^ reference github.com/sourcegraph/scip-go . `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/T#
+   S U
+// ^ definition github.com/sourcegraph/scip-go . `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/S#
+// documentation
+// > ```go
+// > type S struct
+// > ```
+// documentation
+// > Check that we don't panic
+// > Copied from https://github.com/golang/go/issues/68877#issuecomment-2290000187
+// documentation
+// > ```go
+// > struct{}
+// > ```
+//   ^ reference github.com/sourcegraph/scip-go . `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/U#
+  )
+  

--- a/internal/testdata/snapshots/output/testdata/data.go
+++ b/internal/testdata/snapshots/output/testdata/data.go
@@ -244,7 +244,7 @@
 //     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestEqualsStruct#
 //     documentation
 //     > ```go
-//     > type TestEqualsStruct struct
+//     > type TestEqualsStruct = struct
 //     > ```
 //     documentation
 //     > ```go

--- a/internal/testdata/snapshots/output/testdata/implementations.go
+++ b/internal/testdata/snapshots/output/testdata/implementations.go
@@ -69,6 +69,8 @@
 //            > func (T1).F1()
 //            > ```
 //            relationship 0.1.test `sg/testdata`/I1#F1. implementation
+//            relationship 0.1.test `sg/testdata`/I1#F1. implementation
+//            relationship 0.1.test `sg/testdata`/I1#F1. implementation
   
   type T2 int
 //     ^^ definition 0.1.test `sg/testdata`/T2#
@@ -104,6 +106,7 @@
 //     > ```go
 //     > int
 //     > ```
+//     relationship 0.1.test `sg/testdata`/I1# implementation
 //          ^^ reference 0.1.test `sg/testdata`/T1#
   type A12 = A1
 //     ^^^ definition 0.1.test `sg/testdata`/A12#
@@ -111,6 +114,7 @@
 //     > ```go
 //     > int
 //     > ```
+//     relationship 0.1.test `sg/testdata`/I1# implementation
 //           ^^ reference 0.1.test `sg/testdata`/A1#
   
   type InterfaceWithNonExportedMethod interface {

--- a/internal/testdata/snapshots/output/testdata/typealias.go
+++ b/internal/testdata/snapshots/output/testdata/typealias.go
@@ -11,7 +11,7 @@
 //     ^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/SecretBurger#
 //     documentation
 //     > ```go
-//     > type SecretBurger struct
+//     > type SecretBurger = secret.Burger
 //     > ```
 //     documentation
 //     > Type aliased doc
@@ -28,7 +28,7 @@
 //     ^^^^^^^^^ definition 0.1.test `sg/testdata`/BadBurger#
 //     documentation
 //     > ```go
-//     > type BadBurger struct
+//     > type BadBurger = struct
 //     > ```
 //     documentation
 //     > ```go


### PR DESCRIPTION
Adds a regression test and workaround using GODEBUG=gotypesalias=0
if that is not set by the caller.

See https://github.com/golang/go/issues/68877 for context

Fixes https://github.com/sourcegraph/scip-go/issues/119