### PR TITLE
Add type information to local variables in SCIP index

### DIFF
--- a/internal/lookup/local.go
+++ b/internal/lookup/local.go
@@ -19,10 +19,11 @@ func (l *Local) SignatureText() string {
 
 	var parts []string
 
-	// local symbol can only represent const or var
 	switch l.Obj.(type) {
 	case *types.Const:
 		parts = append(parts, "const")
+	case *types.PkgName:
+		parts = append(parts, "import")
 	case *types.Var:
 		parts = append(parts, "var")
 	}
@@ -31,9 +32,16 @@ func (l *Local) SignatureText() string {
 		parts = append(parts, name)
 	}
 
-	if t := l.Obj.Type(); t != nil {
-		if ts := t.String(); ts != "" {
-			parts = append(parts, ts)
+	// For PkgName, append the package path instead of type
+	if pkgName, isPkgName := l.Obj.(*types.PkgName); isPkgName {
+		if imported := pkgName.Imported(); imported != nil {
+			parts = append(parts, imported.Path())
+		}
+	} else {
+		if t := l.Obj.Type(); t != nil {
+			if ts := t.String(); ts != "" {
+				parts = append(parts, ts)
+			}
 		}
 	}
 

--- a/internal/visitors/visitor_file.go
+++ b/internal/visitors/visitor_file.go
@@ -133,7 +133,8 @@ func (v *fileVisitor) Visit(n ast.Node) ast.Visitor {
 		}
 
 		if node.Name != nil && node.Name.Name != "." {
-			symName := v.createNewLocalSymbol(node.Name.Pos(), nil)
+			pkgAlias := v.pkg.TypesInfo.Defs[node.Name]
+			symName := v.createNewLocalSymbol(node.Name.Pos(), pkgAlias)
 			rangeFromName := symbols.RangeFromName(
 				v.pkg.Fset.Position(node.Name.Pos()), node.Name.Name, false)
 			v.NewDefinition(symName, rangeFromName)


### PR DESCRIPTION
For all local symbols (local variables, parameters, etc.), include their Go type information in the `SymbolInformation.SignatureDocumentation` field. This allows code intelligence features like hover tooltips to show the type of local variables without needing to jump to their definitions.

Example signature documentation:
- `var x int`
- `const y *string`

Generating index this way is already compatible with Sourcegraph's code search so feel free to upload index generated with this change and see what the hovers look like. :)