### PR TITLE
fix: return only one tag when `git tag` returns multiple

### DIFF
--- a/internal/git/infer_module_version.go
+++ b/internal/git/infer_module_version.go
@@ -2,6 +2,9 @@ package git
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver"
 
 	"github.com/sourcegraph/scip-go/internal/command"
 )
@@ -10,12 +13,21 @@ import (
 // directory. This will be either the work tree commit's tag, or it will be the
 // short revhash of the HEAD commit.
 func InferModuleVersion(dir string) (string, error) {
-	version, err := command.Run(dir, "git", "tag", "-l", "--points-at", "HEAD")
+	tags, err := command.Run(dir, "git", "tag", "-l", "--points-at", "HEAD")
 	if err != nil {
-		return "", fmt.Errorf("failed to tags for current commit: %v\n%s", err, version)
+		return "", fmt.Errorf("failed to tags for current commit: %v\n%s", err, tags)
 	}
-	if version != "" {
-		return version, nil
+	lines := strings.Split(tags, "\n")
+	for _, tag := range lines {
+		_, err := semver.NewVersion(tag)
+		if err == nil {
+			// Correctly parsed as a version, so just return it.
+			return tag, nil
+		}
+	}
+	if len(lines) > 0 {
+		// None of the tags look like a version, but return one of them anyway.
+		return lines[0], nil
 	}
 
 	commit, err := command.Run(dir, "git", "rev-parse", "HEAD")


### PR DESCRIPTION
This makes version inference work correctly on github.com/kubernetes/api, returning just "v0.34.1" instead of "kubernetes-1.34.1\nv0.34.1".