### PR TITLE
chore: Standardize logging logic & add more lines

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -15,9 +15,3 @@ func ErrOrPanic(format string, a ...any) error {
 
 	return fmt.Errorf(format, a...)
 }
-
-func Println(a ...any) {
-	if devMode {
-		fmt.Println(a...)
-	}
-}

--- a/internal/implementations/implementations.go
+++ b/internal/implementations/implementations.go
@@ -6,6 +6,7 @@ import (
 	"go/types"
 	"strings"
 
+	"github.com/charmbracelet/log"
 	"github.com/sourcegraph/scip-go/internal/handler"
 	"github.com/sourcegraph/scip-go/internal/loader"
 	"github.com/sourcegraph/scip-go/internal/lookup"
@@ -78,7 +79,7 @@ func findImplementations(concreteTypes map[string]ImplDef, interfaces map[string
 		for _, impl := range tyImpls {
 			implDef, ok := interfaces[impl.Symbol]
 			if !ok {
-				fmt.Println(fmt.Sprintf("Could not find interface %s", impl.Symbol))
+				log.Error("Could not find interface", "symbol", impl.Symbol)
 				continue
 			}
 
@@ -88,7 +89,7 @@ func findImplementations(concreteTypes map[string]ImplDef, interfaces map[string
 				IsImplementation: true,
 			})
 
-			// For all methods, add imlementation details as well
+			// For all methods, add implementation details as well
 			for name, implMethod := range implDef.Methods {
 				tyMethodInfo, ok := ty.Methods[name]
 				if !ok {
@@ -173,7 +174,7 @@ func extractInterfacesAndConcreteTypes(pkgs loader.PackageLookup, symbols *looku
 
 		pkgSymbols := symbols.GetPackage(pkg)
 		if pkgSymbols == nil {
-			fmt.Println("No symbols for package:", pkg.Name)
+			log.Warn("No symbols for package", "path", pkg.PkgPath)
 			continue
 		}
 
@@ -199,7 +200,9 @@ func extractInterfacesAndConcreteTypes(pkgs loader.PackageLookup, symbols *looku
 			symbol, ok := pkgSymbols.Get(obj.Pos())
 			if !ok {
 				if obj.Exported() {
-					handler.Println("No symbol for:", ident.Name, obj.Pkg(), obj.Id())
+					// TODO: Look into whether this is a bug or not
+					// https://linear.app/sourcegraph/issue/GRAPH-852
+					// log.Debug("No symbol for:", "identifier", ident.Name, "package", obj.Pkg(), "id", obj.Id())
 				}
 
 				continue

--- a/internal/index/package_ident.go
+++ b/internal/index/package_ident.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/agnivade/levenshtein"
-	"github.com/sourcegraph/scip-go/internal/handler"
+	"github.com/charmbracelet/log"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -22,7 +22,7 @@ func findBestPackageDefinitionPath(pkg *packages.Package) (*ast.File, error) {
 	}
 
 	if len(pkg.Syntax) == 0 {
-		handler.Println("Missing |", pkg.ID, pkg.Module.Path)
+		log.Warn("package does not contain any ASTs", "path", pkg.PkgPath)
 		return nil, nil
 	}
 

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/charmbracelet/log"
 	"github.com/sourcegraph/scip-go/internal/config"
 	"github.com/sourcegraph/scip-go/internal/handler"
 	"github.com/sourcegraph/scip-go/internal/newtypes"
@@ -213,7 +214,7 @@ func normalizePackage(opts *config.IndexOpts, pkg *packages.Package) *packages.P
 			pkg.Module.Version = opts.ModuleVersion
 		} else {
 			// Only panic when running in debug mode.
-			fmt.Println(handler.ErrOrPanic(
+			log.Error(handler.ErrOrPanic(
 				"Unknown version for userland package: %s %s",
 				pkg.Module.Path,
 				opts.ModulePath,
@@ -229,7 +230,7 @@ func normalizePackage(opts *config.IndexOpts, pkg *packages.Package) *packages.P
 		rev, err := module.PseudoVersionRev(pkg.Module.Version)
 		if err != nil {
 			// Only panic when running in debug mode.
-			fmt.Println(handler.ErrOrPanic(
+			log.Error(handler.ErrOrPanic(
 				"Unable to find rev from pseudo-version: %s %s",
 				pkg.Module.Path,
 				pkg.Module.Version,

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -144,14 +144,18 @@ func printProgress(printer *pentimento.Printer, name string, c *uint64, n uint64
 }
 
 func SetOutputOptions(verb Verbosity, animation bool) {
+	switch verb {
+	case NoOutput:
+		log.SetLevel(log.FatalLevel)
+	case DefaultOutput:
+		log.SetLevel(log.WarnLevel)
+	case VerboseOutput:
+		log.SetLevel(log.InfoLevel)
+	case VeryVerboseOutput, VeryVeryVerboseOutput:
+		log.SetLevel(log.DebugLevel)
+	}
 	opts.Verbosity = verb
 	opts.ShowAnimations = animation
-}
-
-func Println(a ...any) {
-	if opts.Verbosity != NoOutput {
-		fmt.Println(a...)
-	}
 }
 
 func Logf(format string, a ...any) {

--- a/internal/visitors/visitor_file.go
+++ b/internal/visitors/visitor_file.go
@@ -7,6 +7,7 @@ import (
 	"go/types"
 	"strings"
 
+	"github.com/charmbracelet/log"
 	"github.com/sourcegraph/scip-go/internal/document"
 	"github.com/sourcegraph/scip-go/internal/handler"
 	"github.com/sourcegraph/scip-go/internal/loader"
@@ -119,7 +120,7 @@ func (v *fileVisitor) Visit(n ast.Node) ast.Visitor {
 		// Generate import references
 		importedPackage := v.pkg.Imports[strings.Trim(node.Path.Value, `"`)]
 		if importedPackage == nil {
-			fmt.Println("Could not find: ", node.Path)
+			log.Warn("Could not find node", "node.Path", node.Path)
 			return nil
 		}
 


### PR DESCRIPTION
- Removes helper `Println` functions, standardizing on logging library.
- Cleans up formatting of default logger output
- Improved some error messages for clarity
- Added debug logging for files being visited, to help investigate a hang
   when indexing the Sourcegraph monorepo