### PR TITLE
feat: Add --auto-index flag and fetch tags if missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ RUN go build -o scip-go ./cmd/scip-go
 FROM golang:1.23.0@sha256:${base_sha} as final
 
 COPY --from=builder /sources/scip-go /usr/bin/
-CMD ["scip-go"]
+CMD ["scip-go", "--auto-index"]

--- a/cmd/scip-go/e2e_test.go
+++ b/cmd/scip-go/e2e_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/sourcegraph/scip-go/internal/command"
+	"github.com/stretchr/testify/require"
+)
+
+var scipGoPath = ""
+
+func TestMain(m *testing.M) {
+	tempDir := os.TempDir()
+	scipGoPath = path.Join(tempDir, "scip-go")
+	_, err := command.Run(".", "go", "build", "-o", scipGoPath, ".")
+	if err != nil {
+		panic(fmt.Sprintf("failed to build scip-go: %s", err.Error()))
+	}
+	os.Exit(m.Run())
+}
+
+func TestAutoIndexFlagFetchesTags(t *testing.T) {
+	tempDir := os.TempDir()
+	concDir := path.Join(tempDir, "conc")
+	t.Cleanup(func() { os.RemoveAll(concDir) })
+	_, err := command.Run(".", "git", "clone", "--depth=1", "--no-tags", "https://github.com/sourcegraph/conc", concDir)
+	require.NoError(t, err)
+	tagsDir := path.Join(concDir, ".git", "refs", "tags")
+	_, err = os.Stat(path.Join(tagsDir, "v0.3.0"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	outErr, err := command.Run(concDir, scipGoPath, "--auto-index")
+	require.NoError(t, err, outErr)
+	dirEntries, err := os.ReadDir(tagsDir)
+	require.NoError(t, err)
+	tagNames := map[string]struct{}{}
+	for _, dirEntry := range dirEntries {
+		tagNames[dirEntry.Name()] = struct{}{}
+	}
+	require.Contains(t, tagNames, "v0.1.0")
+	require.Contains(t, tagNames, "v0.2.0")
+	require.Contains(t, tagNames, "v0.3.0")
+}

--- a/internal/git/fetch_tags.go
+++ b/internal/git/fetch_tags.go
@@ -1,0 +1,44 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/charmbracelet/log"
+	"github.com/sourcegraph/scip-go/internal/command"
+)
+
+// FetchTagsIfMissing attempts to fetch all tags for a git repository,
+// since we rely on git tags (similar to other Go tooling) to determine
+// the module version number (see infer_module_version.go).
+//
+// Since this can change on-disk repository state, this operation should
+// only be invoked during auto-indexing.
+func FetchTagsIfMissing(dir string) error {
+	tagsDir := path.Join(dir, ".git", "refs", "tags")
+	stat, err := os.Stat(tagsDir)
+	dirExists := err == nil && stat.IsDir()
+	if dirExists {
+		tags, err := os.ReadDir(tagsDir)
+		if err != nil {
+			return err
+		}
+		if len(tags) > 0 {
+			return nil // tags already exist, don't fetch more
+		}
+	}
+	// In an auto-indexing context, the remote is called origin.
+	// See https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/executor/internal/worker/workspace/clone.go?L31:1-31:15
+	out, err := command.Run(dir, "git", "fetch", "origin", "refs/tags/*:refs/tags/*")
+	if strings.Count(out, "new tag") == 0 {
+		out, err := command.Run(dir, "git", "rev-parse", "--abbrev-ref", "HEAD")
+		commitInfo := ""
+		if err == nil {
+			commitInfo = fmt.Sprintf(" (commit: %s)", strings.TrimSpace(out))
+		}
+		log.Warn("Found 0 tags, cross-repo navigation may not work correctly%s", commitInfo)
+	}
+	return err
+}


### PR DESCRIPTION
In an auto-indexing context, by default, git tags are
not available since fetching them can increase time taken.
However, scip-go needs tags to determine version numbers.

Fixes https://linear.app/sourcegraph/issue/GRAPH-847