### PR TITLE
Don't panic on missing pkg.Module when GOPACKAGESDRIVER set

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ scip-go --version
 
 ## Indexing a Go project
 
+### Standard `go.mod` project
+
 From the root of your project, you can run:
 
 ```
@@ -39,6 +41,18 @@ If this doesn't solve the problem, check the rest of the available flags in:
 scip-go --help
 ```
 
+### Other build systems
+
+The other build systems Buck/Bazel/Please/etc are supported via [Go Packages Driver Protocol](https://pkg.go.dev/golang.org/x/tools/go/packages#hdr-The_driver_protocol).
+
+
+Usage:
+```
+GOPACKAGESDRIVER=your_driver scip-go
+```
+
+Note: Due to the current protocol design cross-repo navigation will not work.
+
 ### Common Problems:
 
 - Unable to navigate to Go standard library.
@@ -54,7 +68,7 @@ scip-go --help
 
 `scip-go` by default uses a few different `go` commands from the command line to
 gain information about the project and module. To avoid running `go` directly
-(perhaps you have some other build system), you will need to supply the folling args.
+(perhaps you have some other build system), you will need to supply the following args.
 
 ```
 scip-go --module-name="<my modules name here>"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,9 @@
 package config
 
-import "path/filepath"
+import (
+	"os"
+	"path/filepath"
+)
 
 type IndexOpts struct {
 	ModuleRoot    string
@@ -8,6 +11,8 @@ type IndexOpts struct {
 
 	// Path for the current module we are indexing. Same as packages.Package.Module.Path
 	ModulePath string
+
+	IsGoPackagesDriverSet bool
 
 	// Go version. Used for linking to the Go standard library
 	GoStdlibVersion string
@@ -28,14 +33,18 @@ func New(ModuleRoot, ModuleVersion, ModulePath, GoStdlibVersion string, IsIndexi
 		panic(err)
 	}
 
+	driver := os.Getenv("GOPACKAGESDRIVER")
+	isGoPackagesDriverSet := driver != "" && driver != "off"
+
 	return IndexOpts{
-		ModuleRoot:          ModuleRoot,
-		ModuleVersion:       ModuleVersion,
-		ModulePath:          ModulePath,
-		GoStdlibVersion:     GoStdlibVersion,
-		SkipImplementations: SkipImplementations,
-		SkipTests:           SkipTests,
-		IsIndexingStdlib:    IsIndexingStdlib,
-		PackagePatterns:     PackagePatterns,
+		ModuleRoot:            ModuleRoot,
+		ModuleVersion:         ModuleVersion,
+		ModulePath:            ModulePath,
+		GoStdlibVersion:       GoStdlibVersion,
+		SkipImplementations:   SkipImplementations,
+		SkipTests:             SkipTests,
+		IsIndexingStdlib:      IsIndexingStdlib,
+		PackagePatterns:       PackagePatterns,
+		IsGoPackagesDriverSet: isGoPackagesDriverSet,
 	}
 }


### PR DESCRIPTION
`GOPACKAGESDRIVER`'s [JSON doesn't provide `Module` field](https://github.com/golang/tools/blob/v0.26.0/go/packages/packages.go#L609C2-L627C2).
 I've changed panic to an error message to enable usage of `scip-go` with third-party build-systems like Buck2 or Bazel.

Related: #3 