### PR TITLE
Parse package patterns args

### DIFF
--- a/cmd/scip-go/main.go
+++ b/cmd/scip-go/main.go
@@ -53,6 +53,9 @@ var (
 
 	// Debugging flag to turn on profiling
 	profileRate int
+
+	// Package patterns to index
+	packagePatterns []string
 )
 
 func init() {
@@ -86,6 +89,8 @@ func init() {
 	app.Flag("command", "Optionally specifies a command to run. Defaults to 'index'").Default("index").StringVar(&scipCommand)
 
 	app.Flag("profile", "Turn on debug profiling. This will reduce performance. Do not turn on unless debugging. Set to number of milliseconds per sample").Default("0").IntVar(&profileRate)
+
+	app.Arg("package-patterns", "Package patterns to index. Default: './...' which indexes all packages in the current directory recursively. For the full syntax of allowed package patterns, see https://pkg.go.dev/cmd/go#hdr-Package_lists_and_patterns").Default("./...").StringsVar(&packagePatterns)
 }
 
 func main() {
@@ -135,7 +140,7 @@ func mainErr() error {
 		log.Info("Skipping tests")
 	}
 
-	options := config.New(moduleRoot, moduleVersion, modulePath, goVersion, isStdLib, skipImplementations, skipTests)
+	options := config.New(moduleRoot, moduleVersion, modulePath, goVersion, isStdLib, skipImplementations, skipTests, packagePatterns)
 
 	if strings.HasPrefix(scipCommand, "list-packages") {
 		var filter string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,9 +17,12 @@ type IndexOpts struct {
 	SkipTests           bool
 
 	IsIndexingStdlib bool
+
+	// Package patterns to index
+	PackagePatterns []string
 }
 
-func New(ModuleRoot, ModuleVersion, ModulePath, GoStdlibVersion string, IsIndexingStdlib bool, SkipImplementations bool, SkipTests bool) IndexOpts {
+func New(ModuleRoot, ModuleVersion, ModulePath, GoStdlibVersion string, IsIndexingStdlib bool, SkipImplementations bool, SkipTests bool, PackagePatterns []string) IndexOpts {
 	ModuleRoot, err := filepath.Abs(ModuleRoot)
 	if err != nil {
 		panic(err)
@@ -33,5 +36,6 @@ func New(ModuleRoot, ModuleVersion, ModulePath, GoStdlibVersion string, IsIndexi
 		SkipImplementations: SkipImplementations,
 		SkipTests:           SkipTests,
 		IsIndexingStdlib:    IsIndexingStdlib,
+		PackagePatterns:     PackagePatterns,
 	}
 }

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -104,7 +104,12 @@ func LoadPackages(
 		}()
 
 		cfg := getConfig(moduleRoot, opts)
-		pkgs, err := packages.Load(cfg, "./...")
+		patterns := opts.PackagePatterns
+		if len(patterns) == 0 {
+			patterns = append(patterns, "./...")
+			log.Warn("No target patterns provided using default './...'")
+		}
+		pkgs, err := packages.Load(cfg, patterns...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Added an option to specify what packages to index, the default behaviour is the same as before`./...`

```
scip-go ./... # index all recursively
scip-go std # index all stdlib
scip-go ./cmd/scip-go #index main scip-go cmd package
scip-go net/http fmt # index `net/http` and `fmt` packages
scip-go foo//bar:baz # index Buck/Bazel target
scip-go pattern=foo//... file=bar/baz.go # example of usage file and pattern queries
```

The doc: https://pkg.go.dev/golang.org/x/tools/go/packages#pkg-overview

Related: https://github.com/sourcegraph/scip-go/issues/3