### PR TITLE
fix: Set GOTOOLCHAIN=auto to avoid build failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,16 +15,17 @@
 #    <other stuff to ignore>
 # And use this digest in FROM
 
-ARG base_sha=2b1cbf278ce05a2a310a3d695ebb176420117a8cfcfcc4e5e68a1bef5f6354da
+ARG base_sha=39d9e7d9c5d9c9e4baf0d8fff579f06d5032c0f4425cdec9e86732e8e4e374dc
 
-FROM golang:1.24.0@sha256:${base_sha} AS builder
+FROM golang:1.24.3@sha256:${base_sha} AS builder
 
 COPY . /sources
 WORKDIR /sources
 RUN go build -o scip-go ./cmd/scip-go
 
 # Keep in sync with builder image
-FROM golang:1.24.0@sha256:${base_sha} AS final
+FROM golang:1.24.3@sha256:${base_sha} AS final
 
 COPY --from=builder /sources/scip-go /usr/bin/
+ENV GOTOOLCHAIN=auto
 CMD ["scip-go"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcegraph/scip-go
 
-go 1.24.0
+go 1.24.3
 
 require (
 	github.com/charmbracelet/log v0.4.0


### PR DESCRIPTION
The base image seems to be setting GOTOOLCHAIN=local,
which means that auto-indexing would never automatically
download a newer toolchain if the go.mod version exceeded
the Go toolchain version that was part of the image.

Explicitly setting GOTOOLCHAIN=auto changes this to
automatically download the latest toolchain if available
and necessary.

Also bumps the Go version to the latest 1.24.3.

Fixes part of GRAPH-1198. Still need to cut release and
bump image in sg/sg.