### PR TITLE
Handle index.Index panic

### DIFF
--- a/cmd/scip-go/main.go
+++ b/cmd/scip-go/main.go
@@ -100,7 +100,7 @@ func main() {
 	}
 }
 
-func mainErr() error {
+func mainErr() (err error) {
 	// The default formatting also prints the date, which is generally not needed.
 	log.SetTimeFormat("15:04:05")
 	log.SetStyles(func() *log.Styles {
@@ -235,6 +235,7 @@ func mainErr() error {
 	defer func() {
 		if r := recover(); r != nil {
 			removeOutFileIfPresent()
+			err = fmt.Errorf("Index panicked, recovered value: %v", r)
 		}
 	}()
 


### PR DESCRIPTION
Currently the panic message is being thrown away and the indexer exits with 0. 
This change converts panic to an error and returns it, then it's being logged and the process exits with non-zero code.