### PR TITLE
fix: Index all test code in the current module

### DIFF
--- a/internal/testdata/snapshots/input/testspecial/foo.go
+++ b/internal/testdata/snapshots/input/testspecial/foo.go
@@ -1,0 +1,3 @@
+package testspecial
+
+func Foo() {}

--- a/internal/testdata/snapshots/input/testspecial/foo_other_test.go
+++ b/internal/testdata/snapshots/input/testspecial/foo_other_test.go
@@ -1,0 +1,9 @@
+package testspecial_test
+
+import (
+	"testing"
+
+	"sg/testspecial"
+)
+
+func TestFoo_Blackbox(*testing.T) { testspecial.Foo() }

--- a/internal/testdata/snapshots/input/testspecial/foo_test.go
+++ b/internal/testdata/snapshots/input/testspecial/foo_test.go
@@ -1,0 +1,3 @@
+package testspecial
+
+func TestFoo_Whitebox() { Foo() }

--- a/internal/testdata/snapshots/input/testspecial/go.mod
+++ b/internal/testdata/snapshots/input/testspecial/go.mod
@@ -1,0 +1,3 @@
+module sg/testspecial
+
+go 1.19

--- a/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/cleanup_test.go
+++ b/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/cleanup_test.go
@@ -1,0 +1,27 @@
+  package server
+//        ^^^^^^ reference 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/
+  
+  import "testing"
+//        ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
+  
+  func TestStuff(t *testing.T) {
+//     ^^^^^^^^^ definition 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/TestStuff().
+//     documentation
+//     > ```go
+//     > func TestStuff(t *T)
+//     > ```
+//               ^ definition local 0
+//                  ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
+//                          ^ reference github.com/golang/go/src go1.22 testing/T#
+   wd := "hello"
+// ^^ definition local 1
+   repo := "world"
+// ^^^^ definition local 2
+  
+   runCmd(t, wd, "git", "init", repo)
+// ^^^^^^ reference 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/runCmd().
+//        ^ reference local 0
+//           ^^ reference local 1
+//                              ^^^^ reference local 2
+  }
+  

--- a/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/server_test.go
+++ b/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/server_test.go
@@ -1,0 +1,33 @@
+  package server
+//        ^^^^^^ reference 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/
+  
+  import "testing"
+//        ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
+  
+  func TestExecRequest(t *testing.T) {
+//     ^^^^^^^^^^^^^^^ definition 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/TestExecRequest().
+//     documentation
+//     > ```go
+//     > func TestExecRequest(t *T)
+//     > ```
+//                     ^ definition local 0
+//                        ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
+//                                ^ reference github.com/golang/go/src go1.22 testing/T#
+   t.Log("hello world")
+// ^ reference local 0
+//   ^^^ reference github.com/golang/go/src go1.22 testing/common#Log().
+  }
+  
+  func runCmd(t *testing.T, dir string, cmd string, arg ...string) {}
+//     ^^^^^^ definition 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/runCmd().
+//     documentation
+//     > ```go
+//     > func runCmd(t *T, dir string, cmd string, arg ...string)
+//     > ```
+//            ^ definition local 1
+//               ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
+//                       ^ reference github.com/golang/go/src go1.22 testing/T#
+//                          ^^^ definition local 2
+//                                      ^^^ definition local 3
+//                                                  ^^^ definition local 4
+  

--- a/internal/testdata/snapshots/output/testdata/conflicting_test_symbols/sandbox_unsupported_test.go
+++ b/internal/testdata/snapshots/output/testdata/conflicting_test_symbols/sandbox_unsupported_test.go
@@ -1,0 +1,50 @@
+  //go:build !linux && !windows && !freebsd
+  // +build !linux,!windows,!freebsd
+  
+  package osl
+//        ^^^ definition 0.1.test `sg/testdata/conflicting_test_symbols`/
+//        documentation
+//        > package osl
+  
+  import (
+   "errors"
+//  ^^^^^^ reference github.com/golang/go/src go1.22 errors/
+   "testing"
+//  ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
+  )
+  
+  var ErrNotImplemented = errors.New("not implemented")
+//    ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata/conflicting_test_symbols`/ErrNotImplemented.
+//    documentation
+//    > ```go
+//    > var ErrNotImplemented error
+//    > ```
+//                        ^^^^^^ reference github.com/golang/go/src go1.22 errors/
+//                               ^^^ reference github.com/golang/go/src go1.22 errors/New().
+  
+  func newKey(t *testing.T) (string, error) {
+//     ^^^^^^ definition 0.1.test `sg/testdata/conflicting_test_symbols`/newKey().
+//     documentation
+//     > ```go
+//     > func newKey(t *T) (string, error)
+//     > ```
+//            ^ definition local 0
+//               ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
+//                       ^ reference github.com/golang/go/src go1.22 testing/T#
+   return "", ErrNotImplemented
+//            ^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata/conflicting_test_symbols`/ErrNotImplemented.
+  }
+  
+  func verifySandbox(t *testing.T, s string) {
+//     ^^^^^^^^^^^^^ definition 0.1.test `sg/testdata/conflicting_test_symbols`/verifySandbox().
+//     documentation
+//     > ```go
+//     > func verifySandbox(t *T, s string)
+//     > ```
+//                   ^ definition local 1
+//                      ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
+//                              ^ reference github.com/golang/go/src go1.22 testing/T#
+//                                 ^ definition local 2
+   return
+  }
+  

--- a/internal/testdata/snapshots/output/testspecial/foo.go
+++ b/internal/testdata/snapshots/output/testspecial/foo.go
@@ -1,0 +1,12 @@
+  package testspecial
+//        ^^^^^^^^^^^ definition 0.1.test `sg/testspecial`/
+//        documentation
+//        > package testspecial
+  
+  func Foo() {}
+//     ^^^ definition 0.1.test `sg/testspecial`/Foo().
+//     documentation
+//     > ```go
+//     > func Foo()
+//     > ```
+  

--- a/internal/testdata/snapshots/output/testspecial/foo_other_test.go
+++ b/internal/testdata/snapshots/output/testspecial/foo_other_test.go
@@ -1,0 +1,24 @@
+  package testspecial_test
+//        ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testspecial_test`/
+//        documentation
+//        > package testspecial_test
+  
+  import (
+   "testing"
+//  ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
+  
+   "sg/testspecial"
+//  ^^^^^^^^^^^^^^ reference 0.1.test `sg/testspecial`/
+  )
+  
+  func TestFoo_Blackbox(*testing.T) { testspecial.Foo() }
+//     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testspecial_test`/TestFoo_Blackbox().
+//     documentation
+//     > ```go
+//     > func TestFoo_Blackbox(*T)
+//     > ```
+//                       ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
+//                               ^ reference github.com/golang/go/src go1.22 testing/T#
+//                                    ^^^^^^^^^^^ reference 0.1.test `sg/testspecial`/
+//                                                ^^^ reference 0.1.test `sg/testspecial`/Foo().
+  

--- a/internal/testdata/snapshots/output/testspecial/foo_test.go
+++ b/internal/testdata/snapshots/output/testspecial/foo_test.go
@@ -1,0 +1,11 @@
+  package testspecial
+//        ^^^^^^^^^^^ reference 0.1.test `sg/testspecial`/
+  
+  func TestFoo_Whitebox() { Foo() }
+//     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testspecial`/TestFoo_Whitebox().
+//     documentation
+//     > ```go
+//     > func TestFoo_Whitebox()
+//     > ```
+//                          ^^^ reference 0.1.test `sg/testspecial`/Foo().
+  


### PR DESCRIPTION
The fix is basically a one-liner; most of the diff is because of
snapshot changes. Fixes https://linear.app/sourcegraph/issue/GRAPH-866

With this patch, the scip-go index size for the Sourcegraph monorepo grows
from 4012 documents (144MB uncompressed) to 5422 documents (208MB).