### PR TITLE
Emit local definitions for non-aliased imports

### DIFF
--- a/internal/lookup/local.go
+++ b/internal/lookup/local.go
@@ -23,7 +23,7 @@ func (l *Local) SignatureText() string {
 	case *types.Const:
 		parts = append(parts, "const")
 	case *types.PkgName:
-		parts = append(parts, "import")
+		parts = append(parts, "package")
 	case *types.Var:
 		parts = append(parts, "var")
 	}
@@ -32,12 +32,9 @@ func (l *Local) SignatureText() string {
 		parts = append(parts, name)
 	}
 
-	// For PkgName, append the package path instead of type
-	if pkgName, isPkgName := l.Obj.(*types.PkgName); isPkgName {
-		if imported := pkgName.Imported(); imported != nil {
-			parts = append(parts, imported.Path())
-		}
-	} else {
+	// For PkgName, the signature is just "package <name>" (matching gopls).
+	// For other types, append the type string.
+	if _, isPkgName := l.Obj.(*types.PkgName); !isPkgName {
 		if t := l.Obj.Type(); t != nil {
 			if ts := t.String(); ts != "" {
 				parts = append(parts, ts)

--- a/internal/testdata/snapshots/input/pr197/README.md
+++ b/internal/testdata/snapshots/input/pr197/README.md
@@ -1,0 +1,10 @@
+# PR #197: Import symbol definitions
+
+Test cases for https://github.com/sourcegraph/scip-go/issues/34
+
+Covers:
+- Non-aliased imports (single-segment and multi-segment paths)
+- Aliased imports
+- Dot imports
+- Blank/side-effect imports
+- Multiple files in the same package (all `package` statements should be definitions)

--- a/internal/testdata/snapshots/input/pr197/go.mod
+++ b/internal/testdata/snapshots/input/pr197/go.mod
@@ -1,0 +1,3 @@
+module scip-go/pr197
+
+go 1.22

--- a/internal/testdata/snapshots/input/pr197/imports.go
+++ b/internal/testdata/snapshots/input/pr197/imports.go
@@ -1,0 +1,20 @@
+package pr197
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	_ "embed"
+
+	. "strings"
+
+	h "net/http"
+)
+
+func UseImports() {
+	fmt.Println(context.Background())
+	_ = http.StatusOK
+	_ = h.DefaultClient
+	_ = Contains("hello", "ell")
+}

--- a/internal/testdata/snapshots/input/pr197/other.go
+++ b/internal/testdata/snapshots/input/pr197/other.go
@@ -1,0 +1,8 @@
+// Package pr197 tests import symbol definitions.
+package pr197
+
+import "fmt"
+
+func OtherFunc() {
+	fmt.Println("from other file")
+}

--- a/internal/testdata/snapshots/output/embedded/embedded.go
+++ b/internal/testdata/snapshots/output/embedded/embedded.go
@@ -3,9 +3,11 @@
   
   import (
    "fmt"
+//  ^^^ definition local 0
 //  ^^^ reference github.com/golang/go/src go1.22 fmt/
    "os/exec"
 //  ^^^^^^^ reference github.com/golang/go/src go1.22 `os/exec`/
+//     ^^^^ definition local 1
   )
   
   type osExecCommand struct {
@@ -24,7 +26,7 @@
 //     relationship github.com/golang/go/src go1.22 fmt/Stringer# implementation
 //     relationship github.com/golang/go/src go1.22 runtime/stringer# implementation
    *exec.Cmd
-//  ^^^^ reference github.com/golang/go/src go1.22 `os/exec`/
+//  ^^^^ reference local 1
 //       ^^^ definition 0.1.test `sg/embedded`/osExecCommand#Cmd.
 //       documentation
 //       > ```go
@@ -40,13 +42,13 @@
 //     > ```go
 //     > func wrapExecCommand(c *Cmd)
 //     > ```
-//                     ^ definition local 0
-//                        ^^^^ reference github.com/golang/go/src go1.22 `os/exec`/
+//                     ^ definition local 2
+//                        ^^^^ reference local 1
 //                             ^^^ reference github.com/golang/go/src go1.22 `os/exec`/Cmd#
    _ = &osExecCommand{Cmd: c}
 //      ^^^^^^^^^^^^^ reference 0.1.test `sg/embedded`/osExecCommand#
 //                    ^^^ reference 0.1.test `sg/embedded`/osExecCommand#Cmd.
-//                         ^ reference local 0
+//                         ^ reference local 2
   }
 //⌃ enclosing_range_end 0.1.test `sg/embedded`/wrapExecCommand().
   
@@ -120,7 +122,7 @@
 //     > func useOfCompositeStructs()
 //     > ```
    o := Outer{
-// ^ definition local 1
+// ^ definition local 3
 //      ^^^^^ reference 0.1.test `sg/embedded`/Outer#
     Inner: Inner{
 //  ^^^^^ reference 0.1.test `sg/embedded`/Outer#Inner.
@@ -137,14 +139,14 @@
    }
   
    fmt.Printf("> %d\n", o.X)
-// ^^^ reference github.com/golang/go/src go1.22 fmt/
+// ^^^ reference local 0
 //     ^^^^^^ reference github.com/golang/go/src go1.22 fmt/Printf().
-//                      ^ reference local 1
+//                      ^ reference local 3
 //                        ^ reference 0.1.test `sg/embedded`/Inner#X.
    fmt.Println(o.Inner.Y)
-// ^^^ reference github.com/golang/go/src go1.22 fmt/
+// ^^^ reference local 0
 //     ^^^^^^^ reference github.com/golang/go/src go1.22 fmt/Println().
-//             ^ reference local 1
+//             ^ reference local 3
 //               ^^^^^ reference 0.1.test `sg/embedded`/Outer#Inner.
 //                     ^ reference 0.1.test `sg/embedded`/Inner#Y.
   }

--- a/internal/testdata/snapshots/output/embedded/embedded.go
+++ b/internal/testdata/snapshots/output/embedded/embedded.go
@@ -6,8 +6,8 @@
 //  ^^^ definition local 0
 //  ^^^ reference github.com/golang/go/src go1.22 fmt/
    "os/exec"
+//  ^^^^^^^ definition local 1
 //  ^^^^^^^ reference github.com/golang/go/src go1.22 `os/exec`/
-//     ^^^^ definition local 1
   )
   
   type osExecCommand struct {

--- a/internal/testdata/snapshots/output/embedded/internal/nested.go
+++ b/internal/testdata/snapshots/output/embedded/internal/nested.go
@@ -3,9 +3,11 @@
   
   import (
    "fmt"
+//  ^^^ definition local 0
 //  ^^^ reference github.com/golang/go/src go1.22 fmt/
    "sg/embedded"
 //  ^^^^^^^^^^^ reference 0.1.test `sg/embedded`/
+//     ^^^^^^^^ definition local 1
   )
   
 //⌄ enclosing_range_start 0.1.test `sg/embedded/internal`/Something().
@@ -15,22 +17,22 @@
 //     > ```go
 //     > func Something(recent RecentCommittersResults)
 //     > ```
-//               ^^^^^^ definition local 0
-//                      ^^^^^^^^ reference 0.1.test `sg/embedded`/
+//               ^^^^^^ definition local 2
+//                      ^^^^^^^^ reference local 1
 //                               ^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/embedded`/RecentCommittersResults#
    for _, commit := range recent.Nodes {
-//        ^^^^^^ definition local 1
-//                        ^^^^^^ reference local 0
+//        ^^^^^^ definition local 3
+//                        ^^^^^^ reference local 2
 //                               ^^^^^ reference 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.
     for _, author := range commit.Authors.Nodes {
-//         ^^^^^^ definition local 2
-//                         ^^^^^^ reference local 1
+//         ^^^^^^ definition local 4
+//                         ^^^^^^ reference local 3
 //                                ^^^^^^^ reference 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.Authors.
 //                                        ^^^^^ reference 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.Authors.Nodes.
      fmt.Println(author.Name)
-//   ^^^ reference github.com/golang/go/src go1.22 fmt/
+//   ^^^ reference local 0
 //       ^^^^^^^ reference github.com/golang/go/src go1.22 fmt/Println().
-//               ^^^^^^ reference local 2
+//               ^^^^^^ reference local 4
 //                      ^^^^ reference 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.Authors.Nodes.Name.
     }
    }

--- a/internal/testdata/snapshots/output/embedded/internal/nested.go
+++ b/internal/testdata/snapshots/output/embedded/internal/nested.go
@@ -6,8 +6,8 @@
 //  ^^^ definition local 0
 //  ^^^ reference github.com/golang/go/src go1.22 fmt/
    "sg/embedded"
+//  ^^^^^^^^^^^ definition local 1
 //  ^^^^^^^^^^^ reference 0.1.test `sg/embedded`/
-//     ^^^^^^^^ definition local 1
   )
   
 //⌄ enclosing_range_start 0.1.test `sg/embedded/internal`/Something().

--- a/internal/testdata/snapshots/output/embedded/nested.go
+++ b/internal/testdata/snapshots/output/embedded/nested.go
@@ -3,6 +3,7 @@
   
   import "net/http"
 //        ^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/
+//            ^^^^ definition local 0
   
   type NestedHandler struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/NestedHandler#
@@ -19,7 +20,7 @@
 //     > ```
 //     relationship github.com/golang/go/src go1.22 `net/http`/Handler# implementation
    http.Handler
-// ^^^^ reference github.com/golang/go/src go1.22 `net/http`/
+// ^^^^ reference local 0
 //      ^^^^^^^ definition 0.1.test `sg/embedded`/NestedHandler#Handler.
 //      documentation
 //      > ```go
@@ -43,17 +44,17 @@
 //     > ```go
 //     > func NestedExample(n NestedHandler)
 //     > ```
-//                   ^ definition local 0
+//                   ^ definition local 1
 //                     ^^^^^^^^^^^^^ reference 0.1.test `sg/embedded`/NestedHandler#
    _ = n.Handler.ServeHTTP
-//     ^ reference local 0
+//     ^ reference local 1
 //       ^^^^^^^ reference 0.1.test `sg/embedded`/NestedHandler#Handler.
 //               ^^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/Handler#ServeHTTP.
    _ = n.ServeHTTP
-//     ^ reference local 0
+//     ^ reference local 1
 //       ^^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/Handler#ServeHTTP.
    _ = n.Other
-//     ^ reference local 0
+//     ^ reference local 1
 //       ^^^^^ reference 0.1.test `sg/embedded`/NestedHandler#Other.
   }
 //⌃ enclosing_range_end 0.1.test `sg/embedded`/NestedExample().

--- a/internal/testdata/snapshots/output/embedded/nested.go
+++ b/internal/testdata/snapshots/output/embedded/nested.go
@@ -2,8 +2,8 @@
 //        ^^^^^^^^ definition 0.1.test `sg/embedded`/
   
   import "net/http"
+//        ^^^^^^^^ definition local 0
 //        ^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/
-//            ^^^^ definition local 0
   
   type NestedHandler struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/NestedHandler#

--- a/internal/testdata/snapshots/output/embedded/something.go
+++ b/internal/testdata/snapshots/output/embedded/something.go
@@ -2,11 +2,12 @@
 //        ^^^^^^^^ definition 0.1.test `sg/embedded`/
   
   import "fmt"
+//        ^^^ definition local 0
 //        ^^^ reference github.com/golang/go/src go1.22 fmt/
   
 //⌄ enclosing_range_start 0.1.test `sg/embedded`/RecentCommittersResults#String().
   func (r *RecentCommittersResults) String() string {
-//      ^ definition local 0
+//      ^ definition local 1
 //         ^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/embedded`/RecentCommittersResults#
 //                                  ^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#String().
 //                                  documentation
@@ -17,9 +18,9 @@
 //                                  relationship github.com/golang/go/src go1.22 fmt/Stringer#String. implementation
 //                                  relationship github.com/golang/go/src go1.22 runtime/stringer#String. implementation
    return fmt.Sprintf("RecentCommittersResults{Nodes: %d}", len(r.Nodes))
-//        ^^^ reference github.com/golang/go/src go1.22 fmt/
+//        ^^^ reference local 0
 //            ^^^^^^^ reference github.com/golang/go/src go1.22 fmt/Sprintf().
-//                                                              ^ reference local 0
+//                                                              ^ reference local 1
 //                                                                ^^^^^ reference 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.
   }
 //⌃ enclosing_range_end 0.1.test `sg/embedded`/RecentCommittersResults#String().

--- a/internal/testdata/snapshots/output/generallyeric/generallyeric.go
+++ b/internal/testdata/snapshots/output/generallyeric/generallyeric.go
@@ -5,6 +5,7 @@
 //        > generallyeric -> generic for short
   
   import "fmt"
+//        ^^^ definition local 0
 //        ^^^ reference github.com/golang/go/src go1.22 fmt/
   
 //⌄ enclosing_range_start 0.1.test `sg/generallyeric`/Print().
@@ -14,16 +15,16 @@
 //     > ```go
 //     > func Print[T any](s []T)
 //     > ```
-//           ^ definition local 0
-//                  ^ definition local 1
-//                      ^ reference local 0
+//           ^ definition local 1
+//                  ^ definition local 2
+//                      ^ reference local 1
    for _, v := range s {
-//        ^ definition local 2
-//                   ^ reference local 1
+//        ^ definition local 3
+//                   ^ reference local 2
     fmt.Print(v)
-//  ^^^ reference github.com/golang/go/src go1.22 fmt/
+//  ^^^ reference local 0
 //      ^^^^^ reference github.com/golang/go/src go1.22 fmt/Print().
-//            ^ reference local 2
+//            ^ reference local 3
    }
   }
 //⌃ enclosing_range_end 0.1.test `sg/generallyeric`/Print().

--- a/internal/testdata/snapshots/output/generallyeric/person.go
+++ b/internal/testdata/snapshots/output/generallyeric/person.go
@@ -2,6 +2,7 @@
 //        ^^^^^^^^^^^^^ definition 0.1.test `sg/generallyeric`/
   
   import "fmt"
+//        ^^^ definition local 0
 //        ^^^ reference github.com/golang/go/src go1.22 fmt/
   
   type Person interface {
@@ -34,7 +35,7 @@
   
 //⌄ enclosing_range_start 0.1.test `sg/generallyeric`/worker#Work().
   func (w worker) Work() {
-//      ^ definition local 0
+//      ^ definition local 1
 //        ^^^^^^ reference 0.1.test `sg/generallyeric`/worker#
 //                ^^^^ definition 0.1.test `sg/generallyeric`/worker#Work().
 //                documentation
@@ -43,9 +44,9 @@
 //                > ```
 //                relationship 0.1.test `sg/generallyeric`/Person#Work. implementation
    fmt.Printf("%s is working\n", w)
-// ^^^ reference github.com/golang/go/src go1.22 fmt/
+// ^^^ reference local 0
 //     ^^^^^^ reference github.com/golang/go/src go1.22 fmt/Printf().
-//                               ^ reference local 0
+//                               ^ reference local 1
   }
 //⌃ enclosing_range_end 0.1.test `sg/generallyeric`/worker#Work().
   
@@ -56,15 +57,15 @@
 //     > ```go
 //     > func DoWork[T Person](things []T)
 //     > ```
-//            ^ definition local 1
+//            ^ definition local 2
 //              ^^^^^^ reference 0.1.test `sg/generallyeric`/Person#
-//                      ^^^^^^ definition local 2
-//                               ^ reference local 1
+//                      ^^^^^^ definition local 3
+//                               ^ reference local 2
    for _, v := range things {
-//        ^ definition local 3
-//                   ^^^^^^ reference local 2
+//        ^ definition local 4
+//                   ^^^^^^ reference local 3
     v.Work()
-//  ^ reference local 3
+//  ^ reference local 4
 //    ^^^^ reference 0.1.test `sg/generallyeric`/Person#Work.
    }
   }
@@ -78,22 +79,22 @@
 //     > func main()
 //     > ```
    var a, b, c worker
-//     ^ definition local 4
-//        ^ definition local 5
-//           ^ definition local 6
+//     ^ definition local 5
+//        ^ definition local 6
+//           ^ definition local 7
 //             ^^^^^^ reference 0.1.test `sg/generallyeric`/worker#
    a = "A"
-// ^ reference local 4
-   b = "B"
 // ^ reference local 5
-   c = "C"
+   b = "B"
 // ^ reference local 6
+   c = "C"
+// ^ reference local 7
    DoWork([]worker{a, b, c})
 // ^^^^^^ reference 0.1.test `sg/generallyeric`/DoWork().
 //          ^^^^^^ reference 0.1.test `sg/generallyeric`/worker#
-//                 ^ reference local 4
-//                    ^ reference local 5
-//                       ^ reference local 6
+//                 ^ reference local 5
+//                    ^ reference local 6
+//                       ^ reference local 7
   }
 //⌃ enclosing_range_end 0.1.test `sg/generallyeric`/main().
   

--- a/internal/testdata/snapshots/output/impls/remote_impls.go
+++ b/internal/testdata/snapshots/output/impls/remote_impls.go
@@ -2,8 +2,8 @@
 //        ^^^^^ definition 0.1.test `sg/impls`/
   
   import "net/http"
+//        ^^^^^^^^ definition local 0
 //        ^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/
-//            ^^^^ definition local 0
   
 //⌄ enclosing_range_start 0.1.test `sg/impls`/Something().
   func Something(r http.ResponseWriter) {}

--- a/internal/testdata/snapshots/output/impls/remote_impls.go
+++ b/internal/testdata/snapshots/output/impls/remote_impls.go
@@ -3,6 +3,7 @@
   
   import "net/http"
 //        ^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/
+//            ^^^^ definition local 0
   
 //⌄ enclosing_range_start 0.1.test `sg/impls`/Something().
   func Something(r http.ResponseWriter) {}
@@ -11,8 +12,8 @@
 //     > ```go
 //     > func Something(r ResponseWriter)
 //     > ```
-//               ^ definition local 0
-//                 ^^^^ reference github.com/golang/go/src go1.22 `net/http`/
+//               ^ definition local 1
+//                 ^^^^ reference local 0
 //                      ^^^^^^^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/ResponseWriter#
 //                                       ⌃ enclosing_range_end 0.1.test `sg/impls`/Something().
   
@@ -33,7 +34,7 @@
   
 //⌄ enclosing_range_start 0.1.test `sg/impls`/MyWriter#Header().
   func (w MyWriter) Header() http.Header        { panic("") }
-//      ^ definition local 1
+//      ^ definition local 2
 //        ^^^^^^^^ reference 0.1.test `sg/impls`/MyWriter#
 //                  ^^^^^^ definition 0.1.test `sg/impls`/MyWriter#Header().
 //                  documentation
@@ -41,12 +42,12 @@
 //                  > func (MyWriter).Header() Header
 //                  > ```
 //                  relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#Header. implementation
-//                           ^^^^ reference github.com/golang/go/src go1.22 `net/http`/
+//                           ^^^^ reference local 0
 //                                ^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/Header#
 //                                                          ⌃ enclosing_range_end 0.1.test `sg/impls`/MyWriter#Header().
 //⌄ enclosing_range_start 0.1.test `sg/impls`/MyWriter#Write().
   func (w MyWriter) Write([]byte) (int, error)  { panic("") }
-//      ^ definition local 2
+//      ^ definition local 3
 //        ^^^^^^^^ reference 0.1.test `sg/impls`/MyWriter#
 //                  ^^^^^ definition 0.1.test `sg/impls`/MyWriter#Write().
 //                  documentation
@@ -60,7 +61,7 @@
 //                                                          ⌃ enclosing_range_end 0.1.test `sg/impls`/MyWriter#Write().
 //⌄ enclosing_range_start 0.1.test `sg/impls`/MyWriter#WriteHeader().
   func (w MyWriter) WriteHeader(statusCode int) { panic("") }
-//      ^ definition local 3
+//      ^ definition local 4
 //        ^^^^^^^^ reference 0.1.test `sg/impls`/MyWriter#
 //                  ^^^^^^^^^^^ definition 0.1.test `sg/impls`/MyWriter#WriteHeader().
 //                  documentation
@@ -68,7 +69,7 @@
 //                  > func (MyWriter).WriteHeader(statusCode int)
 //                  > ```
 //                  relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#WriteHeader. implementation
-//                              ^^^^^^^^^^ definition local 4
+//                              ^^^^^^^^^^ definition local 5
 //                                                          ⌃ enclosing_range_end 0.1.test `sg/impls`/MyWriter#WriteHeader().
   
 //⌄ enclosing_range_start 0.1.test `sg/impls`/Another().

--- a/internal/testdata/snapshots/output/initial/methods_and_receivers.go
+++ b/internal/testdata/snapshots/output/initial/methods_and_receivers.go
@@ -2,6 +2,7 @@
 //        ^^^^^^^ definition 0.1.test `sg/initial`/
   
   import "fmt"
+//        ^^^ definition local 0
 //        ^^^ reference github.com/golang/go/src go1.22 fmt/
   
   type MyStruct struct{ f, y int }
@@ -30,17 +31,17 @@
   
 //⌄ enclosing_range_start 0.1.test `sg/initial`/MyStruct#RecvFunction().
   func (m MyStruct) RecvFunction(b int) int { return m.f + b }
-//      ^ definition local 0
+//      ^ definition local 1
 //        ^^^^^^^^ reference 0.1.test `sg/initial`/MyStruct#
 //                  ^^^^^^^^^^^^ definition 0.1.test `sg/initial`/MyStruct#RecvFunction().
 //                  documentation
 //                  > ```go
 //                  > func (MyStruct).RecvFunction(b int) int
 //                  > ```
-//                               ^ definition local 1
-//                                                   ^ reference local 0
+//                               ^ definition local 2
+//                                                   ^ reference local 1
 //                                                     ^ reference 0.1.test `sg/initial`/MyStruct#f.
-//                                                         ^ reference local 1
+//                                                         ^ reference local 2
 //                                                           ⌃ enclosing_range_end 0.1.test `sg/initial`/MyStruct#RecvFunction().
   
 //⌄ enclosing_range_start 0.1.test `sg/initial`/SomethingElse().
@@ -51,13 +52,13 @@
 //     > func SomethingElse()
 //     > ```
    s := MyStruct{f: 0}
-// ^ definition local 2
+// ^ definition local 3
 //      ^^^^^^^^ reference 0.1.test `sg/initial`/MyStruct#
 //               ^ reference 0.1.test `sg/initial`/MyStruct#f.
    fmt.Println(s)
-// ^^^ reference github.com/golang/go/src go1.22 fmt/
+// ^^^ reference local 0
 //     ^^^^^^^ reference github.com/golang/go/src go1.22 fmt/Println().
-//             ^ reference local 2
+//             ^ reference local 3
   }
 //⌃ enclosing_range_end 0.1.test `sg/initial`/SomethingElse().
   

--- a/internal/testdata/snapshots/output/initial/rangefunc.go
+++ b/internal/testdata/snapshots/output/initial/rangefunc.go
@@ -3,6 +3,7 @@
   
   import (
    "slices"
+//  ^^^^^^ definition local 0
 //  ^^^^^^ reference github.com/golang/go/src go1.22 slices/
   )
   
@@ -13,14 +14,14 @@
 //     > ```go
 //     > func f(xs []int) int
 //     > ```
-//       ^^ definition local 0
+//       ^^ definition local 1
    for _, x := range slices.All(xs) {
-//        ^ definition local 1
-//                   ^^^^^^ reference github.com/golang/go/src go1.22 slices/
+//        ^ definition local 2
+//                   ^^^^^^ reference local 0
 //                          ^^^ reference github.com/golang/go/src go1.22 slices/All().
-//                              ^^ reference local 0
+//                              ^^ reference local 1
     return x
-//         ^ reference local 1
+//         ^ reference local 2
    }
    return -1
   }

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_interface.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_interface.go
@@ -2,6 +2,7 @@
 //        ^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/
   
   import "context"
+//        ^^^^^^^ definition local 0
 //        ^^^^^^^ reference github.com/golang/go/src go1.22 context/
   
 //⌄ enclosing_range_start 0.1.test `sg/inlinestruct`/Target().
@@ -17,7 +18,7 @@
 // > ```go
 // > func (interface).OID(Context) (int, error)
 // > ```
-//     ^^^^^^^ reference github.com/golang/go/src go1.22 context/
+//     ^^^^^^^ reference local 0
 //             ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
    AbbreviatedOID(context.Context) (string, error)
 // ^^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/func:Target:AbbreviatedOID().
@@ -25,7 +26,7 @@
 // > ```go
 // > func (interface).AbbreviatedOID(Context) (string, error)
 // > ```
-//                ^^^^^^^ reference github.com/golang/go/src go1.22 context/
+//                ^^^^^^^ reference local 0
 //                        ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
    Commit(context.Context) (string, error)
 // ^^^^^^ definition 0.1.test `sg/inlinestruct`/func:Target:Commit().
@@ -33,7 +34,7 @@
 // > ```go
 // > func (interface).Commit(Context) (string, error)
 // > ```
-//        ^^^^^^^ reference github.com/golang/go/src go1.22 context/
+//        ^^^^^^^ reference local 0
 //                ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
    Type(context.Context) (int, error)
 // ^^^^ definition 0.1.test `sg/inlinestruct`/func:Target:Type().
@@ -41,7 +42,7 @@
 // > ```go
 // > func (interface).Type(Context) (int, error)
 // > ```
-//      ^^^^^^^ reference github.com/golang/go/src go1.22 context/
+//      ^^^^^^^ reference local 0
 //              ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
   } {
    panic("not implemented")
@@ -56,12 +57,12 @@
 //     > func something()
 //     > ```
    x := Target()
-// ^ definition local 0
+// ^ definition local 1
 //      ^^^^^^ reference 0.1.test `sg/inlinestruct`/Target().
    x.OID(context.Background())
-// ^ reference local 0
+// ^ reference local 1
 //   ^^^ reference 0.1.test `sg/inlinestruct`/func:Target:OID().
-//       ^^^^^^^ reference github.com/golang/go/src go1.22 context/
+//       ^^^^^^^ reference local 0
 //               ^^^^^^^^^^ reference github.com/golang/go/src go1.22 context/Background().
   }
 //⌃ enclosing_range_end 0.1.test `sg/inlinestruct`/something().

--- a/internal/testdata/snapshots/output/pr197/imports.go
+++ b/internal/testdata/snapshots/output/pr197/imports.go
@@ -1,0 +1,48 @@
+  package pr197
+//        ^^^^^ definition scip-go/pr197 0.1.test `scip-go/pr197`/
+  
+  import (
+   "context"
+//  ^^^^^^^ definition local 0
+//  ^^^^^^^ reference github.com/golang/go/src go1.22 context/
+   "fmt"
+//  ^^^ definition local 1
+//  ^^^ reference github.com/golang/go/src go1.22 fmt/
+   "net/http"
+//  ^^^^^^^^ definition local 2
+//  ^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/
+  
+   _ "embed"
+//    ^^^^^ reference github.com/golang/go/src go1.22 embed/
+  
+   . "strings"
+//    ^^^^^^^ reference github.com/golang/go/src go1.22 strings/
+  
+   h "net/http"
+// ^ definition local 3
+//    ^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/
+  )
+  
+//⌄ enclosing_range_start scip-go/pr197 0.1.test `scip-go/pr197`/UseImports().
+  func UseImports() {
+//     ^^^^^^^^^^ definition scip-go/pr197 0.1.test `scip-go/pr197`/UseImports().
+//     documentation
+//     > ```go
+//     > func UseImports()
+//     > ```
+   fmt.Println(context.Background())
+// ^^^ reference local 1
+//     ^^^^^^^ reference github.com/golang/go/src go1.22 fmt/Println().
+//             ^^^^^^^ reference local 0
+//                     ^^^^^^^^^^ reference github.com/golang/go/src go1.22 context/Background().
+   _ = http.StatusOK
+//     ^^^^ reference local 3
+//          ^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/StatusOK.
+   _ = h.DefaultClient
+//     ^ reference local 3
+//       ^^^^^^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/DefaultClient.
+   _ = Contains("hello", "ell")
+//     ^^^^^^^^ reference github.com/golang/go/src go1.22 strings/Contains().
+  }
+//⌃ enclosing_range_end scip-go/pr197 0.1.test `scip-go/pr197`/UseImports().
+  

--- a/internal/testdata/snapshots/output/pr197/other.go
+++ b/internal/testdata/snapshots/output/pr197/other.go
@@ -1,0 +1,23 @@
+  // Package pr197 tests import symbol definitions.
+  package pr197
+//        ^^^^^ definition scip-go/pr197 0.1.test `scip-go/pr197`/
+//        documentation
+//        > Package pr197 tests import symbol definitions.
+  
+  import "fmt"
+//        ^^^ definition local 0
+//        ^^^ reference github.com/golang/go/src go1.22 fmt/
+  
+//⌄ enclosing_range_start scip-go/pr197 0.1.test `scip-go/pr197`/OtherFunc().
+  func OtherFunc() {
+//     ^^^^^^^^^ definition scip-go/pr197 0.1.test `scip-go/pr197`/OtherFunc().
+//     documentation
+//     > ```go
+//     > func OtherFunc()
+//     > ```
+   fmt.Println("from other file")
+// ^^^ reference local 0
+//     ^^^^^^^ reference github.com/golang/go/src go1.22 fmt/Println().
+  }
+//⌃ enclosing_range_end scip-go/pr197 0.1.test `scip-go/pr197`/OtherFunc().
+  

--- a/internal/testdata/snapshots/output/replace-directives/replace_directives.go
+++ b/internal/testdata/snapshots/output/replace-directives/replace_directives.go
@@ -3,10 +3,11 @@
   
   import (
    "fmt"
+//  ^^^ definition local 0
 //  ^^^ reference github.com/golang/go/src go1.22 fmt/
   
    replaced "github.com/example/original"
-// ^^^^^^^^ definition local 0
+// ^^^^^^^^ definition local 1
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference github.com/example/replaced 0.1.test `github.com/example/original`/
   )
   
@@ -18,9 +19,9 @@
 //     > func Something()
 //     > ```
    fmt.Println(replaced.DefaultConfig)
-// ^^^ reference github.com/golang/go/src go1.22 fmt/
+// ^^^ reference local 0
 //     ^^^^^^^ reference github.com/golang/go/src go1.22 fmt/Println().
-//             ^^^^^^^^ reference local 0
+//             ^^^^^^^^ reference local 1
 //                      ^^^^^^^^^^^^^ reference github.com/example/replaced 0.1.test `github.com/example/original`/DefaultConfig.
   }
 //⌃ enclosing_range_end 0.1.test `sg/replace-directives`/Something().

--- a/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/cleanup_test.go
+++ b/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/cleanup_test.go
@@ -2,6 +2,7 @@
 //        ^^^^^^ definition 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/
   
   import "testing"
+//        ^^^^^^^ definition local 0
 //        ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
   
 //⌄ enclosing_range_start 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/TestStuff().
@@ -11,19 +12,19 @@
 //     > ```go
 //     > func TestStuff(t *T)
 //     > ```
-//               ^ definition local 0
-//                  ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
+//               ^ definition local 1
+//                  ^^^^^^^ reference local 0
 //                          ^ reference github.com/golang/go/src go1.22 testing/T#
    wd := "hello"
-// ^^ definition local 1
+// ^^ definition local 2
    repo := "world"
-// ^^^^ definition local 2
+// ^^^^ definition local 3
   
    runCmd(t, wd, "git", "init", repo)
 // ^^^^^^ reference 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/runCmd().
-//        ^ reference local 0
-//           ^^ reference local 1
-//                              ^^^^ reference local 2
+//        ^ reference local 1
+//           ^^ reference local 2
+//                              ^^^^ reference local 3
   }
 //⌃ enclosing_range_end 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/TestStuff().
   

--- a/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/server_test.go
+++ b/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/server_test.go
@@ -2,6 +2,7 @@
 //        ^^^^^^ definition 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/
   
   import "testing"
+//        ^^^^^^^ definition local 0
 //        ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
   
 //⌄ enclosing_range_start 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/TestExecRequest().
@@ -11,11 +12,11 @@
 //     > ```go
 //     > func TestExecRequest(t *T)
 //     > ```
-//                     ^ definition local 0
-//                        ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
+//                     ^ definition local 1
+//                        ^^^^^^^ reference local 0
 //                                ^ reference github.com/golang/go/src go1.22 testing/T#
    t.Log("hello world")
-// ^ reference local 0
+// ^ reference local 1
 //   ^^^ reference github.com/golang/go/src go1.22 testing/common#Log().
   }
 //⌃ enclosing_range_end 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/TestExecRequest().
@@ -27,11 +28,11 @@
 //     > ```go
 //     > func runCmd(t *T, dir string, cmd string, arg ...string)
 //     > ```
-//            ^ definition local 1
-//               ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
+//            ^ definition local 2
+//               ^^^^^^^ reference local 0
 //                       ^ reference github.com/golang/go/src go1.22 testing/T#
-//                          ^^^ definition local 2
-//                                      ^^^ definition local 3
-//                                                  ^^^ definition local 4
+//                          ^^^ definition local 3
+//                                      ^^^ definition local 4
+//                                                  ^^^ definition local 5
 //                                                                  ⌃ enclosing_range_end 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/runCmd().
   

--- a/internal/testdata/snapshots/output/testdata/anonymous_structs.go
+++ b/internal/testdata/snapshots/output/testdata/anonymous_structs.go
@@ -2,6 +2,7 @@
 //        ^^^^^^^^ definition 0.1.test `sg/testdata`/
   
   import "fmt"
+//        ^^^ definition local 0
 //        ^^^ reference github.com/golang/go/src go1.22 fmt/
   
   type TypeContainingAnonymousStructs struct {
@@ -80,101 +81,101 @@
 //     > func funcContainingAnonymousStructs()
 //     > ```
    d := struct {
-// ^ definition local 0
+// ^ definition local 1
     x int
-//  ^ definition local 1
-    y string
 //  ^ definition local 2
+    y string
+//  ^ definition local 3
    }{
     x: 1,
-//  ^ reference local 1
-    y: "one",
 //  ^ reference local 2
+    y: "one",
+//  ^ reference local 3
    }
   
    var e struct {
-//     ^ definition local 3
+//     ^ definition local 4
     x int
-//  ^ definition local 4
-    y string
 //  ^ definition local 5
+    y string
+//  ^ definition local 6
    }
   
    e.x = 2
-// ^ reference local 3
-//   ^ reference local 4
-   e.y = "two"
-// ^ reference local 3
+// ^ reference local 4
 //   ^ reference local 5
+   e.y = "two"
+// ^ reference local 4
+//   ^ reference local 6
   
    var f TypeContainingAnonymousStructs
-//     ^ definition local 6
+//     ^ definition local 7
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#
    f.a.x = 3
-// ^ reference local 6
+// ^ reference local 7
 //   ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#a.
 //     ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#a.b.x.
    f.a.y = "three"
-// ^ reference local 6
+// ^ reference local 7
 //   ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#a.
 //     ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#a.b.y.
    f.b.x = 4
-// ^ reference local 6
+// ^ reference local 7
 //   ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#a.b.
 //     ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#a.b.x.
    f.b.y = "four"
-// ^ reference local 6
+// ^ reference local 7
 //   ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#a.b.
 //     ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#a.b.y.
    f.c.X = 5
-// ^ reference local 6
+// ^ reference local 7
 //   ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#c.
 //     ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#c.X.
    f.c.Y = "five"
-// ^ reference local 6
+// ^ reference local 7
 //   ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#c.
 //     ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#c.Y.
   
    fmt.Printf("> %s, %s\n", d.x, d.y)
-// ^^^ reference github.com/golang/go/src go1.22 fmt/
+// ^^^ reference local 0
 //     ^^^^^^ reference github.com/golang/go/src go1.22 fmt/Printf().
-//                          ^ reference local 0
-//                            ^ reference local 1
-//                               ^ reference local 0
-//                                 ^ reference local 2
+//                          ^ reference local 1
+//                            ^ reference local 2
+//                               ^ reference local 1
+//                                 ^ reference local 3
    fmt.Printf("> %s, %s\n", e.x, e.y)
-// ^^^ reference github.com/golang/go/src go1.22 fmt/
+// ^^^ reference local 0
 //     ^^^^^^ reference github.com/golang/go/src go1.22 fmt/Printf().
-//                          ^ reference local 3
-//                            ^ reference local 4
-//                               ^ reference local 3
-//                                 ^ reference local 5
+//                          ^ reference local 4
+//                            ^ reference local 5
+//                               ^ reference local 4
+//                                 ^ reference local 6
   
    fmt.Printf("> %s, %s\n", f.a.x, f.a.y)
-// ^^^ reference github.com/golang/go/src go1.22 fmt/
+// ^^^ reference local 0
 //     ^^^^^^ reference github.com/golang/go/src go1.22 fmt/Printf().
-//                          ^ reference local 6
+//                          ^ reference local 7
 //                            ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#a.
 //                              ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#a.b.x.
-//                                 ^ reference local 6
+//                                 ^ reference local 7
 //                                   ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#a.
 //                                     ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#a.b.y.
    fmt.Printf("> %s, %s\n", f.b.x, f.b.y)
-// ^^^ reference github.com/golang/go/src go1.22 fmt/
+// ^^^ reference local 0
 //     ^^^^^^ reference github.com/golang/go/src go1.22 fmt/Printf().
-//                          ^ reference local 6
+//                          ^ reference local 7
 //                            ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#a.b.
 //                              ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#a.b.x.
-//                                 ^ reference local 6
+//                                 ^ reference local 7
 //                                   ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#a.b.
 //                                     ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#a.b.y.
    fmt.Printf("> %s, %s\n", f.c.X, f.c.Y)
-// ^^^ reference github.com/golang/go/src go1.22 fmt/
+// ^^^ reference local 0
 //     ^^^^^^ reference github.com/golang/go/src go1.22 fmt/Printf().
-//                          ^ reference local 6
+//                          ^ reference local 7
 //                            ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#c.
 //                              ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#c.X.
-//                                 ^ reference local 6
+//                                 ^ reference local 7
 //                                   ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#c.
 //                                     ^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#c.Y.
   }

--- a/internal/testdata/snapshots/output/testdata/conflicting_test_symbols/sandbox_unsupported_test.go
+++ b/internal/testdata/snapshots/output/testdata/conflicting_test_symbols/sandbox_unsupported_test.go
@@ -6,8 +6,10 @@
   
   import (
    "errors"
+//  ^^^^^^ definition local 0
 //  ^^^^^^ reference github.com/golang/go/src go1.22 errors/
    "testing"
+//  ^^^^^^^ definition local 1
 //  ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
   )
   
@@ -17,7 +19,7 @@
 //    > ```go
 //    > var ErrNotImplemented error
 //    > ```
-//                        ^^^^^^ reference github.com/golang/go/src go1.22 errors/
+//                        ^^^^^^ reference local 0
 //                               ^^^ reference github.com/golang/go/src go1.22 errors/New().
   
 //⌄ enclosing_range_start 0.1.test `sg/testdata/conflicting_test_symbols`/newKey().
@@ -27,8 +29,8 @@
 //     > ```go
 //     > func newKey(t *T) (string, error)
 //     > ```
-//            ^ definition local 0
-//               ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
+//            ^ definition local 2
+//               ^^^^^^^ reference local 1
 //                       ^ reference github.com/golang/go/src go1.22 testing/T#
    return "", ErrNotImplemented
 //            ^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata/conflicting_test_symbols`/ErrNotImplemented.
@@ -42,10 +44,10 @@
 //     > ```go
 //     > func verifySandbox(t *T, s string)
 //     > ```
-//                   ^ definition local 1
-//                      ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
+//                   ^ definition local 3
+//                      ^^^^^^^ reference local 1
 //                              ^ reference github.com/golang/go/src go1.22 testing/T#
-//                                 ^ definition local 2
+//                                 ^ definition local 4
    return
   }
 //⌃ enclosing_range_end 0.1.test `sg/testdata/conflicting_test_symbols`/verifySandbox().

--- a/internal/testdata/snapshots/output/testdata/data.go
+++ b/internal/testdata/snapshots/output/testdata/data.go
@@ -7,8 +7,8 @@
 //  ^^^^^^^ reference github.com/golang/go/src go1.22 context/
   
    "sg/testdata/internal/secret"
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition local 1
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/
-//                       ^^^^^^ definition local 1
   )
   
   // TestInterface is an interface used for testing.

--- a/internal/testdata/snapshots/output/testdata/data.go
+++ b/internal/testdata/snapshots/output/testdata/data.go
@@ -3,10 +3,12 @@
   
   import (
    "context"
+//  ^^^^^^^ definition local 0
 //  ^^^^^^^ reference github.com/golang/go/src go1.22 context/
   
    "sg/testdata/internal/secret"
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/
+//                       ^^^^^^ definition local 1
   )
   
   // TestInterface is an interface used for testing.
@@ -31,11 +33,11 @@
 // > ```go
 // > func (TestInterface).Do(ctx Context, data string) (score int, _ error)
 // > ```
-//    ^^^ definition local 0
-//        ^^^^^^^ reference github.com/golang/go/src go1.22 context/
+//    ^^^ definition local 2
+//        ^^^^^^^ reference local 0
 //                ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
-//                         ^^^^ definition local 1
-//                                       ^^^^^ definition local 2
+//                         ^^^^ definition local 3
+//                                       ^^^^^ definition local 4
   }
   
   type (
@@ -151,7 +153,7 @@
 //      > ```go
 //      > const secretScore uint64 = 43
 //      > ```
-//                    ^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/
+//                    ^^^^^^ reference local 1
 //                           ^^^^^^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/SecretScore.
   
   const SomeString = "foobar"
@@ -191,7 +193,7 @@
   // Doer is similar to the test interface (but not the same).
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/TestStruct#Doer().
   func (ts *TestStruct) Doer(ctx context.Context, data string) (score int, err error) {
-//      ^^ definition local 3
+//      ^^ definition local 5
 //          ^^^^^^^^^^ reference 0.1.test `sg/testdata`/TestStruct#
 //                      ^^^^ definition 0.1.test `sg/testdata`/TestStruct#Doer().
 //                      documentation
@@ -200,12 +202,12 @@
 //                      > ```
 //                      documentation
 //                      > Doer is similar to the test interface (but not the same).
-//                           ^^^ definition local 4
-//                               ^^^^^^^ reference github.com/golang/go/src go1.22 context/
+//                           ^^^ definition local 6
+//                               ^^^^^^^ reference local 0
 //                                       ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
-//                                                ^^^^ definition local 5
-//                                                              ^^^^^ definition local 6
-//                                                                         ^^^ definition local 7
+//                                                ^^^^ definition local 7
+//                                                              ^^^^^ definition local 8
+//                                                                         ^^^ definition local 9
    return Score, nil
 //        ^^^^^ reference 0.1.test `sg/testdata`/Score.
   }

--- a/internal/testdata/snapshots/output/testdata/external_composite.go
+++ b/internal/testdata/snapshots/output/testdata/external_composite.go
@@ -3,6 +3,7 @@
   
   import "net/http"
 //        ^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/
+//            ^^^^ definition local 0
   
   type NestedHandler struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/NestedHandler#
@@ -19,7 +20,7 @@
 //     > ```
 //     relationship github.com/golang/go/src go1.22 `net/http`/Handler# implementation
    http.Handler
-// ^^^^ reference github.com/golang/go/src go1.22 `net/http`/
+// ^^^^ reference local 0
 //      ^^^^^^^ definition 0.1.test `sg/testdata`/NestedHandler#Handler.
 //      documentation
 //      > ```go

--- a/internal/testdata/snapshots/output/testdata/external_composite.go
+++ b/internal/testdata/snapshots/output/testdata/external_composite.go
@@ -2,8 +2,8 @@
 //        ^^^^^^^^ definition 0.1.test `sg/testdata`/
   
   import "net/http"
+//        ^^^^^^^^ definition local 0
 //        ^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/
-//            ^^^^ definition local 0
   
   type NestedHandler struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/NestedHandler#

--- a/internal/testdata/snapshots/output/testdata/implementations_embedded.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_embedded.go
@@ -2,6 +2,7 @@
 //        ^^^^^^^^ definition 0.1.test `sg/testdata`/
   
   import "io"
+//        ^^ definition local 0
 //        ^^ reference github.com/golang/go/src go1.22 io/
   
   type I3 interface {
@@ -39,7 +40,7 @@
 //     relationship github.com/golang/go/src go1.22 io/Closer# implementation
 //     relationship 0.1.test `sg/testdata`/I3# implementation
    io.Closer
-// ^^ reference github.com/golang/go/src go1.22 io/
+// ^^ reference local 0
 //    ^^^^^^ definition 0.1.test `sg/testdata`/TClose#Closer.
 //    documentation
 //    > ```go

--- a/internal/testdata/snapshots/output/testdata/implementations_remote.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_remote.go
@@ -2,8 +2,8 @@
 //        ^^^^^^^^ definition 0.1.test `sg/testdata`/
   
   import "net/http"
+//        ^^^^^^^^ definition local 0
 //        ^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/
-//            ^^^^ definition local 0
   
   type implementsWriter struct{}
 //     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/implementsWriter#

--- a/internal/testdata/snapshots/output/testdata/implementations_remote.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_remote.go
@@ -3,6 +3,7 @@
   
   import "net/http"
 //        ^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/
+//            ^^^^ definition local 0
   
   type implementsWriter struct{}
 //     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/implementsWriter#
@@ -28,7 +29,7 @@
 //                        > func (implementsWriter).Header() Header
 //                        > ```
 //                        relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#Header. implementation
-//                                 ^^^^ reference github.com/golang/go/src go1.22 `net/http`/
+//                                 ^^^^ reference local 0
 //                                      ^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/Header#
 //                                                                            ⌃ enclosing_range_end 0.1.test `sg/testdata`/implementsWriter#Header().
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/implementsWriter#Write().
@@ -53,7 +54,7 @@
 //                        > func (implementsWriter).WriteHeader(statusCode int)
 //                        > ```
 //                        relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#WriteHeader. implementation
-//                                    ^^^^^^^^^^ definition local 0
+//                                    ^^^^^^^^^^ definition local 1
 //                                                     ⌃ enclosing_range_end 0.1.test `sg/testdata`/implementsWriter#WriteHeader().
   
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/ShowsInSignature().
@@ -63,11 +64,11 @@
 //     > ```go
 //     > func ShowsInSignature(respWriter ResponseWriter)
 //     > ```
-//                      ^^^^^^^^^^ definition local 1
-//                                 ^^^^ reference github.com/golang/go/src go1.22 `net/http`/
+//                      ^^^^^^^^^^ definition local 2
+//                                 ^^^^ reference local 0
 //                                      ^^^^^^^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/ResponseWriter#
    respWriter.WriteHeader(1)
-// ^^^^^^^^^^ reference local 1
+// ^^^^^^^^^^ reference local 2
 //            ^^^^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/ResponseWriter#WriteHeader.
   }
 //⌃ enclosing_range_end 0.1.test `sg/testdata`/ShowsInSignature().

--- a/internal/testdata/snapshots/output/testdata/parallel.go
+++ b/internal/testdata/snapshots/output/testdata/parallel.go
@@ -3,8 +3,10 @@
   
   import (
    "context"
+//  ^^^^^^^ definition local 0
 //  ^^^^^^^ reference github.com/golang/go/src go1.22 context/
    "sync"
+//  ^^^^ definition local 1
 //  ^^^^ reference github.com/golang/go/src go1.22 sync/
   )
   
@@ -19,8 +21,8 @@
 //     > ```go
 //     > func(ctx Context) error
 //     > ```
-//                             ^^^ definition local 0
-//                                 ^^^^^^^ reference github.com/golang/go/src go1.22 context/
+//                             ^^^ definition local 2
+//                                 ^^^^^^^ reference local 0
 //                                         ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
   
   // Parallel invokes each of the given parallelizable functions in their own goroutines and
@@ -35,51 +37,51 @@
 //     documentation
 //     > Parallel invokes each of the given parallelizable functions in their own goroutines and
 //     > returns the first error to occur. This method will block until all goroutines have returned.
-//              ^^^ definition local 1
-//                  ^^^^^^^ reference github.com/golang/go/src go1.22 context/
+//              ^^^ definition local 3
+//                  ^^^^^^^ reference local 0
 //                          ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
-//                                   ^^^ definition local 2
+//                                   ^^^ definition local 4
 //                                          ^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/ParallelizableFunc#
    var wg sync.WaitGroup
-//     ^^ definition local 3
-//        ^^^^ reference github.com/golang/go/src go1.22 sync/
+//     ^^ definition local 5
+//        ^^^^ reference local 1
 //             ^^^^^^^^^ reference github.com/golang/go/src go1.22 sync/WaitGroup#
    errs := make(chan error, len(fns))
-// ^^^^ definition local 4
-//                              ^^^ reference local 2
+// ^^^^ definition local 6
+//                              ^^^ reference local 4
   
    for _, fn := range fns {
-//        ^^ definition local 5
-//                    ^^^ reference local 2
+//        ^^ definition local 7
+//                    ^^^ reference local 4
     wg.Add(1)
-//  ^^ reference local 3
+//  ^^ reference local 5
 //     ^^^ reference github.com/golang/go/src go1.22 sync/WaitGroup#Add().
   
     go func(fn ParallelizableFunc) {
-//          ^^ definition local 6
+//          ^^ definition local 8
 //             ^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/ParallelizableFunc#
      errs <- fn(ctx)
-//   ^^^^ reference local 4
-//           ^^ reference local 6
-//              ^^^ reference local 1
+//   ^^^^ reference local 6
+//           ^^ reference local 8
+//              ^^^ reference local 3
      wg.Done()
-//   ^^ reference local 3
+//   ^^ reference local 5
 //      ^^^^ reference github.com/golang/go/src go1.22 sync/WaitGroup#Done().
     }(fn)
-//    ^^ reference local 5
+//    ^^ reference local 7
    }
   
    wg.Wait()
-// ^^ reference local 3
+// ^^ reference local 5
 //    ^^^^ reference github.com/golang/go/src go1.22 sync/WaitGroup#Wait().
   
    for err := range errs {
-//     ^^^ definition local 7
-//                  ^^^^ reference local 4
+//     ^^^ definition local 9
+//                  ^^^^ reference local 6
     if err != nil {
-//     ^^^ reference local 7
+//     ^^^ reference local 9
      return err
-//          ^^^ reference local 7
+//          ^^^ reference local 9
     }
    }
   

--- a/internal/testdata/snapshots/output/testdata/typealias.go
+++ b/internal/testdata/snapshots/output/testdata/typealias.go
@@ -3,8 +3,8 @@
   
   import (
    "sg/testdata/internal/secret"
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition local 0
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/
-//                       ^^^^^^ definition local 0
   )
   
   // Type aliased doc

--- a/internal/testdata/snapshots/output/testdata/typealias.go
+++ b/internal/testdata/snapshots/output/testdata/typealias.go
@@ -4,6 +4,7 @@
   import (
    "sg/testdata/internal/secret"
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/
+//                       ^^^^^^ definition local 0
   )
   
   // Type aliased doc
@@ -21,7 +22,7 @@
 //     >     Field int
 //     > }
 //     > ```
-//                    ^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/
+//                    ^^^^^^ reference local 0
 //                           ^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/Burger#
   
   type BadBurger = struct {

--- a/internal/testdata/snapshots/output/testspecial/foo_other_test.go
+++ b/internal/testdata/snapshots/output/testspecial/foo_other_test.go
@@ -3,10 +3,12 @@
   
   import (
    "testing"
+//  ^^^^^^^ definition local 0
 //  ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
   
    "sg/testspecial"
 //  ^^^^^^^^^^^^^^ reference 0.1.test `sg/testspecial`/
+//     ^^^^^^^^^^^ definition local 1
   )
   
 //⌄ enclosing_range_start 0.1.test `sg/testspecial_test`/TestFoo_Blackbox().
@@ -16,9 +18,9 @@
 //     > ```go
 //     > func TestFoo_Blackbox(*T)
 //     > ```
-//                       ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
+//                       ^^^^^^^ reference local 0
 //                               ^ reference github.com/golang/go/src go1.22 testing/T#
-//                                    ^^^^^^^^^^^ reference 0.1.test `sg/testspecial`/
+//                                    ^^^^^^^^^^^ reference local 1
 //                                                ^^^ reference 0.1.test `sg/testspecial`/Foo().
 //                                                      ⌃ enclosing_range_end 0.1.test `sg/testspecial_test`/TestFoo_Blackbox().
   

--- a/internal/testdata/snapshots/output/testspecial/foo_other_test.go
+++ b/internal/testdata/snapshots/output/testspecial/foo_other_test.go
@@ -7,8 +7,8 @@
 //  ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
   
    "sg/testspecial"
+//  ^^^^^^^^^^^^^^ definition local 1
 //  ^^^^^^^^^^^^^^ reference 0.1.test `sg/testspecial`/
-//     ^^^^^^^^^^^ definition local 1
   )
   
 //⌄ enclosing_range_start 0.1.test `sg/testspecial_test`/TestFoo_Blackbox().

--- a/internal/visitors/visitor_file.go
+++ b/internal/visitors/visitor_file.go
@@ -6,7 +6,6 @@ import (
 	"go/token"
 	"go/types"
 	"log/slog"
-	"path"
 	"strings"
 
 	"github.com/scip-code/scip/bindings/go/scip"
@@ -150,15 +149,13 @@ func (v *fileVisitor) Visit(n ast.Node) ast.Visitor {
 			// within this file
 			v.overrides.pkgNameOverride[newtypes.GetID(importedPackage)] = symName
 		} else if implicitObj, ok := v.pkg.TypesInfo.Implicits[node]; ok {
-			// Non-aliased import: emit a local definition for the implicit
-			// package name (last segment of the import path), so that usages
-			// like `modfile.Parse()` resolve to the import line.
+			// Non-aliased import: emit a local definition covering the
+			// entire import path, so that usages like `modfile.Parse()`
+			// resolve to the import line.
 			symName := v.createNewLocalSymbol(node.Path.Pos(), implicitObj)
-			pathPos := v.pkg.Fset.Position(node.Path.Pos())
-			baseName := path.Base(importPath)
-			line := int32(pathPos.Line - 1)
-			col := int32(pathPos.Column-1) + 1 + int32(len(importPath)-len(baseName))
-			v.NewDefinition(symName, []int32{line, col, col + int32(len(baseName))}, nil)
+			defRange := symbols.RangeFromName(
+				v.pkg.Fset.Position(node.Path.Pos()), importPath, true)
+			v.NewDefinition(symName, defRange, nil)
 
 			v.overrides.pkgNameOverride[newtypes.GetID(importedPackage)] = symName
 		}

--- a/internal/visitors/visitor_file.go
+++ b/internal/visitors/visitor_file.go
@@ -131,13 +131,14 @@ func (v *fileVisitor) Visit(n ast.Node) ast.Visitor {
 	switch node := n.(type) {
 	case *ast.ImportSpec:
 		// Generate import references
-		importedPackage := v.pkg.Imports[strings.Trim(node.Path.Value, `"`)]
+		importPath := strings.Trim(node.Path.Value, `"`)
+		importedPackage := v.pkg.Imports[importPath]
 		if importedPackage == nil {
 			slog.Warn("Could not find node", "node.Path", node.Path)
 			return nil
 		}
 
-		if node.Name != nil && node.Name.Name != "." {
+		if node.Name != nil && node.Name.Name != "." && node.Name.Name != "_" {
 			// Aliased import: emit a local definition for the alias
 			pkgAlias := v.pkg.TypesInfo.Defs[node.Name]
 			symName := v.createNewLocalSymbol(node.Name.Pos(), pkgAlias)
@@ -150,12 +151,13 @@ func (v *fileVisitor) Visit(n ast.Node) ast.Visitor {
 			v.overrides.pkgNameOverride[newtypes.GetID(importedPackage)] = symName
 		} else if implicitObj, ok := v.pkg.TypesInfo.Implicits[node]; ok {
 			// Non-aliased import: emit a local definition for the implicit
-			// package name (last segment of the import path)
+			// package name (last segment of the import path), so that usages
+			// like `modfile.Parse()` resolve to the import line.
 			symName := v.createNewLocalSymbol(node.Path.Pos(), implicitObj)
 			pathPos := v.pkg.Fset.Position(node.Path.Pos())
-			baseName := path.Base(importedPackage.PkgPath)
+			baseName := path.Base(importPath)
 			line := int32(pathPos.Line - 1)
-			col := int32(pathPos.Column-1) + 1 + int32(len(importedPackage.PkgPath)-len(baseName))
+			col := int32(pathPos.Column-1) + 1 + int32(len(importPath)-len(baseName))
 			v.NewDefinition(symName, []int32{line, col, col + int32(len(baseName))}, nil)
 
 			v.overrides.pkgNameOverride[newtypes.GetID(importedPackage)] = symName

--- a/internal/visitors/visitor_file.go
+++ b/internal/visitors/visitor_file.go
@@ -149,9 +149,7 @@ func (v *fileVisitor) Visit(n ast.Node) ast.Visitor {
 			// within this file
 			v.overrides.pkgNameOverride[newtypes.GetID(importedPackage)] = symName
 		} else if implicitObj, ok := v.pkg.TypesInfo.Implicits[node]; ok {
-			// Non-aliased import: emit a local definition covering the
-			// entire import path, so that usages like `modfile.Parse()`
-			// resolve to the import line.
+			// Non-aliased import: emit a local definition for the entire import path
 			symName := v.createNewLocalSymbol(node.Path.Pos(), implicitObj)
 			defRange := symbols.RangeFromName(
 				v.pkg.Fset.Position(node.Path.Pos()), importPath, true)

--- a/internal/visitors/visitor_file.go
+++ b/internal/visitors/visitor_file.go
@@ -6,6 +6,7 @@ import (
 	"go/token"
 	"go/types"
 	"log/slog"
+	"path"
 	"strings"
 
 	"github.com/scip-code/scip/bindings/go/scip"
@@ -137,6 +138,7 @@ func (v *fileVisitor) Visit(n ast.Node) ast.Visitor {
 		}
 
 		if node.Name != nil && node.Name.Name != "." {
+			// Aliased import: emit a local definition for the alias
 			pkgAlias := v.pkg.TypesInfo.Defs[node.Name]
 			symName := v.createNewLocalSymbol(node.Name.Pos(), pkgAlias)
 			rangeFromName := symbols.RangeFromName(
@@ -145,6 +147,17 @@ func (v *fileVisitor) Visit(n ast.Node) ast.Visitor {
 
 			// Save package name override, so that we use the new local symbol
 			// within this file
+			v.overrides.pkgNameOverride[newtypes.GetID(importedPackage)] = symName
+		} else if implicitObj, ok := v.pkg.TypesInfo.Implicits[node]; ok {
+			// Non-aliased import: emit a local definition for the implicit
+			// package name (last segment of the import path)
+			symName := v.createNewLocalSymbol(node.Path.Pos(), implicitObj)
+			pathPos := v.pkg.Fset.Position(node.Path.Pos())
+			baseName := path.Base(importedPackage.PkgPath)
+			line := int32(pathPos.Line - 1)
+			col := int32(pathPos.Column-1) + 1 + int32(len(importedPackage.PkgPath)-len(baseName))
+			v.NewDefinition(symName, []int32{line, col, col + int32(len(baseName))}, nil)
+
 			v.overrides.pkgNameOverride[newtypes.GetID(importedPackage)] = symName
 		}
 


### PR DESCRIPTION
For non-aliased imports, emit a local definition on the package name (last segment of the import path), matching the behavior that aliased imports already have. This ensures that usages like modfile.Parse() resolve to the import line rather than the dependency's package declaration.

Fixes #34.