### PR TITLE
Don't panic on missing TypeInfo

### DIFF
--- a/internal/implementations/implementations.go
+++ b/internal/implementations/implementations.go
@@ -168,8 +168,9 @@ func extractInterfacesAndConcreteTypes(pkgs loader.PackageLookup, symbols *looku
 			continue
 		}
 
-		if pkg == nil || pkg.TypesInfo == nil {
-			panic(fmt.Sprintf("nill types info %s", pkg.Name))
+		if pkg.TypesInfo == nil {
+			log.Warn("No types for package", "path", pkg.PkgPath)
+			continue
 		}
 
 		pkgSymbols := symbols.GetPackage(pkg)


### PR DESCRIPTION
There's cases when TypeInfo is missing, e.q. [packages with no sources](https://cs.opensource.google/go/x/tools/+/master:go/packages/packages.go;l=1169-1176;drc=9d9b0b6e546c97608d8d52f87995980144ffb66c). 
Sometimes this might happen due to misconfigured build-system like Buck/Bazel on large monorepos.

I'd like to avoid the entire indexer process failure in such case and  and log a warning instead.

Related #3 




