### PR TITLE
Add SymbolInformation for local symbols per SCIP spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# scip-go Development Guide
+
+## Commands
+
+- **Build**: `go build ./cmd/scip-go`
+- **Test all**: `go test ./...`
+- **Test single package**: `go test ./internal/index`
+- **Update snapshots**: `go test ./internal/index -update-snapshots`
+- **Install**: `go install ./cmd/scip-go`
+- **Version check**: `go version` (uses Go 1.24.3)
+
+## Architecture
+
+SCIP (Source Code Intelligence Protocol) indexer for Go. Main entry point is
+`cmd/scip-go/main.go`. Key packages: `internal/index` (core indexing),
+`internal/loader` (package loading), `internal/visitors` (AST traversal),
+`internal/document` (SCIP document generation).
+
+## Code Style
+
+- Package naming: lowercase, single word preferred (e.g., `index`, `loader`,
+  `symbols`)
+- Imports: grouped by std library, third-party, then internal packages with
+  blank lines
+- Test files: use `package_test` convention for black-box testing
+- Embed files: use `//go:embed` for version.txt and similar resources
+- Error handling: return explicit errors, no panics in library code
+- Logging: use `charmbracelet/log` for structured logging

--- a/internal/visitors/visitor_file.go
+++ b/internal/visitors/visitor_file.go
@@ -18,8 +18,10 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
-const symbolDefinition = int32(scip.SymbolRole_Definition)
-const symbolReference = int32(scip.SymbolRole_ReadAccess)
+const (
+	symbolDefinition = int32(scip.SymbolRole_Definition)
+	symbolReference  = int32(scip.SymbolRole_ReadAccess)
+)
 
 func NewFileVisitor(
 	doc *document.Document,
@@ -336,6 +338,12 @@ func (v *fileVisitor) ToScipDocument() *scip.Document {
 	}
 
 	documentSymbols := v.pkgSymbols.SymbolsForFile(documentFile)
+	for _, localSymbol := range v.locals {
+		documentSymbols = append(documentSymbols, &scip.SymbolInformation{
+			Symbol: localSymbol,
+		})
+	}
+
 	return &scip.Document{
 		Language:     "go",
 		RelativePath: v.doc.RelativePath,

--- a/internal/visitors/visitor_file_test.go
+++ b/internal/visitors/visitor_file_test.go
@@ -1,0 +1,96 @@
+package visitors
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"testing"
+
+	"github.com/sourcegraph/scip-go/internal/document"
+	"github.com/sourcegraph/scip-go/internal/loader"
+	"github.com/sourcegraph/scip-go/internal/lookup"
+	"golang.org/x/tools/go/packages"
+)
+
+func TestToScipDocument_IncludesLocalSymbols(t *testing.T) {
+	src := `
+	package main
+
+	func main() {
+		x := 42
+		y := "hello"
+		if true {
+			z := x + 1
+			_ = z
+		}
+		_ = y
+	}
+	`
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "test.go", src, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse source: %v", err)
+	}
+
+	// Create a mock package
+	pkg := &packages.Package{
+		Fset:   fset,
+		Syntax: []*ast.File{file},
+		Types:  types.NewPackage("main", "main"),
+		TypesInfo: &types.Info{
+			Implicits: make(map[ast.Node]types.Object),
+		},
+	}
+
+	doc := &document.Document{RelativePath: "test.go"}
+
+	pkgSymbols := lookup.NewPackageSymbols(pkg)
+	globalSymbols := lookup.NewGlobalSymbols()
+	pkgLookup := make(loader.PackageLookup) // empty
+
+	visitor := NewFileVisitor(
+		doc, pkg, file, pkgLookup, pkgSymbols, globalSymbols)
+
+	// Simulate visiting the file to create local symbols
+	// In real usage, ast.Walk would populate the locals
+	// For testing, we'll manually add some local symbols to simulate what happens
+	visitor.locals = map[token.Pos]string{
+		token.Pos(100): "local 0", // x
+		token.Pos(200): "local 1", // y
+		token.Pos(300): "local 2", // z
+	}
+
+	scipDoc := visitor.ToScipDocument()
+	localSymbolCount := 0
+	for _, symbol := range scipDoc.Symbols {
+		if len(symbol.Symbol) >= 5 && symbol.Symbol[:5] == "local" {
+			localSymbolCount++
+		}
+	}
+
+	if localSymbolCount != 3 {
+		t.Errorf(
+			"Expected 3 local symbols in Document.symbols, got %d", localSymbolCount)
+	}
+
+	expectedLocals := map[string]bool{
+		"local 0": false,
+		"local 1": false,
+		"local 2": false,
+	}
+
+	for _, symbol := range scipDoc.Symbols {
+		if _, ok := expectedLocals[symbol.Symbol]; ok {
+			expectedLocals[symbol.Symbol] = true
+		}
+	}
+
+	for localSymbol, found := range expectedLocals {
+		if !found {
+			t.Errorf(
+				"Expected local symbol %q not found in Document.symbols", localSymbol)
+		}
+	}
+}


### PR DESCRIPTION
Fixes `scip lint` issue of missing local symbol definitions (there is still an issue of missing external symbols).

According to the SCIP specification, `Document.symbols` should contain all symbols defined within the document, including local symbols (local variables, parameters, etc.). Local symbols use the format 'local <id>' and must be included in `Document.symbols` for proper SCIP compliance.

This change adds `SymbolInformation` entries for all local symbols to each document, fixing scip lint errors about missing symbol definitions for local 0, local 1, etc.

Also added `AGENTS.md`.