### PR TITLE
Resolve import aliases as global references instead of local definitions

### DIFF
--- a/internal/testdata/snapshots/input/pr201/README.md
+++ b/internal/testdata/snapshots/input/pr201/README.md
@@ -1,0 +1,23 @@
+# pr201 --- Import alias resolution
+
+This test covers import alias handling introduced in PR #201, addressing [#34].
+
+Import aliases are resolved as **global references** to the original package
+symbol rather than local definitions. This means:
+
+- `h` in `import h "net/http"` emits a reference to `net/http`, not a local
+  definition.
+- All subsequent usages of `h` (e.g., `h.StatusOK`) also reference `net/http`
+  directly.
+- A "Find references" lookup on the original `package http` statement returns
+  every individual usage site, not just the import line.
+
+This applies consistently to all aliased imports: same-name aliases, renamed
+aliases, and aliases used across multiple files in the same package.
+
+While this approach differs from gopls, which treats import aliases as local
+definitions, SCIP is a protocol serving a greater number of languages. Resolving
+aliases as global references is a more universal approach --- it matches how
+most languages treat imports and ensures consistent cross-language behavior.
+
+  [#34]: https://github.com/sourcegraph/scip-go/issues/34

--- a/internal/testdata/snapshots/input/pr201/go.mod
+++ b/internal/testdata/snapshots/input/pr201/go.mod
@@ -1,0 +1,3 @@
+module sg/pr201
+
+go 1.23

--- a/internal/testdata/snapshots/input/pr201/imports.go
+++ b/internal/testdata/snapshots/input/pr201/imports.go
@@ -1,0 +1,20 @@
+package pr201
+
+import (
+	"context"
+	"net/http"
+
+	_ "embed"
+
+	. "strings"
+
+	fmt "fmt"
+	h "net/http"
+)
+
+func UseImports() {
+	fmt.Println(context.Background())
+	_ = http.StatusOK
+	_ = h.DefaultClient
+	_ = Contains("hello", "ell")
+}

--- a/internal/testdata/snapshots/output/pr201/imports.go
+++ b/internal/testdata/snapshots/output/pr201/imports.go
@@ -1,0 +1,46 @@
+  package pr201
+//        ^^^^^ definition 0.1.test `sg/pr201`/
+  
+  import (
+   "context"
+//  ^^^^^^^ reference github.com/golang/go/src go1.22 context/
+   "net/http"
+//  ^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/
+  
+   _ "embed"
+//    ^^^^^ reference github.com/golang/go/src go1.22 embed/
+  
+   . "strings"
+//    ^^^^^^^ reference github.com/golang/go/src go1.22 strings/
+  
+   fmt "fmt"
+// ^^^ reference github.com/golang/go/src go1.22 fmt/
+//      ^^^ reference github.com/golang/go/src go1.22 fmt/
+   h "net/http"
+// ^ reference github.com/golang/go/src go1.22 `net/http`/
+//    ^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/
+  )
+  
+//⌄ enclosing_range_start 0.1.test `sg/pr201`/UseImports().
+  func UseImports() {
+//     ^^^^^^^^^^ definition 0.1.test `sg/pr201`/UseImports().
+//     documentation
+//     > ```go
+//     > func UseImports()
+//     > ```
+   fmt.Println(context.Background())
+// ^^^ reference github.com/golang/go/src go1.22 fmt/
+//     ^^^^^^^ reference github.com/golang/go/src go1.22 fmt/Println().
+//             ^^^^^^^ reference github.com/golang/go/src go1.22 context/
+//                     ^^^^^^^^^^ reference github.com/golang/go/src go1.22 context/Background().
+   _ = http.StatusOK
+//     ^^^^ reference github.com/golang/go/src go1.22 `net/http`/
+//          ^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/StatusOK.
+   _ = h.DefaultClient
+//     ^ reference github.com/golang/go/src go1.22 `net/http`/
+//       ^^^^^^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/DefaultClient.
+   _ = Contains("hello", "ell")
+//     ^^^^^^^^ reference github.com/golang/go/src go1.22 strings/Contains().
+  }
+//⌃ enclosing_range_end 0.1.test `sg/pr201`/UseImports().
+  

--- a/internal/testdata/snapshots/output/replace-directives/replace_directives.go
+++ b/internal/testdata/snapshots/output/replace-directives/replace_directives.go
@@ -6,7 +6,7 @@
 //  ^^^ reference github.com/golang/go/src go1.22 fmt/
   
    replaced "github.com/example/original"
-// ^^^^^^^^ definition local 0
+// ^^^^^^^^ reference github.com/example/replaced 0.1.test `github.com/example/original`/
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference github.com/example/replaced 0.1.test `github.com/example/original`/
   )
   
@@ -20,7 +20,7 @@
    fmt.Println(replaced.DefaultConfig)
 // ^^^ reference github.com/golang/go/src go1.22 fmt/
 //     ^^^^^^^ reference github.com/golang/go/src go1.22 fmt/Println().
-//             ^^^^^^^^ reference local 0
+//             ^^^^^^^^ reference github.com/example/replaced 0.1.test `github.com/example/original`/
 //                      ^^^^^^^^^^^^^ reference github.com/example/replaced 0.1.test `github.com/example/original`/DefaultConfig.
   }
 //⌃ enclosing_range_end 0.1.test `sg/replace-directives`/Something().

--- a/internal/testdata/snapshots/output/testdata/named_import.go
+++ b/internal/testdata/snapshots/output/testdata/named_import.go
@@ -5,7 +5,7 @@
    . "fmt"
 //    ^^^ reference github.com/golang/go/src go1.22 fmt/
    h "net/http"
-// ^ definition local 0
+// ^ reference github.com/golang/go/src go1.22 `net/http`/
 //    ^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/
   )
   
@@ -18,7 +18,7 @@
 //     > ```
    Println(h.CanonicalHeaderKey("accept-encoding"))
 // ^^^^^^^ reference github.com/golang/go/src go1.22 fmt/Println().
-//         ^ reference local 0
+//         ^ reference github.com/golang/go/src go1.22 `net/http`/
 //           ^^^^^^^^^^^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/CanonicalHeaderKey().
   }
 //⌃ enclosing_range_end 0.1.test `sg/testdata`/Example().

--- a/internal/visitors/visitor_file.go
+++ b/internal/visitors/visitor_file.go
@@ -52,11 +52,9 @@ func NewFileVisitor(
 		globalSymbols: globalSymbols,
 		occurrences:   occurrences,
 		overrides: struct {
-			caseClauses     map[token.Pos]types.Object
-			pkgNameOverride map[newtypes.PackageID]string
+			caseClauses map[token.Pos]types.Object
 		}{
-			caseClauses:     caseClauses,
-			pkgNameOverride: map[newtypes.PackageID]string{},
+			caseClauses: caseClauses,
 		},
 		enclosingNodeMap: enclosingNodeMap(file),
 	}
@@ -93,10 +91,6 @@ type fileVisitor struct {
 	overrides struct {
 		// Case clauses have to map particular positions to different types
 		caseClauses map[token.Pos]types.Object
-
-		// maps tokens for package declaration to a local var,
-		// if ImportSpec.Name is not nil. Otherwise, just use package directly
-		pkgNameOverride map[newtypes.PackageID]string
 	}
 
 	// enclosingNodeMap maps certain nodes to their enclosing nodes for
@@ -136,16 +130,17 @@ func (v *fileVisitor) Visit(n ast.Node) ast.Visitor {
 			return nil
 		}
 
-		if node.Name != nil && node.Name.Name != "." {
-			pkgAlias := v.pkg.TypesInfo.Defs[node.Name]
-			symName := v.createNewLocalSymbol(node.Name.Pos(), pkgAlias)
+		if node.Name != nil && node.Name.Name != "." && node.Name.Name != "_" {
+			// Aliased import: emit a reference to the global package symbol
+			// for the alias name (Option A - pierce the veil)
 			rangeFromName := symbols.RangeFromName(
 				v.pkg.Fset.Position(node.Name.Pos()), node.Name.Name, false)
-			v.NewDefinition(symName, rangeFromName, nil)
-
-			// Save package name override, so that we use the new local symbol
-			// within this file
-			v.overrides.pkgNameOverride[newtypes.GetID(importedPackage)] = symName
+			if rangeFromName != nil {
+				sym, ok := v.globalSymbols.GetPkgSymbol(importedPackage)
+				if ok {
+					v.AppendSymbolReference(sym, rangeFromName, nil)
+				}
+			}
 		}
 
 		position := v.pkg.Fset.Position(node.Path.Pos())
@@ -163,22 +158,14 @@ func (v *fileVisitor) Visit(n ast.Node) ast.Visitor {
 			case *types.PkgName:
 				startPosition := v.pkg.Fset.Position(ident.Pos())
 				endPosition := v.pkg.Fset.Position(ident.End())
-				pkgID := newtypes.GetFromTypesPackage(sel.Imported())
 
-				var symbolName string
-				if overrideSymbol, ok := v.overrides.pkgNameOverride[pkgID]; ok {
-					symbolName = overrideSymbol
-				} else {
-					sym, ok := v.globalSymbols.GetPkgSymbolByID(pkgID)
-					if !ok {
-						slog.Debug(fmt.Sprintf("Missing symbol for package: %s", sel.Imported().Path()))
-						return nil
-					}
-
-					symbolName = sym
+				sym, ok := v.globalSymbols.GetPkgSymbolByID(newtypes.GetFromTypesPackage(sel.Imported()))
+				if !ok {
+					slog.Debug(fmt.Sprintf("Missing symbol for package: %s", sel.Imported().Path()))
+					return nil
 				}
 
-				v.AppendSymbolReference(symbolName, scipRange(startPosition, endPosition, sel), nil)
+				v.AppendSymbolReference(sym, scipRange(startPosition, endPosition, sel), nil)
 
 				// Then walk the selection
 				ast.Walk(v, node.Sel)

--- a/internal/visitors/visitor_file.go
+++ b/internal/visitors/visitor_file.go
@@ -43,19 +43,15 @@ func NewFileVisitor(
 	}
 
 	return &fileVisitor{
-		doc:           doc,
-		pkg:           pkg,
-		file:          file,
-		pkgLookup:     pkgLookup,
-		locals:        map[token.Pos]lookup.Local{},
-		pkgSymbols:    pkgSymbols,
-		globalSymbols: globalSymbols,
-		occurrences:   occurrences,
-		overrides: struct {
-			caseClauses map[token.Pos]types.Object
-		}{
-			caseClauses: caseClauses,
-		},
+		doc:              doc,
+		pkg:              pkg,
+		file:             file,
+		pkgLookup:        pkgLookup,
+		locals:           map[token.Pos]lookup.Local{},
+		pkgSymbols:       pkgSymbols,
+		globalSymbols:    globalSymbols,
+		occurrences:      occurrences,
+		caseClauses:      caseClauses,
 		enclosingNodeMap: enclosingNodeMap(file),
 	}
 }
@@ -87,11 +83,8 @@ type fileVisitor struct {
 	// occurrences in this file
 	occurrences []*scip.Occurrence
 
-	// Overriding Definition Behvaior:
-	overrides struct {
-		// Case clauses have to map particular positions to different types
-		caseClauses map[token.Pos]types.Object
-	}
+	// caseClauses maps particular positions to different types for case clauses
+	caseClauses map[token.Pos]types.Object
 
 	// enclosingNodeMap maps certain nodes to their enclosing nodes for
 	// enclosing range computation.
@@ -131,13 +124,10 @@ func (v *fileVisitor) Visit(n ast.Node) ast.Visitor {
 		}
 
 		if node.Name != nil && node.Name.Name != "." && node.Name.Name != "_" {
-			// Aliased import: emit a reference to the global package symbol
-			// for the alias name (Option A - pierce the veil)
 			rangeFromName := symbols.RangeFromName(
 				v.pkg.Fset.Position(node.Name.Pos()), node.Name.Name, false)
 			if rangeFromName != nil {
-				sym, ok := v.globalSymbols.GetPkgSymbol(importedPackage)
-				if ok {
+				if sym, ok := v.globalSymbols.GetPkgSymbol(importedPackage); ok {
 					v.AppendSymbolReference(sym, rangeFromName, nil)
 				}
 			}
@@ -159,13 +149,16 @@ func (v *fileVisitor) Visit(n ast.Node) ast.Visitor {
 				startPosition := v.pkg.Fset.Position(ident.Pos())
 				endPosition := v.pkg.Fset.Position(ident.End())
 
-				sym, ok := v.globalSymbols.GetPkgSymbolByID(newtypes.GetFromTypesPackage(sel.Imported()))
+				packageID := newtypes.GetFromTypesPackage(sel.Imported())
+				sym, ok := v.globalSymbols.GetPkgSymbolByID(packageID)
 				if !ok {
-					slog.Debug(fmt.Sprintf("Missing symbol for package: %s", sel.Imported().Path()))
+					slog.Debug(fmt.Sprintf(
+						"Missing symbol for package: %s", sel.Imported().Path()))
 					return nil
 				}
 
-				v.AppendSymbolReference(sym, scipRange(startPosition, endPosition, sel), nil)
+				symRange := scipRange(startPosition, endPosition, sel)
+				v.AppendSymbolReference(sym, symRange, nil)
 
 				// Then walk the selection
 				ast.Walk(v, node.Sel)
@@ -196,7 +189,7 @@ func (v *fileVisitor) Visit(n ast.Node) ast.Visitor {
 		endPosition := v.pkg.Fset.Position(node.End())
 
 		// Short circuit on case clauses
-		if obj, ok := v.overrides.caseClauses[node.Pos()]; ok {
+		if obj, ok := v.caseClauses[node.Pos()]; ok {
 			symName := v.createNewLocalSymbol(obj.Pos(), obj)
 			v.NewDefinition(symName, scipRange(startPosition, endPosition, obj), nil)
 			return nil
@@ -230,7 +223,7 @@ func (v *fileVisitor) Visit(n ast.Node) ast.Visitor {
 			if localSymbol, ok := v.locals[ref.Pos()]; ok {
 				symbol = localSymbol.Symbol
 
-				if _, ok := v.overrides.caseClauses[ref.Pos()]; ok {
+				if _, ok := v.caseClauses[ref.Pos()]; ok {
 					overrideType = v.pkg.TypesInfo.TypeOf(node)
 				}
 			} else {


### PR DESCRIPTION
For more context see: https://github.com/sourcegraph/scip-go/pull/197#discussion_r3052643988. Fixes https://github.com/sourcegraph/scip-go/issues/34.