### PR TITLE
Show full type declaration in hover docs

### DIFF
--- a/internal/document/document.go
+++ b/internal/document/document.go
@@ -193,25 +193,26 @@ func formatTypeDeclaration(obj *types.TypeName) string {
 	return fmt.Sprintf("type %s %s", obj.Name(), expandTypeExpr(obj.Type().Underlying()))
 }
 
+// qualifiedName returns the name of original, prefixed with its package name
+// if it differs from obj's package. Handles nil packages (builtins).
+func qualifiedName(obj, original types.Object) string {
+	objPkg := obj.Pkg()
+	origPkg := original.Pkg()
+	if objPkg == nil || origPkg == nil || objPkg.Name() == origPkg.Name() {
+		return original.Name()
+	}
+	return origPkg.Name() + "." + original.Name()
+}
+
 // formatAliasDeclaration returns the type declaration for alias types.
 func formatAliasDeclaration(obj *types.TypeName) string {
 	switch ty := obj.Type().(type) {
 	case *types.Alias:
 		switch rhs := ty.Rhs().(type) {
 		case *types.Alias:
-			original := rhs.Obj()
-			var pkg string
-			if obj.Pkg().Name() != original.Pkg().Name() {
-				pkg = original.Pkg().Name() + "."
-			}
-			return fmt.Sprintf("type %s = %s%s", obj.Name(), pkg, original.Name())
+			return fmt.Sprintf("type %s = %s", obj.Name(), qualifiedName(obj, rhs.Obj()))
 		case *types.Named:
-			original := rhs.Obj()
-			var pkg string
-			if obj.Pkg().Name() != original.Pkg().Name() {
-				pkg = original.Pkg().Name() + "."
-			}
-			return fmt.Sprintf("type %s = %s%s", obj.Name(), pkg, original.Name())
+			return fmt.Sprintf("type %s = %s", obj.Name(), qualifiedName(obj, rhs.Obj()))
 		default:
 			return fmt.Sprintf("type %s = %s", obj.Name(), expandTypeExpr(rhs))
 		}

--- a/internal/document/document.go
+++ b/internal/document/document.go
@@ -94,11 +94,7 @@ func (d *Document) SetNewSymbolForPos(
 	var sigDoc *scip.Document
 	if ident != nil {
 		if def := d.pkg.TypesInfo.Defs[ident]; def != nil {
-			signature, extra := typeStringForObject(def)
-			if signature != "" {
-				if extra != "" {
-					signature += "\n" + extra
-				}
+			if signature := typeStringForObject(def); signature != "" {
 				sigDoc = &scip.Document{
 					Language: "go",
 					Text:     signature,
@@ -164,115 +160,111 @@ func (d *Document) extractHoverText(parent ast.Node, node ast.Node) string {
 // name from all identifiers in the return value of types.ObjectString.
 func packageQualifier(*types.Package) string { return "" }
 
-func typeStringForObject(obj types.Object) (signature string, extra string) {
+func typeStringForObject(obj types.Object) string {
 	switch v := obj.(type) {
 	case *types.PkgName:
-		return fmt.Sprintf("package %s", v.Name()), ""
+		return fmt.Sprintf("package %s", v.Name())
 
 	case *types.TypeName:
-		return formatTypeSignature(v), formatTypeExtra(v)
+		return formatTypeDeclaration(v)
 
 	case *types.Var:
 		if v.IsField() {
 			// TODO(tjdevries) - make this be "(T).F" instead of "struct field F string"
-			return fmt.Sprintf("struct %s", quotedTagsToBacktick(obj.String())), ""
+			return fmt.Sprintf("struct %s", quotedTagsToBacktick(obj.String()))
 		}
 
 	case *types.Const:
-		return fmt.Sprintf("%s = %s", types.ObjectString(v, packageQualifier), v.Val()), ""
-		// TODO: We had this case in previous iterations
-		// case *PkgDeclaration:
-		// 	return fmt.Sprintf("package %s", v.name), ""
+		return fmt.Sprintf("%s = %s", types.ObjectString(v, packageQualifier), v.Val())
 	}
 
-	// Fall back to types.Object
-	//    All other cases of this should be this type. We only had to implement PkgDeclaration because
-	//    some fields are not exported in types.Object.
-	return types.ObjectString(obj, packageQualifier), ""
+	return types.ObjectString(obj, packageQualifier)
 }
 
 var loggedGODEBUGWarning sync.Once
 
-// formatTypeSignature returns a brief description of the given struct or interface type.
-func formatTypeSignature(obj *types.TypeName) string {
-	switch obj.Type().Underlying().(type) {
-	case *types.Struct:
-		if obj.IsAlias() {
-			switch ty := obj.Type().(type) {
-			case *types.Alias:
-				switch rhs := ty.Rhs().(type) {
-				case *types.Alias:
-					original := rhs.Obj()
-					var pkg string
-					if obj.Pkg().Name() != original.Pkg().Name() {
-						pkg = original.Pkg().Name() + "."
-					}
-					return fmt.Sprintf("type %s = %s%s", obj.Name(), pkg, original.Name())
-				case *types.Named:
-					original := rhs.Obj()
-					var pkg string
-					if obj.Pkg().Name() != original.Pkg().Name() {
-						pkg = original.Pkg().Name() + "."
-					}
-					return fmt.Sprintf("type %s = %s%s", obj.Name(), pkg, original.Name())
-				case *types.Struct:
-					return fmt.Sprintf("type %s = struct", obj.Name())
-				}
-			default:
-				if val := os.Getenv("GODEBUG"); strings.Contains(val, "gotypealias=0") {
-					loggedGODEBUGWarning.Do(func() {
-						slog.Warn("Running with GODEBUG=gotypealias=0, this may cause incorrect hover docs")
-					})
-				} else {
-					slog.Warn("IsAlias() is true but Type() is not Alias; please report this as a bug",
-						"obj", obj.String(), "obj.Type()", ty.String())
-				}
-			}
-		}
-
-		return fmt.Sprintf("type %s struct", obj.Name())
-	case *types.Interface:
-		return fmt.Sprintf("type %s interface", obj.Name())
+// formatTypeDeclaration returns the full type declaration string for a type,
+// e.g. "type T struct{}", "type I interface { ... }", "type U = T", "type Z int32".
+func formatTypeDeclaration(obj *types.TypeName) string {
+	if obj.IsAlias() {
+		return formatAliasDeclaration(obj)
 	}
 
-	return fmt.Sprintf(
-		"type %s %s",
-		obj.Name(), types.TypeString(obj.Type().Underlying(), packageQualifier))
+	return fmt.Sprintf("type %s %s", obj.Name(), expandTypeExpr(obj.Type().Underlying()))
 }
 
-// formatTypeExtra returns the beautified fields of the given struct or interface type.
-//
-// The output of `types.TypeString` puts fields of structs and interfaces on a single
-// line separated by a semicolon. This method simply expands the fields to reside on
-// different lines with the appropriate indentation.
-func formatTypeExtra(obj *types.TypeName) string {
-	switch obj.Type().Underlying().(type) {
-	case *types.Struct, *types.Interface:
-		// Only show extra details for struct/interface types,
-		// where we expand fields across multiple lines.
+// formatAliasDeclaration returns the type declaration for alias types.
+func formatAliasDeclaration(obj *types.TypeName) string {
+	switch ty := obj.Type().(type) {
+	case *types.Alias:
+		switch rhs := ty.Rhs().(type) {
+		case *types.Alias:
+			original := rhs.Obj()
+			var pkg string
+			if obj.Pkg().Name() != original.Pkg().Name() {
+				pkg = original.Pkg().Name() + "."
+			}
+			return fmt.Sprintf("type %s = %s%s", obj.Name(), pkg, original.Name())
+		case *types.Named:
+			original := rhs.Obj()
+			var pkg string
+			if obj.Pkg().Name() != original.Pkg().Name() {
+				pkg = original.Pkg().Name() + "."
+			}
+			return fmt.Sprintf("type %s = %s%s", obj.Name(), pkg, original.Name())
+		default:
+			return fmt.Sprintf("type %s = %s", obj.Name(), expandTypeExpr(rhs))
+		}
 	default:
-		return ""
+		if val := os.Getenv("GODEBUG"); strings.Contains(val, "gotypealias=0") {
+			loggedGODEBUGWarning.Do(func() {
+				slog.Warn(
+					"Running with GODEBUG=gotypealias=0, this may cause incorrect hover docs")
+			})
+		} else {
+			slog.Warn(
+				"IsAlias() is true but Type() is not Alias; please report this as a bug",
+				"obj", obj.String(), "obj.Type()", ty.String())
+		}
 	}
 
-	extra := types.TypeString(obj.Type().Underlying(), packageQualifier)
+	// Fallback for when GODEBUG=gotypealias=0 or unexpected types.
+	return fmt.Sprintf("type %s %s", obj.Name(), expandTypeExpr(obj.Type().Underlying()))
+}
 
+// expandTypeExpr renders a type expression, expanding struct and interface
+// fields across multiple lines for readability.
+func expandTypeExpr(t types.Type) string {
+	raw := types.TypeString(t, packageQualifier)
+
+	switch t.(type) {
+	case *types.Struct, *types.Interface:
+		return beautifyTypeExpr(raw)
+	default:
+		return raw
+	}
+}
+
+// beautifyTypeExpr expands semicolon-separated fields in a struct or interface
+// type string onto separate indented lines.
+func beautifyTypeExpr(raw string) string {
 	depth := 0
-	buf := bytes.NewBuffer(make([]byte, 0, len(extra)))
+	buf := bytes.NewBuffer(make([]byte, 0, len(raw)))
 
 outer:
-	for i := 0; i < len(extra); i++ {
-		switch extra[i] {
+	for i := 0; i < len(raw); i++ {
+		switch raw[i] {
 		case '"':
-			for j := i + 1; j < len(extra); j++ {
-				if extra[j] == '\\' {
+			for j := i + 1; j < len(raw); j++ {
+				if raw[j] == '\\' {
 					// skip over escaped characters
 					j++
 					continue
 				}
 
-				if extra[j] == '"' {
+				if raw[j] == '"' {
 					// found non-escaped ending quote
-					quoted := extra[i : j+1]
+					quoted := raw[i : j+1]
 					if unquoted, err := strconv.Unquote(quoted); err == nil {
 						buf.WriteByte('`')
 						buf.WriteString(unquoted)
@@ -296,7 +288,7 @@ outer:
 		case '{':
 			// Special case empty fields so we don't insert
 			// an unnecessary newline.
-			if i < len(extra)-1 && extra[i+1] == '}' {
+			if i < len(raw)-1 && raw[i+1] == '}' {
 				buf.WriteString("{}")
 				i++ // Skip following '}'
 			} else {
@@ -312,7 +304,7 @@ outer:
 			buf.WriteString("}")
 
 		default:
-			buf.WriteByte(extra[i])
+			buf.WriteByte(raw[i])
 		}
 	}
 

--- a/internal/document/document.go
+++ b/internal/document/document.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/scip-code/scip/bindings/go/scip"
 	"github.com/sourcegraph/scip-go/internal/lookup"
-	"github.com/sourcegraph/scip-go/internal/symbols"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -91,7 +90,8 @@ func (d *Document) SetNewSymbolForPos(
 	ident *ast.Ident,
 	pos token.Pos,
 ) {
-	documentation := []string{}
+	var documentation []string
+	var sigDoc *scip.Document
 	if ident != nil {
 		hover := d.extractHoverText(parent, ident)
 		var signature, extra string
@@ -101,20 +101,24 @@ func (d *Document) SetNewSymbolForPos(
 		}
 
 		if signature != "" {
-			documentation = append(documentation, symbols.FormatCode(signature))
+			if extra != "" {
+				signature += "\n" + extra
+			}
+			sigDoc = &scip.Document{
+				Language: "go",
+				Text:     signature,
+			}
 		}
 		if hover != "" {
 			documentation = append(documentation, hover)
 		}
-		if extra != "" {
-			documentation = append(documentation, symbols.FormatCode(extra))
-		}
 	}
 
 	d.pkgSymbols.Set(pos, &scip.SymbolInformation{
-		Symbol:        symbol,
-		Documentation: documentation,
-		Relationships: []*scip.Relationship{},
+		Symbol:                 symbol,
+		Documentation:          documentation,
+		SignatureDocumentation: sigDoc,
+		Relationships:          []*scip.Relationship{},
 	})
 }
 
@@ -236,7 +240,7 @@ func formatTypeSignature(obj *types.TypeName) string {
 		return fmt.Sprintf("type %s interface", obj.Name())
 	}
 
-	return ""
+	return fmt.Sprintf("type %s %s", obj.Name(), types.TypeString(obj.Type().Underlying(), packageQualifier))
 }
 
 // formatTypeExtra returns the beautified fields of the given struct or interface type.
@@ -245,6 +249,14 @@ func formatTypeSignature(obj *types.TypeName) string {
 // line separated by a semicolon. This method simply expands the fields to reside on
 // different lines with the appropriate indentation.
 func formatTypeExtra(obj *types.TypeName) string {
+	switch obj.Type().Underlying().(type) {
+	case *types.Struct, *types.Interface:
+		// Only show extra details for struct/interface types,
+		// where we expand fields across multiple lines.
+	default:
+		return ""
+	}
+
 	extra := types.TypeString(obj.Type().Underlying(), packageQualifier)
 
 	depth := 0

--- a/internal/document/document.go
+++ b/internal/document/document.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/doc"
+	"go/format"
 	"go/token"
 	"go/types"
 	"log/slog"
@@ -233,83 +234,33 @@ func formatAliasDeclaration(obj *types.TypeName) string {
 	return fmt.Sprintf("type %s %s", obj.Name(), expandTypeExpr(obj.Type().Underlying()))
 }
 
-// expandTypeExpr renders a type expression, expanding struct and interface
-// fields across multiple lines for readability.
+// expandTypeExpr renders a type expression, formatting struct and interface
+// types with aligned fields using go/format.
 func expandTypeExpr(t types.Type) string {
 	raw := types.TypeString(t, packageQualifier)
 
 	switch t.(type) {
 	case *types.Struct, *types.Interface:
-		return beautifyTypeExpr(raw)
-	default:
-		return raw
-	}
-}
-
-// beautifyTypeExpr expands semicolon-separated fields in a struct or interface
-// type string onto separate indented lines.
-func beautifyTypeExpr(raw string) string {
-	depth := 0
-	buf := bytes.NewBuffer(make([]byte, 0, len(raw)))
-
-outer:
-	for i := 0; i < len(raw); i++ {
-		switch raw[i] {
-		case '"':
-			for j := i + 1; j < len(raw); j++ {
-				if raw[j] == '\\' {
-					// skip over escaped characters
-					j++
-					continue
-				}
-
-				if raw[j] == '"' {
-					// found non-escaped ending quote
-					quoted := raw[i : j+1]
-					if unquoted, err := strconv.Unquote(quoted); err == nil {
-						buf.WriteByte('`')
-						buf.WriteString(unquoted)
-						buf.WriteByte('`')
-					} else {
-						buf.WriteString(quoted)
-					}
-					i = j
-					continue outer
-				}
-			}
-
-			// note: we should never get down here otherwise
-			// there is some illegal output from types.TypeString.
-
-		case ';':
-			buf.WriteString("\n")
-			buf.WriteString(strings.Repeat(indent, depth))
-			i++ // Skip following ' '
-
-		case '{':
-			// Special case empty fields so we don't insert
-			// an unnecessary newline.
-			if i < len(raw)-1 && raw[i+1] == '}' {
-				buf.WriteString("{}")
-				i++ // Skip following '}'
-			} else {
-				depth++
-				buf.WriteString(" {\n")
-				buf.WriteString(strings.Repeat(indent, depth))
-			}
-
-		case '}':
-			depth--
-			buf.WriteString("\n")
-			buf.WriteString(strings.Repeat(indent, depth))
-			buf.WriteString("}")
-
-		default:
-			buf.WriteByte(raw[i])
+		if formatted, err := formatGoDecl("type _ " + raw); err == nil {
+			return strings.TrimPrefix(formatted, "type _ ")
 		}
 	}
 
-	return buf.String()
+	return raw
+}
+
+// formatGoDecl formats a Go type declaration using go/format, returning
+// the formatted result with tabs replaced by spaces.
+func formatGoDecl(decl string) (string, error) {
+	src := "package p\n\n" + decl + "\n"
+	formatted, err := format.Source([]byte(src))
+	if err != nil {
+		return "", err
+	}
+	result := strings.TrimPrefix(string(formatted), "package p\n\n")
+	result = strings.TrimSpace(result)
+	result = strings.ReplaceAll(result, "\t", indent)
+	return result, nil
 }
 
 // quotedTagsToBacktick replaces double-quoted struct tag strings with

--- a/internal/document/document.go
+++ b/internal/document/document.go
@@ -93,23 +93,19 @@ func (d *Document) SetNewSymbolForPos(
 	var documentation []string
 	var sigDoc *scip.Document
 	if ident != nil {
-		hover := d.extractHoverText(parent, ident)
-		var signature, extra string
-		def := d.pkg.TypesInfo.Defs[ident]
-		if def != nil {
-			signature, extra = typeStringForObject(def)
-		}
-
-		if signature != "" {
-			if extra != "" {
-				signature += "\n" + extra
-			}
-			sigDoc = &scip.Document{
-				Language: "go",
-				Text:     signature,
+		if def := d.pkg.TypesInfo.Defs[ident]; def != nil {
+			signature, extra := typeStringForObject(def)
+			if signature != "" {
+				if extra != "" {
+					signature += "\n" + extra
+				}
+				sigDoc = &scip.Document{
+					Language: "go",
+					Text:     signature,
+				}
 			}
 		}
-		if hover != "" {
+		if hover := d.extractHoverText(parent, ident); hover != "" {
 			documentation = append(documentation, hover)
 		}
 	}
@@ -232,7 +228,6 @@ func formatTypeSignature(obj *types.TypeName) string {
 						"obj", obj.String(), "obj.Type()", ty.String())
 				}
 			}
-
 		}
 
 		return fmt.Sprintf("type %s struct", obj.Name())
@@ -240,7 +235,9 @@ func formatTypeSignature(obj *types.TypeName) string {
 		return fmt.Sprintf("type %s interface", obj.Name())
 	}
 
-	return fmt.Sprintf("type %s %s", obj.Name(), types.TypeString(obj.Type().Underlying(), packageQualifier))
+	return fmt.Sprintf(
+		"type %s %s",
+		obj.Name(), types.TypeString(obj.Type().Underlying(), packageQualifier))
 }
 
 // formatTypeExtra returns the beautified fields of the given struct or interface type.

--- a/internal/lookup/local.go
+++ b/internal/lookup/local.go
@@ -39,7 +39,9 @@ func (l *Local) SignatureText() string {
 		}
 	} else {
 		if t := l.Obj.Type(); t != nil {
-			if ts := t.String(); ts != "" {
+			if ts := types.TypeString(
+				t, func(*types.Package) string { return "" },
+			); ts != "" {
 				parts = append(parts, ts)
 			}
 		}

--- a/internal/testdata/snapshots/output/alias/main.go
+++ b/internal/testdata/snapshots/output/alias/main.go
@@ -10,8 +10,7 @@
    T struct{}
 // ^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/T#
 //   signature_documentation
-//   > type T struct
-//   > struct{}
+//   > type T struct{}
 //   documentation
 //   > Check that we don't panic
 //   > Copied from https://github.com/golang/go/issues/68877#issuecomment-2290000187
@@ -19,7 +18,6 @@
 // ^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/U#
 //   signature_documentation
 //   > type U = T
-//   > struct{}
 //   documentation
 //   > Check that we don't panic
 //   > Copied from https://github.com/golang/go/issues/68877#issuecomment-2290000187
@@ -28,7 +26,6 @@
 // ^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/V#
 //   signature_documentation
 //   > type V = U
-//   > struct{}
 //   documentation
 //   > Check that we don't panic
 //   > Copied from https://github.com/golang/go/issues/68877#issuecomment-2290000187
@@ -36,8 +33,7 @@
    S U
 // ^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/S#
 //   signature_documentation
-//   > type S struct
-//   > struct{}
+//   > type S struct{}
 //   documentation
 //   > Check that we don't panic
 //   > Copied from https://github.com/golang/go/issues/68877#issuecomment-2290000187

--- a/internal/testdata/snapshots/output/alias/main.go
+++ b/internal/testdata/snapshots/output/alias/main.go
@@ -55,7 +55,7 @@
 //       ^ definition local 0
 //         display_name u
 //         signature_documentation
-//         > var u github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias.U
+//         > var u U
 //         ^ reference github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/U#
 //             ⌃ enclosing_range_end github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/f().
   

--- a/internal/testdata/snapshots/output/alias/main.go
+++ b/internal/testdata/snapshots/output/alias/main.go
@@ -9,77 +9,53 @@
   type (
    T struct{}
 // ^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/T#
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > type T struct
-//   > ```
+//   > struct{}
 //   documentation
 //   > Check that we don't panic
 //   > Copied from https://github.com/golang/go/issues/68877#issuecomment-2290000187
-//   documentation
-//   > ```go
-//   > struct{}
-//   > ```
    U = T
 // ^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/U#
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > type U = T
-//   > ```
+//   > struct{}
 //   documentation
 //   > Check that we don't panic
 //   > Copied from https://github.com/golang/go/issues/68877#issuecomment-2290000187
-//   documentation
-//   > ```go
-//   > struct{}
-//   > ```
 //     ^ reference github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/T#
    V = U
 // ^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/V#
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > type V = U
-//   > ```
+//   > struct{}
 //   documentation
 //   > Check that we don't panic
 //   > Copied from https://github.com/golang/go/issues/68877#issuecomment-2290000187
-//   documentation
-//   > ```go
-//   > struct{}
-//   > ```
 //     ^ reference github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/U#
    S U
 // ^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/S#
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > type S struct
-//   > ```
+//   > struct{}
 //   documentation
 //   > Check that we don't panic
 //   > Copied from https://github.com/golang/go/issues/68877#issuecomment-2290000187
-//   documentation
-//   > ```go
-//   > struct{}
-//   > ```
 //   ^ reference github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/U#
    Z int32
 // ^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/Z#
+//   signature_documentation
+//   > type Z int32
 //   documentation
 //   > Check that we don't panic
 //   > Copied from https://github.com/golang/go/issues/68877#issuecomment-2290000187
-//   documentation
-//   > ```go
-//   > int32
-//   > ```
   )
   
 //⌄ enclosing_range_start github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/f().
   func f(u U) {}
 //     ^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/f().
-//       documentation
-//       > ```go
+//       signature_documentation
 //       > func f(u U)
-//       > ```
 //       ^ definition local 0
 //         display_name u
 //         signature_documentation

--- a/internal/testdata/snapshots/output/embedded/embedded.go
+++ b/internal/testdata/snapshots/output/embedded/embedded.go
@@ -14,9 +14,7 @@
   type osExecCommand struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/osExecCommand#
 //                   signature_documentation
-//                   > type osExecCommand struct {
-//                   >     *Cmd
-//                   > }
+//                   > type osExecCommand struct{ *Cmd }
 //                   relationship github.com/golang/go/src go1.22 context/stringer# implementation
 //                   relationship github.com/golang/go/src go1.22 fmt/Stringer# implementation
 //                   relationship github.com/golang/go/src go1.22 runtime/stringer# implementation

--- a/internal/testdata/snapshots/output/embedded/embedded.go
+++ b/internal/testdata/snapshots/output/embedded/embedded.go
@@ -36,7 +36,7 @@
 //                     ^ definition local 0
 //                       display_name c
 //                       signature_documentation
-//                       > var c *os/exec.Cmd
+//                       > var c *Cmd
 //                        ^^^^ reference github.com/golang/go/src go1.22 `os/exec`/
 //                             ^^^ reference github.com/golang/go/src go1.22 `os/exec`/Cmd#
    _ = &osExecCommand{Cmd: c}
@@ -95,7 +95,7 @@
 // ^ definition local 1
 //   display_name o
 //   signature_documentation
-//   > var o sg/embedded.Outer
+//   > var o Outer
 //      ^^^^^ reference 0.1.test `sg/embedded`/Outer#
     Inner: Inner{
 //  ^^^^^ reference 0.1.test `sg/embedded`/Outer#Inner.

--- a/internal/testdata/snapshots/output/embedded/embedded.go
+++ b/internal/testdata/snapshots/output/embedded/embedded.go
@@ -14,8 +14,7 @@
   type osExecCommand struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/osExecCommand#
 //                   signature_documentation
-//                   > type osExecCommand struct
-//                   > struct {
+//                   > type osExecCommand struct {
 //                   >     *Cmd
 //                   > }
 //                   relationship github.com/golang/go/src go1.22 context/stringer# implementation
@@ -50,8 +49,7 @@
   type Inner struct {
 //     ^^^^^ definition 0.1.test `sg/embedded`/Inner#
 //           signature_documentation
-//           > type Inner struct
-//           > struct {
+//           > type Inner struct {
 //           >     X int
 //           >     Y int
 //           >     Z int
@@ -73,8 +71,7 @@
   type Outer struct {
 //     ^^^^^ definition 0.1.test `sg/embedded`/Outer#
 //           signature_documentation
-//           > type Outer struct
-//           > struct {
+//           > type Outer struct {
 //           >     Inner
 //           >     W int
 //           > }

--- a/internal/testdata/snapshots/output/embedded/embedded.go
+++ b/internal/testdata/snapshots/output/embedded/embedded.go
@@ -13,36 +13,27 @@
   
   type osExecCommand struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/osExecCommand#
-//                   documentation
-//                   > ```go
+//                   signature_documentation
 //                   > type osExecCommand struct
-//                   > ```
-//                   documentation
-//                   > ```go
 //                   > struct {
 //                   >     *Cmd
 //                   > }
-//                   > ```
 //                   relationship github.com/golang/go/src go1.22 context/stringer# implementation
 //                   relationship github.com/golang/go/src go1.22 fmt/Stringer# implementation
 //                   relationship github.com/golang/go/src go1.22 runtime/stringer# implementation
    *exec.Cmd
 //  ^^^^ reference github.com/golang/go/src go1.22 `os/exec`/
 //       ^^^ definition 0.1.test `sg/embedded`/osExecCommand#Cmd.
-//           documentation
-//           > ```go
+//           signature_documentation
 //           > struct field Cmd *os/exec.Cmd
-//           > ```
 //       ^^^ reference github.com/golang/go/src go1.22 `os/exec`/Cmd#
   }
   
 //⌄ enclosing_range_start 0.1.test `sg/embedded`/wrapExecCommand().
   func wrapExecCommand(c *exec.Cmd) {
 //     ^^^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/wrapExecCommand().
-//                     documentation
-//                     > ```go
+//                     signature_documentation
 //                     > func wrapExecCommand(c *Cmd)
-//                     > ```
 //                     ^ definition local 0
 //                       display_name c
 //                       signature_documentation
@@ -58,73 +49,51 @@
   
   type Inner struct {
 //     ^^^^^ definition 0.1.test `sg/embedded`/Inner#
-//           documentation
-//           > ```go
+//           signature_documentation
 //           > type Inner struct
-//           > ```
-//           documentation
-//           > ```go
 //           > struct {
 //           >     X int
 //           >     Y int
 //           >     Z int
 //           > }
-//           > ```
    X int
 // ^ definition 0.1.test `sg/embedded`/Inner#X.
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > struct field X int
-//   > ```
    Y int
 // ^ definition 0.1.test `sg/embedded`/Inner#Y.
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > struct field Y int
-//   > ```
    Z int
 // ^ definition 0.1.test `sg/embedded`/Inner#Z.
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > struct field Z int
-//   > ```
   }
   
   type Outer struct {
 //     ^^^^^ definition 0.1.test `sg/embedded`/Outer#
-//           documentation
-//           > ```go
+//           signature_documentation
 //           > type Outer struct
-//           > ```
-//           documentation
-//           > ```go
 //           > struct {
 //           >     Inner
 //           >     W int
 //           > }
-//           > ```
    Inner
 // ^^^^^ definition 0.1.test `sg/embedded`/Outer#Inner.
-//       documentation
-//       > ```go
+//       signature_documentation
 //       > struct field Inner sg/embedded.Inner
-//       > ```
 // ^^^^^ reference 0.1.test `sg/embedded`/Inner#
    W int
 // ^ definition 0.1.test `sg/embedded`/Outer#W.
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > struct field W int
-//   > ```
   }
   
 //⌄ enclosing_range_start 0.1.test `sg/embedded`/useOfCompositeStructs().
   func useOfCompositeStructs() {
 //     ^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/useOfCompositeStructs().
-//                           documentation
-//                           > ```go
+//                           signature_documentation
 //                           > func useOfCompositeStructs()
-//                           > ```
    o := Outer{
 // ^ definition local 1
 //   display_name o

--- a/internal/testdata/snapshots/output/embedded/internal/nested.go
+++ b/internal/testdata/snapshots/output/embedded/internal/nested.go
@@ -19,7 +19,7 @@
 //               ^^^^^^ definition local 0
 //                      display_name recent
 //                      signature_documentation
-//                      > var recent sg/embedded.RecentCommittersResults
+//                      > var recent RecentCommittersResults
 //                      ^^^^^^^^ reference 0.1.test `sg/embedded`/
 //                               ^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/embedded`/RecentCommittersResults#
    for _, commit := range recent.Nodes {

--- a/internal/testdata/snapshots/output/embedded/internal/nested.go
+++ b/internal/testdata/snapshots/output/embedded/internal/nested.go
@@ -14,10 +14,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/embedded/internal`/Something().
   func Something(recent embedded.RecentCommittersResults) {
 //     ^^^^^^^^^ definition 0.1.test `sg/embedded/internal`/Something().
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > func Something(recent RecentCommittersResults)
-//               > ```
 //               ^^^^^^ definition local 0
 //                      display_name recent
 //                      signature_documentation

--- a/internal/testdata/snapshots/output/embedded/nested.go
+++ b/internal/testdata/snapshots/output/embedded/nested.go
@@ -34,7 +34,7 @@
 //                   ^ definition local 0
 //                     display_name n
 //                     signature_documentation
-//                     > var n sg/embedded.NestedHandler
+//                     > var n NestedHandler
 //                     ^^^^^^^^^^^^^ reference 0.1.test `sg/embedded`/NestedHandler#
    _ = n.Handler.ServeHTTP
 //     ^ reference local 0

--- a/internal/testdata/snapshots/output/embedded/nested.go
+++ b/internal/testdata/snapshots/output/embedded/nested.go
@@ -6,43 +6,32 @@
   
   type NestedHandler struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/NestedHandler#
-//                   documentation
-//                   > ```go
+//                   signature_documentation
 //                   > type NestedHandler struct
-//                   > ```
-//                   documentation
-//                   > ```go
 //                   > struct {
 //                   >     Handler
 //                   >     Other int
 //                   > }
-//                   > ```
 //                   relationship github.com/golang/go/src go1.22 `net/http`/Handler# implementation
    http.Handler
 // ^^^^ reference github.com/golang/go/src go1.22 `net/http`/
 //      ^^^^^^^ definition 0.1.test `sg/embedded`/NestedHandler#Handler.
-//              documentation
-//              > ```go
+//              signature_documentation
 //              > struct field Handler net/http.Handler
-//              > ```
 //      ^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/Handler#
   
    // Wow, a great thing for integers
    Other int
 // ^^^^^ definition 0.1.test `sg/embedded`/NestedHandler#Other.
-//       documentation
-//       > ```go
+//       signature_documentation
 //       > struct field Other int
-//       > ```
   }
   
 //⌄ enclosing_range_start 0.1.test `sg/embedded`/NestedExample().
   func NestedExample(n NestedHandler) {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/NestedExample().
-//                   documentation
-//                   > ```go
+//                   signature_documentation
 //                   > func NestedExample(n NestedHandler)
-//                   > ```
 //                   ^ definition local 0
 //                     display_name n
 //                     signature_documentation

--- a/internal/testdata/snapshots/output/embedded/nested.go
+++ b/internal/testdata/snapshots/output/embedded/nested.go
@@ -7,8 +7,7 @@
   type NestedHandler struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/NestedHandler#
 //                   signature_documentation
-//                   > type NestedHandler struct
-//                   > struct {
+//                   > type NestedHandler struct {
 //                   >     Handler
 //                   >     Other int
 //                   > }

--- a/internal/testdata/snapshots/output/embedded/something.go
+++ b/internal/testdata/snapshots/output/embedded/something.go
@@ -9,7 +9,7 @@
 //      ^ definition local 0
 //        display_name r
 //        signature_documentation
-//        > var r *sg/embedded.RecentCommittersResults
+//        > var r *RecentCommittersResults
 //         ^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/embedded`/RecentCommittersResults#
 //                                  ^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#String().
 //                                         signature_documentation

--- a/internal/testdata/snapshots/output/embedded/something.go
+++ b/internal/testdata/snapshots/output/embedded/something.go
@@ -32,19 +32,15 @@
 //                             >     Nodes []struct {
 //                             >         Authors struct {
 //                             >             Nodes []struct {
-//                             >                 Date string
-//                             >                 Email string
-//                             >                 Name string
-//                             >                 User struct {
-//                             >                     Login string
-//                             >                 }
+//                             >                 Date      string
+//                             >                 Email     string
+//                             >                 Name      string
+//                             >                 User      struct{ Login string }
 //                             >                 AvatarURL string
 //                             >             }
 //                             >         }
 //                             >     }
-//                             >     PageInfo struct {
-//                             >         HasNextPage bool
-//                             >     }
+//                             >     PageInfo struct{ HasNextPage bool }
 //                             > }
 //                             relationship github.com/golang/go/src go1.22 context/stringer# implementation
 //                             relationship github.com/golang/go/src go1.22 fmt/Stringer# implementation

--- a/internal/testdata/snapshots/output/embedded/something.go
+++ b/internal/testdata/snapshots/output/embedded/something.go
@@ -12,10 +12,8 @@
 //        > var r *sg/embedded.RecentCommittersResults
 //         ^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/embedded`/RecentCommittersResults#
 //                                  ^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#String().
-//                                         documentation
-//                                         > ```go
+//                                         signature_documentation
 //                                         > func (*RecentCommittersResults).String() string
-//                                         > ```
 //                                         relationship github.com/golang/go/src go1.22 context/stringer#String. implementation
 //                                         relationship github.com/golang/go/src go1.22 fmt/Stringer#String. implementation
 //                                         relationship github.com/golang/go/src go1.22 runtime/stringer#String. implementation
@@ -29,12 +27,8 @@
   
   type RecentCommittersResults struct {
 //     ^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#
-//                             documentation
-//                             > ```go
+//                             signature_documentation
 //                             > type RecentCommittersResults struct
-//                             > ```
-//                             documentation
-//                             > ```go
 //                             > struct {
 //                             >     Nodes []struct {
 //                             >         Authors struct {
@@ -53,80 +47,57 @@
 //                             >         HasNextPage bool
 //                             >     }
 //                             > }
-//                             > ```
 //                             relationship github.com/golang/go/src go1.22 context/stringer# implementation
 //                             relationship github.com/golang/go/src go1.22 fmt/Stringer# implementation
 //                             relationship github.com/golang/go/src go1.22 runtime/stringer# implementation
    Nodes []struct {
 // ^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.
-//       documentation
-//       > ```go
+//       signature_documentation
 //       > struct field Nodes []struct{Authors struct{Nodes []struct{Date string; Email string; Name string; User struct{Login string}; AvatarURL string}}}
-//       > ```
     Authors struct {
 //  ^^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#$anon_90b32de18ec80596#Authors.
-//          documentation
-//          > ```go
+//          signature_documentation
 //          > struct field Authors struct{Nodes []struct{Date string; Email string; Name string; User struct{Login string}; AvatarURL string}}
-//          > ```
      Nodes []struct {
 //   ^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#$anon_90b32de18ec80596#$anon_bb290b1f6ea0cf58#Nodes.
-//         documentation
-//         > ```go
+//         signature_documentation
 //         > struct field Nodes []struct{Date string; Email string; Name string; User struct{Login string}; AvatarURL string}
-//         > ```
       Date  string
 //    ^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#$anon_90b32de18ec80596#$anon_bb290b1f6ea0cf58#$anon_b2a8a16c744b2d4b#Date.
-//         documentation
-//         > ```go
+//         signature_documentation
 //         > struct field Date string
-//         > ```
       Email string
 //    ^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#$anon_90b32de18ec80596#$anon_bb290b1f6ea0cf58#$anon_b2a8a16c744b2d4b#Email.
-//          documentation
-//          > ```go
+//          signature_documentation
 //          > struct field Email string
-//          > ```
       Name  string
 //    ^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#$anon_90b32de18ec80596#$anon_bb290b1f6ea0cf58#$anon_b2a8a16c744b2d4b#Name.
-//         documentation
-//         > ```go
+//         signature_documentation
 //         > struct field Name string
-//         > ```
       User  struct {
 //    ^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#$anon_90b32de18ec80596#$anon_bb290b1f6ea0cf58#$anon_b2a8a16c744b2d4b#User.
-//         documentation
-//         > ```go
+//         signature_documentation
 //         > struct field User struct{Login string}
-//         > ```
        Login string
 //     ^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#$anon_90b32de18ec80596#$anon_bb290b1f6ea0cf58#$anon_b2a8a16c744b2d4b#$anon_d4bff1f61f45b2a1#Login.
-//           documentation
-//           > ```go
+//           signature_documentation
 //           > struct field Login string
-//           > ```
       }
       AvatarURL string
 //    ^^^^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#$anon_90b32de18ec80596#$anon_bb290b1f6ea0cf58#$anon_b2a8a16c744b2d4b#AvatarURL.
-//              documentation
-//              > ```go
+//              signature_documentation
 //              > struct field AvatarURL string
-//              > ```
      }
     }
    }
    PageInfo struct {
 // ^^^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#PageInfo.
-//          documentation
-//          > ```go
+//          signature_documentation
 //          > struct field PageInfo struct{HasNextPage bool}
-//          > ```
     HasNextPage bool
 //  ^^^^^^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#$anon_0a5c453971407ce4#HasNextPage.
-//              documentation
-//              > ```go
+//              signature_documentation
 //              > struct field HasNextPage bool
-//              > ```
    }
   }
   

--- a/internal/testdata/snapshots/output/embedded/something.go
+++ b/internal/testdata/snapshots/output/embedded/something.go
@@ -28,8 +28,7 @@
   type RecentCommittersResults struct {
 //     ^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#
 //                             signature_documentation
-//                             > type RecentCommittersResults struct
-//                             > struct {
+//                             > type RecentCommittersResults struct {
 //                             >     Nodes []struct {
 //                             >         Authors struct {
 //                             >             Nodes []struct {

--- a/internal/testdata/snapshots/output/generallyeric/generallyeric.go
+++ b/internal/testdata/snapshots/output/generallyeric/generallyeric.go
@@ -13,10 +13,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/generallyeric`/Print().
   func Print[T any](s []T) {
 //     ^^^^^ definition 0.1.test `sg/generallyeric`/Print().
-//           documentation
-//           > ```go
+//           signature_documentation
 //           > func Print[T any](s []T)
-//           > ```
 //           ^ definition local 0
 //             display_name T
 //             signature_documentation

--- a/internal/testdata/snapshots/output/generallyeric/new_operators.go
+++ b/internal/testdata/snapshots/output/generallyeric/new_operators.go
@@ -3,16 +3,11 @@
   
   type Number interface {
 //     ^^^^^^ definition 0.1.test `sg/generallyeric`/Number#
-//            documentation
-//            > ```go
+//            signature_documentation
 //            > type Number interface
-//            > ```
-//            documentation
-//            > ```go
 //            > interface {
 //            >     ~int | ~int8 | ~int16 | ~int32 | ~int64 | ~float32 | ~float64
 //            > }
-//            > ```
    ~int | ~int8 | ~int16 | ~int32 | ~int64 |
     ~float32 | ~float64
   }
@@ -20,10 +15,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/generallyeric`/Double().
   func Double[T Number](value T) T {
 //     ^^^^^^ definition 0.1.test `sg/generallyeric`/Double().
-//            documentation
-//            > ```go
+//            signature_documentation
 //            > func Double[T Number](value T) T
-//            > ```
 //            ^ definition local 0
 //              display_name T
 //              signature_documentation
@@ -42,59 +35,43 @@
   
   type Box[T any] struct {
 //     ^^^ definition 0.1.test `sg/generallyeric`/Box#
-//         documentation
-//         > ```go
+//         signature_documentation
 //         > type Box struct
-//         > ```
-//         documentation
-//         > ```go
 //         > struct {
 //         >     Something T
 //         > }
-//         > ```
 //         ^ definition local 2
 //           display_name T
 //           signature_documentation
 //           > T T
    Something T
 // ^^^^^^^^^ definition 0.1.test `sg/generallyeric`/Box#Something.
-//           documentation
-//           > ```go
+//           signature_documentation
 //           > struct field Something T
-//           > ```
 //           ^ reference local 2
   }
   
   type handler[T any] struct {
 //     ^^^^^^^ definition 0.1.test `sg/generallyeric`/handler#
-//             documentation
-//             > ```go
+//             signature_documentation
 //             > type handler struct
-//             > ```
-//             documentation
-//             > ```go
 //             > struct {
 //             >     Box[T]
 //             >     Another string
 //             > }
-//             > ```
 //             ^ definition local 3
 //               display_name T
 //               signature_documentation
 //               > T T
    Box[T]
 // ^^^ definition 0.1.test `sg/generallyeric`/handler#Box.
-//     documentation
-//     > ```go
+//     signature_documentation
 //     > struct field Box sg/generallyeric.Box[T]
-//     > ```
 // ^^^ reference 0.1.test `sg/generallyeric`/Box#
 //     ^ reference local 3
    Another string
 // ^^^^^^^ definition 0.1.test `sg/generallyeric`/handler#Another.
-//         documentation
-//         > ```go
+//         signature_documentation
 //         > struct field Another string
-//         > ```
   }
   

--- a/internal/testdata/snapshots/output/generallyeric/new_operators.go
+++ b/internal/testdata/snapshots/output/generallyeric/new_operators.go
@@ -4,8 +4,7 @@
   type Number interface {
 //     ^^^^^^ definition 0.1.test `sg/generallyeric`/Number#
 //            signature_documentation
-//            > type Number interface
-//            > interface {
+//            > type Number interface {
 //            >     ~int | ~int8 | ~int16 | ~int32 | ~int64 | ~float32 | ~float64
 //            > }
    ~int | ~int8 | ~int16 | ~int32 | ~int64 |
@@ -36,8 +35,7 @@
   type Box[T any] struct {
 //     ^^^ definition 0.1.test `sg/generallyeric`/Box#
 //         signature_documentation
-//         > type Box struct
-//         > struct {
+//         > type Box struct {
 //         >     Something T
 //         > }
 //         ^ definition local 2
@@ -54,8 +52,7 @@
   type handler[T any] struct {
 //     ^^^^^^^ definition 0.1.test `sg/generallyeric`/handler#
 //             signature_documentation
-//             > type handler struct
-//             > struct {
+//             > type handler struct {
 //             >     Box[T]
 //             >     Another string
 //             > }

--- a/internal/testdata/snapshots/output/generallyeric/new_operators.go
+++ b/internal/testdata/snapshots/output/generallyeric/new_operators.go
@@ -35,9 +35,7 @@
   type Box[T any] struct {
 //     ^^^ definition 0.1.test `sg/generallyeric`/Box#
 //         signature_documentation
-//         > type Box struct {
-//         >     Something T
-//         > }
+//         > type Box struct{ Something T }
 //         ^ definition local 2
 //           display_name T
 //           signature_documentation

--- a/internal/testdata/snapshots/output/generallyeric/person.go
+++ b/internal/testdata/snapshots/output/generallyeric/person.go
@@ -27,7 +27,7 @@
 //      ^ definition local 0
 //        display_name w
 //        signature_documentation
-//        > var w sg/generallyeric.worker
+//        > var w worker
 //        ^^^^^^ reference 0.1.test `sg/generallyeric`/worker#
 //                ^^^^ definition 0.1.test `sg/generallyeric`/worker#Work().
 //                     signature_documentation
@@ -77,15 +77,15 @@
 //     ^ definition local 4
 //       display_name a
 //       signature_documentation
-//       > var a sg/generallyeric.worker
+//       > var a worker
 //        ^ definition local 5
 //          display_name b
 //          signature_documentation
-//          > var b sg/generallyeric.worker
+//          > var b worker
 //           ^ definition local 6
 //             display_name c
 //             signature_documentation
-//             > var c sg/generallyeric.worker
+//             > var c worker
 //             ^^^^^^ reference 0.1.test `sg/generallyeric`/worker#
    a = "A"
 // ^ reference local 4

--- a/internal/testdata/snapshots/output/generallyeric/person.go
+++ b/internal/testdata/snapshots/output/generallyeric/person.go
@@ -7,8 +7,7 @@
   type Person interface {
 //     ^^^^^^ definition 0.1.test `sg/generallyeric`/Person#
 //            signature_documentation
-//            > type Person interface
-//            > interface {
+//            > type Person interface {
 //            >     Work()
 //            > }
    Work()

--- a/internal/testdata/snapshots/output/generallyeric/person.go
+++ b/internal/testdata/snapshots/output/generallyeric/person.go
@@ -6,30 +6,21 @@
   
   type Person interface {
 //     ^^^^^^ definition 0.1.test `sg/generallyeric`/Person#
-//            documentation
-//            > ```go
+//            signature_documentation
 //            > type Person interface
-//            > ```
-//            documentation
-//            > ```go
 //            > interface {
 //            >     Work()
 //            > }
-//            > ```
    Work()
 // ^^^^ definition 0.1.test `sg/generallyeric`/Person#Work.
-//      documentation
-//      > ```go
+//      signature_documentation
 //      > func (Person).Work()
-//      > ```
   }
   
   type worker string
 //     ^^^^^^ definition 0.1.test `sg/generallyeric`/worker#
-//            documentation
-//            > ```go
-//            > string
-//            > ```
+//            signature_documentation
+//            > type worker string
 //            relationship 0.1.test `sg/generallyeric`/Person# implementation
   
 //⌄ enclosing_range_start 0.1.test `sg/generallyeric`/worker#Work().
@@ -40,10 +31,8 @@
 //        > var w sg/generallyeric.worker
 //        ^^^^^^ reference 0.1.test `sg/generallyeric`/worker#
 //                ^^^^ definition 0.1.test `sg/generallyeric`/worker#Work().
-//                     documentation
-//                     > ```go
+//                     signature_documentation
 //                     > func (worker).Work()
-//                     > ```
 //                     relationship 0.1.test `sg/generallyeric`/Person#Work. implementation
    fmt.Printf("%s is working\n", w)
 // ^^^ reference github.com/golang/go/src go1.22 fmt/
@@ -55,10 +44,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/generallyeric`/DoWork().
   func DoWork[T Person](things []T) {
 //     ^^^^^^ definition 0.1.test `sg/generallyeric`/DoWork().
-//            documentation
-//            > ```go
+//            signature_documentation
 //            > func DoWork[T Person](things []T)
-//            > ```
 //            ^ definition local 1
 //              display_name T
 //              signature_documentation
@@ -85,10 +72,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/generallyeric`/main().
   func main() {
 //     ^^^^ definition 0.1.test `sg/generallyeric`/main().
-//          documentation
-//          > ```go
+//          signature_documentation
 //          > func main()
-//          > ```
    var a, b, c worker
 //     ^ definition local 4
 //       display_name a

--- a/internal/testdata/snapshots/output/generallyeric/person.go
+++ b/internal/testdata/snapshots/output/generallyeric/person.go
@@ -7,9 +7,7 @@
   type Person interface {
 //     ^^^^^^ definition 0.1.test `sg/generallyeric`/Person#
 //            signature_documentation
-//            > type Person interface {
-//            >     Work()
-//            > }
+//            > type Person interface{ Work() }
    Work()
 // ^^^^ definition 0.1.test `sg/generallyeric`/Person#Work.
 //      signature_documentation

--- a/internal/testdata/snapshots/output/impls/impls.go
+++ b/internal/testdata/snapshots/output/impls/impls.go
@@ -57,7 +57,7 @@
 //      ^ definition local 0
 //        display_name r
 //        signature_documentation
-//        > var r sg/impls.T1
+//        > var r T1
 //        ^^ reference 0.1.test `sg/impls`/T1#
 //            ^^ definition 0.1.test `sg/impls`/T1#F1().
 //               signature_documentation
@@ -78,7 +78,7 @@
 //      ^ definition local 1
 //        display_name r
 //        signature_documentation
-//        > var r sg/impls.T2
+//        > var r T2
 //        ^^ reference 0.1.test `sg/impls`/T2#
 //            ^^ definition 0.1.test `sg/impls`/T2#F1().
 //               signature_documentation
@@ -91,7 +91,7 @@
 //      ^ definition local 2
 //        display_name r
 //        signature_documentation
-//        > var r sg/impls.T2
+//        > var r T2
 //        ^^ reference 0.1.test `sg/impls`/T2#
 //            ^^ definition 0.1.test `sg/impls`/T2#F2().
 //               signature_documentation

--- a/internal/testdata/snapshots/output/impls/impls.go
+++ b/internal/testdata/snapshots/output/impls/impls.go
@@ -7,9 +7,7 @@
   type I1 interface {
 //     ^^ definition 0.1.test `sg/impls`/I1#
 //        signature_documentation
-//        > type I1 interface {
-//        >     F1()
-//        > }
+//        > type I1 interface{ F1() }
    F1()
 // ^^ definition 0.1.test `sg/impls`/I1#F1.
 //    signature_documentation
@@ -19,9 +17,7 @@
   type I1Clone interface {
 //     ^^^^^^^ definition 0.1.test `sg/impls`/I1Clone#
 //             signature_documentation
-//             > type I1Clone interface {
-//             >     F1()
-//             > }
+//             > type I1Clone interface{ F1() }
    F1()
 // ^^ definition 0.1.test `sg/impls`/I1Clone#F1.
 //    signature_documentation

--- a/internal/testdata/snapshots/output/impls/impls.go
+++ b/internal/testdata/snapshots/output/impls/impls.go
@@ -7,8 +7,7 @@
   type I1 interface {
 //     ^^ definition 0.1.test `sg/impls`/I1#
 //        signature_documentation
-//        > type I1 interface
-//        > interface {
+//        > type I1 interface {
 //        >     F1()
 //        > }
    F1()
@@ -20,8 +19,7 @@
   type I1Clone interface {
 //     ^^^^^^^ definition 0.1.test `sg/impls`/I1Clone#
 //             signature_documentation
-//             > type I1Clone interface
-//             > interface {
+//             > type I1Clone interface {
 //             >     F1()
 //             > }
    F1()
@@ -33,8 +31,7 @@
   type IfaceOther interface {
 //     ^^^^^^^^^^ definition 0.1.test `sg/impls`/IfaceOther#
 //                signature_documentation
-//                > type IfaceOther interface
-//                > interface {
+//                > type IfaceOther interface {
 //                >     Another()
 //                >     Something()
 //                > }

--- a/internal/testdata/snapshots/output/impls/impls.go
+++ b/internal/testdata/snapshots/output/impls/impls.go
@@ -6,77 +6,52 @@
   
   type I1 interface {
 //     ^^ definition 0.1.test `sg/impls`/I1#
-//        documentation
-//        > ```go
+//        signature_documentation
 //        > type I1 interface
-//        > ```
-//        documentation
-//        > ```go
 //        > interface {
 //        >     F1()
 //        > }
-//        > ```
    F1()
 // ^^ definition 0.1.test `sg/impls`/I1#F1.
-//    documentation
-//    > ```go
+//    signature_documentation
 //    > func (I1).F1()
-//    > ```
   }
   
   type I1Clone interface {
 //     ^^^^^^^ definition 0.1.test `sg/impls`/I1Clone#
-//             documentation
-//             > ```go
+//             signature_documentation
 //             > type I1Clone interface
-//             > ```
-//             documentation
-//             > ```go
 //             > interface {
 //             >     F1()
 //             > }
-//             > ```
    F1()
 // ^^ definition 0.1.test `sg/impls`/I1Clone#F1.
-//    documentation
-//    > ```go
+//    signature_documentation
 //    > func (I1Clone).F1()
-//    > ```
   }
   
   type IfaceOther interface {
 //     ^^^^^^^^^^ definition 0.1.test `sg/impls`/IfaceOther#
-//                documentation
-//                > ```go
+//                signature_documentation
 //                > type IfaceOther interface
-//                > ```
-//                documentation
-//                > ```go
 //                > interface {
 //                >     Another()
 //                >     Something()
 //                > }
-//                > ```
    Something()
 // ^^^^^^^^^ definition 0.1.test `sg/impls`/IfaceOther#Something.
-//           documentation
-//           > ```go
+//           signature_documentation
 //           > func (IfaceOther).Something()
-//           > ```
    Another()
 // ^^^^^^^ definition 0.1.test `sg/impls`/IfaceOther#Another.
-//         documentation
-//         > ```go
+//         signature_documentation
 //         > func (IfaceOther).Another()
-//         > ```
   }
   
   type T1 int
 //     ^^ definition 0.1.test `sg/impls`/T1#
-//        documentation
-//        > ```go
-//        > int
-//        > ```
+//        signature_documentation
+//        > type T1 int
 //        relationship 0.1.test `sg/impls`/I1# implementation
 //        relationship 0.1.test `sg/impls`/I1Clone# implementation
   
@@ -88,20 +63,16 @@
 //        > var r sg/impls.T1
 //        ^^ reference 0.1.test `sg/impls`/T1#
 //            ^^ definition 0.1.test `sg/impls`/T1#F1().
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > func (T1).F1()
-//               > ```
 //               relationship 0.1.test `sg/impls`/I1#F1. implementation
 //               relationship 0.1.test `sg/impls`/I1Clone#F1. implementation
 //                  ⌃ enclosing_range_end 0.1.test `sg/impls`/T1#F1().
   
   type T2 int
 //     ^^ definition 0.1.test `sg/impls`/T2#
-//        documentation
-//        > ```go
-//        > int
-//        > ```
+//        signature_documentation
+//        > type T2 int
 //        relationship 0.1.test `sg/impls`/I1# implementation
 //        relationship 0.1.test `sg/impls`/I1Clone# implementation
   
@@ -113,10 +84,8 @@
 //        > var r sg/impls.T2
 //        ^^ reference 0.1.test `sg/impls`/T2#
 //            ^^ definition 0.1.test `sg/impls`/T2#F1().
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > func (T2).F1()
-//               > ```
 //               relationship 0.1.test `sg/impls`/I1#F1. implementation
 //               relationship 0.1.test `sg/impls`/I1Clone#F1. implementation
 //                  ⌃ enclosing_range_end 0.1.test `sg/impls`/T2#F1().
@@ -128,9 +97,7 @@
 //        > var r sg/impls.T2
 //        ^^ reference 0.1.test `sg/impls`/T2#
 //            ^^ definition 0.1.test `sg/impls`/T2#F2().
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > func (T2).F2()
-//               > ```
 //                  ⌃ enclosing_range_end 0.1.test `sg/impls`/T2#F2().
   

--- a/internal/testdata/snapshots/output/impls/remote_impls.go
+++ b/internal/testdata/snapshots/output/impls/remote_impls.go
@@ -12,7 +12,7 @@
 //               ^ definition local 0
 //                 display_name r
 //                 signature_documentation
-//                 > var r net/http.ResponseWriter
+//                 > var r ResponseWriter
 //                 ^^^^ reference github.com/golang/go/src go1.22 `net/http`/
 //                      ^^^^^^^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/ResponseWriter#
 //                                       ⌃ enclosing_range_end 0.1.test `sg/impls`/Something().
@@ -31,7 +31,7 @@
 //      ^ definition local 1
 //        display_name w
 //        signature_documentation
-//        > var w sg/impls.MyWriter
+//        > var w MyWriter
 //        ^^^^^^^^ reference 0.1.test `sg/impls`/MyWriter#
 //                  ^^^^^^ definition 0.1.test `sg/impls`/MyWriter#Header().
 //                         signature_documentation
@@ -45,7 +45,7 @@
 //      ^ definition local 2
 //        display_name w
 //        signature_documentation
-//        > var w sg/impls.MyWriter
+//        > var w MyWriter
 //        ^^^^^^^^ reference 0.1.test `sg/impls`/MyWriter#
 //                  ^^^^^ definition 0.1.test `sg/impls`/MyWriter#Write().
 //                        signature_documentation
@@ -60,7 +60,7 @@
 //      ^ definition local 3
 //        display_name w
 //        signature_documentation
-//        > var w sg/impls.MyWriter
+//        > var w MyWriter
 //        ^^^^^^^^ reference 0.1.test `sg/impls`/MyWriter#
 //                  ^^^^^^^^^^^ definition 0.1.test `sg/impls`/MyWriter#WriteHeader().
 //                              signature_documentation

--- a/internal/testdata/snapshots/output/impls/remote_impls.go
+++ b/internal/testdata/snapshots/output/impls/remote_impls.go
@@ -7,10 +7,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/impls`/Something().
   func Something(r http.ResponseWriter) {}
 //     ^^^^^^^^^ definition 0.1.test `sg/impls`/Something().
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > func Something(r ResponseWriter)
-//               > ```
 //               ^ definition local 0
 //                 display_name r
 //                 signature_documentation
@@ -21,14 +19,9 @@
   
   type MyWriter struct{}
 //     ^^^^^^^^ definition 0.1.test `sg/impls`/MyWriter#
-//              documentation
-//              > ```go
+//              signature_documentation
 //              > type MyWriter struct
-//              > ```
-//              documentation
-//              > ```go
 //              > struct{}
-//              > ```
 //              relationship github.com/golang/go/src go1.22 `crypto/tls`/transcriptHash# implementation
 //              relationship github.com/golang/go/src go1.22 `internal/bisect`/Writer# implementation
 //              relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter# implementation
@@ -42,10 +35,8 @@
 //        > var w sg/impls.MyWriter
 //        ^^^^^^^^ reference 0.1.test `sg/impls`/MyWriter#
 //                  ^^^^^^ definition 0.1.test `sg/impls`/MyWriter#Header().
-//                         documentation
-//                         > ```go
+//                         signature_documentation
 //                         > func (MyWriter).Header() Header
-//                         > ```
 //                         relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#Header. implementation
 //                           ^^^^ reference github.com/golang/go/src go1.22 `net/http`/
 //                                ^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/Header#
@@ -58,10 +49,8 @@
 //        > var w sg/impls.MyWriter
 //        ^^^^^^^^ reference 0.1.test `sg/impls`/MyWriter#
 //                  ^^^^^ definition 0.1.test `sg/impls`/MyWriter#Write().
-//                        documentation
-//                        > ```go
+//                        signature_documentation
 //                        > func (MyWriter).Write([]byte) (int, error)
-//                        > ```
 //                        relationship github.com/golang/go/src go1.22 `crypto/tls`/transcriptHash#Write. implementation
 //                        relationship github.com/golang/go/src go1.22 `internal/bisect`/Writer#Write. implementation
 //                        relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#Write. implementation
@@ -75,10 +64,8 @@
 //        > var w sg/impls.MyWriter
 //        ^^^^^^^^ reference 0.1.test `sg/impls`/MyWriter#
 //                  ^^^^^^^^^^^ definition 0.1.test `sg/impls`/MyWriter#WriteHeader().
-//                              documentation
-//                              > ```go
+//                              signature_documentation
 //                              > func (MyWriter).WriteHeader(statusCode int)
-//                              > ```
 //                              relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#WriteHeader. implementation
 //                              ^^^^^^^^^^ definition local 4
 //                                         display_name statusCode
@@ -89,10 +76,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/impls`/Another().
   func Another() {
 //     ^^^^^^^ definition 0.1.test `sg/impls`/Another().
-//             documentation
-//             > ```go
+//             signature_documentation
 //             > func Another()
-//             > ```
    Something(MyWriter{})
 // ^^^^^^^^^ reference 0.1.test `sg/impls`/Something().
 //           ^^^^^^^^ reference 0.1.test `sg/impls`/MyWriter#

--- a/internal/testdata/snapshots/output/impls/remote_impls.go
+++ b/internal/testdata/snapshots/output/impls/remote_impls.go
@@ -20,8 +20,7 @@
   type MyWriter struct{}
 //     ^^^^^^^^ definition 0.1.test `sg/impls`/MyWriter#
 //              signature_documentation
-//              > type MyWriter struct
-//              > struct{}
+//              > type MyWriter struct{}
 //              relationship github.com/golang/go/src go1.22 `crypto/tls`/transcriptHash# implementation
 //              relationship github.com/golang/go/src go1.22 `internal/bisect`/Writer# implementation
 //              relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter# implementation

--- a/internal/testdata/snapshots/output/initial/builtin_types.go
+++ b/internal/testdata/snapshots/output/initial/builtin_types.go
@@ -10,10 +10,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/initial`/UsesBuiltin().
   func UsesBuiltin() int {
 //     ^^^^^^^^^^^ definition 0.1.test `sg/initial`/UsesBuiltin().
-//                 documentation
-//                 > ```go
+//                 signature_documentation
 //                 > func UsesBuiltin() int
-//                 > ```
    var x int = 5
 //     ^ definition local 0
 //       display_name x

--- a/internal/testdata/snapshots/output/initial/child_symbols.go
+++ b/internal/testdata/snapshots/output/initial/child_symbols.go
@@ -136,8 +136,7 @@
   type Embedded struct {
 //     ^^^^^^^^ definition 0.1.test `sg/initial`/Embedded#
 //              signature_documentation
-//              > type Embedded struct
-//              > struct {
+//              > type Embedded struct {
 //              >     EmbeddedField string
 //              >     Field string
 //              > }
@@ -157,8 +156,7 @@
   type Struct struct {
 //     ^^^^^^ definition 0.1.test `sg/initial`/Struct#
 //            signature_documentation
-//            > type Struct struct
-//            > struct {
+//            > type Struct struct {
 //            >     *Embedded
 //            >     Field string
 //            >     Anonymous struct {
@@ -312,8 +310,7 @@
   type Interface interface {
 //     ^^^^^^^^^ definition 0.1.test `sg/initial`/Interface#
 //               signature_documentation
-//               > type Interface interface
-//               > interface {
+//               > type Interface interface {
 //               >     ImplementsInterface() string
 //               > }
 //               documentation
@@ -375,8 +372,7 @@
    X struct {
 // ^ definition 0.1.test `sg/initial`/X#
 //   signature_documentation
-//   > type X struct
-//   > struct {
+//   > type X struct {
 //   >     bar string
 //   > }
 //   documentation
@@ -390,8 +386,7 @@
    Y struct {
 // ^ definition 0.1.test `sg/initial`/Y#
 //   signature_documentation
-//   > type Y struct
-//   > struct {
+//   > type Y struct {
 //   >     baz float64
 //   > }
 //   documentation

--- a/internal/testdata/snapshots/output/initial/child_symbols.go
+++ b/internal/testdata/snapshots/output/initial/child_symbols.go
@@ -4,10 +4,8 @@
   // Const is a constant equal to 5. It's the best constant I've ever written. 😹
   const Const = 5
 //      ^^^^^ definition 0.1.test `sg/initial`/Const.
-//            documentation
-//            > ```go
+//            signature_documentation
 //            > const Const untyped int = 5
-//            > ```
 //            documentation
 //            > Const is a constant equal to 5. It's the best constant I've ever written. 😹
   
@@ -16,20 +14,16 @@
    // ConstBlock1 is a constant in a block.
    ConstBlock1 = 1
 // ^^^^^^^^^^^ definition 0.1.test `sg/initial`/ConstBlock1.
-//             documentation
-//             > ```go
+//             signature_documentation
 //             > const ConstBlock1 untyped int = 1
-//             > ```
 //             documentation
 //             > Docs for the const block itself.
   
    // ConstBlock2 is a constant in a block.
    ConstBlock2 = 2
 // ^^^^^^^^^^^ definition 0.1.test `sg/initial`/ConstBlock2.
-//             documentation
-//             > ```go
+//             signature_documentation
 //             > const ConstBlock2 untyped int = 2
-//             > ```
 //             documentation
 //             > Docs for the const block itself.
   )
@@ -37,10 +31,8 @@
   // Var is a variable interface.
   var Var Interface = &Struct{Field: "bar!"}
 //    ^^^ definition 0.1.test `sg/initial`/Var.
-//        documentation
-//        > ```go
+//        signature_documentation
 //        > var Var Interface
-//        > ```
 //        documentation
 //        > Var is a variable interface.
 //        ^^^^^^^^^ reference 0.1.test `sg/initial`/Interface#
@@ -50,10 +42,8 @@
   // unexportedVar is an unexported variable interface.
   var unexportedVar Interface = &Struct{Field: "bar!"}
 //    ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/unexportedVar.
-//                  documentation
-//                  > ```go
+//                  signature_documentation
 //                  > var unexportedVar Interface
-//                  > ```
 //                  documentation
 //                  > unexportedVar is an unexported variable interface.
 //                  ^^^^^^^^^ reference 0.1.test `sg/initial`/Interface#
@@ -63,19 +53,15 @@
   // x has a builtin error type
   var x error
 //    ^ definition 0.1.test `sg/initial`/x.
-//      documentation
-//      > ```go
+//      signature_documentation
 //      > var x error
-//      > ```
 //      documentation
 //      > x has a builtin error type
   
   var BigVar Interface = &Struct{
 //    ^^^^^^ definition 0.1.test `sg/initial`/BigVar.
-//           documentation
-//           > ```go
+//           signature_documentation
 //           > var BigVar Interface
-//           > ```
 //           ^^^^^^^^^ reference 0.1.test `sg/initial`/Interface#
 //                        ^^^^^^ reference 0.1.test `sg/initial`/Struct#
    Field: "bar!",
@@ -84,22 +70,16 @@
 // ^^^^^^^^^ reference 0.1.test `sg/initial`/Struct#Anonymous.
     FieldA int
 //  ^^^^^^ definition 0.1.test `sg/initial`/BigVar:FieldA.
-//         documentation
-//         > ```go
+//         signature_documentation
 //         > struct field FieldA int
-//         > ```
     FieldB int
 //  ^^^^^^ definition 0.1.test `sg/initial`/BigVar:FieldB.
-//         documentation
-//         > ```go
+//         signature_documentation
 //         > struct field FieldB int
-//         > ```
     FieldC int
 //  ^^^^^^ definition 0.1.test `sg/initial`/BigVar:FieldC.
-//         documentation
-//         > ```go
+//         signature_documentation
 //         > struct field FieldC int
-//         > ```
    }{FieldA: 1337},
 //   ^^^^^^ reference 0.1.test `sg/initial`/BigVar:FieldA.
   }
@@ -119,10 +99,8 @@
    // This has some docs
    VarBlock1 = "if you're reading this"
 // ^^^^^^^^^ definition 0.1.test `sg/initial`/VarBlock1.
-//           documentation
-//           > ```go
+//           signature_documentation
 //           > var VarBlock1 string
-//           > ```
 //           documentation
 //           > What are docs, really?
 //           > I can't say for sure, I don't write any.
@@ -138,10 +116,8 @@
   
    VarBlock2 = "hi"
 // ^^^^^^^^^ definition 0.1.test `sg/initial`/VarBlock2.
-//           documentation
-//           > ```go
+//           signature_documentation
 //           > var VarBlock2 string
-//           > ```
 //           documentation
 //           > What are docs, really?
 //           > I can't say for sure, I don't write any.
@@ -159,42 +135,29 @@
   // Embedded is a struct, to be embedded in another struct.
   type Embedded struct {
 //     ^^^^^^^^ definition 0.1.test `sg/initial`/Embedded#
-//              documentation
-//              > ```go
+//              signature_documentation
 //              > type Embedded struct
-//              > ```
-//              documentation
-//              > Embedded is a struct, to be embedded in another struct.
-//              documentation
-//              > ```go
 //              > struct {
 //              >     EmbeddedField string
 //              >     Field string
 //              > }
-//              > ```
+//              documentation
+//              > Embedded is a struct, to be embedded in another struct.
    // EmbeddedField has some docs!
    EmbeddedField string
 // ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/Embedded#EmbeddedField.
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > struct field EmbeddedField string
-//               > ```
    Field         string // conflicts with parent "Field"
 // ^^^^^ definition 0.1.test `sg/initial`/Embedded#Field.
-//       documentation
-//       > ```go
+//       signature_documentation
 //       > struct field Field string
-//       > ```
   }
   
   type Struct struct {
 //     ^^^^^^ definition 0.1.test `sg/initial`/Struct#
-//            documentation
-//            > ```go
+//            signature_documentation
 //            > type Struct struct
-//            > ```
-//            documentation
-//            > ```go
 //            > struct {
 //            >     *Embedded
 //            >     Field string
@@ -204,45 +167,32 @@
 //            >         FieldC int
 //            >     }
 //            > }
-//            > ```
 //            relationship 0.1.test `sg/initial`/Interface# implementation
    *Embedded
 //  ^^^^^^^^ definition 0.1.test `sg/initial`/Struct#Embedded.
-//           documentation
-//           > ```go
+//           signature_documentation
 //           > struct field Embedded *sg/initial.Embedded
-//           > ```
 //  ^^^^^^^^ reference 0.1.test `sg/initial`/Embedded#
    Field     string
 // ^^^^^ definition 0.1.test `sg/initial`/Struct#Field.
-//       documentation
-//       > ```go
+//       signature_documentation
 //       > struct field Field string
-//       > ```
    Anonymous struct {
 // ^^^^^^^^^ definition 0.1.test `sg/initial`/Struct#Anonymous.
-//           documentation
-//           > ```go
+//           signature_documentation
 //           > struct field Anonymous struct{FieldA int; FieldB int; FieldC int}
-//           > ```
     FieldA int
 //  ^^^^^^ definition 0.1.test `sg/initial`/Struct#$anon_81475a76ba757de7#FieldA.
-//         documentation
-//         > ```go
+//         signature_documentation
 //         > struct field FieldA int
-//         > ```
     FieldB int
 //  ^^^^^^ definition 0.1.test `sg/initial`/Struct#$anon_81475a76ba757de7#FieldB.
-//         documentation
-//         > ```go
+//         signature_documentation
 //         > struct field FieldB int
-//         > ```
     FieldC int
 //  ^^^^^^ definition 0.1.test `sg/initial`/Struct#$anon_81475a76ba757de7#FieldC.
-//         documentation
-//         > ```go
+//         signature_documentation
 //         > struct field FieldC int
-//         > ```
    }
   }
   
@@ -255,10 +205,8 @@
 //        > var s *sg/initial.Struct
 //         ^^^^^^ reference 0.1.test `sg/initial`/Struct#
 //                 ^^^^^^^^^^^^ definition 0.1.test `sg/initial`/Struct#StructMethod().
-//                              documentation
-//                              > ```go
+//                              signature_documentation
 //                              > func (*Struct).StructMethod()
-//                              > ```
 //                              documentation
 //                              > StructMethod has some docs!
 //                                 ⌃ enclosing_range_end 0.1.test `sg/initial`/Struct#StructMethod().
@@ -271,10 +219,8 @@
 //        > var s *sg/initial.Struct
 //         ^^^^^^ reference 0.1.test `sg/initial`/Struct#
 //                 ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/Struct#ImplementsInterface().
-//                                     documentation
-//                                     > ```go
+//                                     signature_documentation
 //                                     > func (*Struct).ImplementsInterface() string
-//                                     > ```
 //                                     relationship 0.1.test `sg/initial`/Interface#ImplementsInterface. implementation
 //                                                             ⌃ enclosing_range_end 0.1.test `sg/initial`/Struct#ImplementsInterface().
   
@@ -286,10 +232,8 @@
 //        > var s *sg/initial.Struct
 //         ^^^^^^ reference 0.1.test `sg/initial`/Struct#
 //                 ^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/Struct#MachineLearning().
-//                                 documentation
-//                                 > ```go
+//                                 signature_documentation
 //                                 > func (*Struct).MachineLearning(param1 float32, hyperparam2 float32, hyperparam3 float32) float32
-//                                 > ```
    param1 float32, // It's ML, I can't describe what this param is.
 // ^^^^^^ definition local 3
 //        display_name param1
@@ -367,56 +311,41 @@
   // Interface has docs too
   type Interface interface {
 //     ^^^^^^^^^ definition 0.1.test `sg/initial`/Interface#
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > type Interface interface
-//               > ```
-//               documentation
-//               > Interface has docs too
-//               documentation
-//               > ```go
 //               > interface {
 //               >     ImplementsInterface() string
 //               > }
-//               > ```
+//               documentation
+//               > Interface has docs too
    ImplementsInterface() string
 // ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/Interface#ImplementsInterface.
-//                     documentation
-//                     > ```go
+//                     signature_documentation
 //                     > func (Interface).ImplementsInterface() string
-//                     > ```
   }
   
 //⌄ enclosing_range_start 0.1.test `sg/initial`/NewInterface().
   func NewInterface() Interface { return nil }
 //     ^^^^^^^^^^^^ definition 0.1.test `sg/initial`/NewInterface().
-//                  documentation
-//                  > ```go
+//                  signature_documentation
 //                  > func NewInterface() Interface
-//                  > ```
 //                    ^^^^^^^^^ reference 0.1.test `sg/initial`/Interface#
 //                                           ⌃ enclosing_range_end 0.1.test `sg/initial`/NewInterface().
   
   var SortExportedFirst = 1
 //    ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/SortExportedFirst.
-//                      documentation
-//                      > ```go
+//                      signature_documentation
 //                      > var SortExportedFirst int
-//                      > ```
   
   var sortUnexportedSecond = 2
 //    ^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/sortUnexportedSecond.
-//                         documentation
-//                         > ```go
+//                         signature_documentation
 //                         > var sortUnexportedSecond int
-//                         > ```
   
   var _sortUnderscoreLast = 3
 //    ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/_sortUnderscoreLast.
-//                        documentation
-//                        > ```go
+//                        signature_documentation
 //                        > var _sortUnderscoreLast int
-//                        > ```
   
   // Yeah this is some Go magic incantation which is common.
   //
@@ -445,46 +374,32 @@
    // And confusing
    X struct {
 // ^ definition 0.1.test `sg/initial`/X#
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > type X struct
-//   > ```
-//   documentation
-//   > Go can be fun
-//   documentation
-//   > ```go
 //   > struct {
 //   >     bar string
 //   > }
-//   > ```
+//   documentation
+//   > Go can be fun
     bar string
 //  ^^^ definition 0.1.test `sg/initial`/X#bar.
-//      documentation
-//      > ```go
+//      signature_documentation
 //      > struct field bar string
-//      > ```
    }
   
    Y struct {
 // ^ definition 0.1.test `sg/initial`/Y#
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > type Y struct
-//   > ```
-//   documentation
-//   > Go can be fun
-//   documentation
-//   > ```go
 //   > struct {
 //   >     baz float64
 //   > }
-//   > ```
+//   documentation
+//   > Go can be fun
     baz float64
 //  ^^^ definition 0.1.test `sg/initial`/Y#baz.
-//      documentation
-//      > ```go
+//      signature_documentation
 //      > struct field baz float64
-//      > ```
    }
   )
   

--- a/internal/testdata/snapshots/output/initial/child_symbols.go
+++ b/internal/testdata/snapshots/output/initial/child_symbols.go
@@ -200,7 +200,7 @@
 //      ^ definition local 0
 //        display_name s
 //        signature_documentation
-//        > var s *sg/initial.Struct
+//        > var s *Struct
 //         ^^^^^^ reference 0.1.test `sg/initial`/Struct#
 //                 ^^^^^^^^^^^^ definition 0.1.test `sg/initial`/Struct#StructMethod().
 //                              signature_documentation
@@ -214,7 +214,7 @@
 //      ^ definition local 1
 //        display_name s
 //        signature_documentation
-//        > var s *sg/initial.Struct
+//        > var s *Struct
 //         ^^^^^^ reference 0.1.test `sg/initial`/Struct#
 //                 ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/Struct#ImplementsInterface().
 //                                     signature_documentation
@@ -227,7 +227,7 @@
 //      ^ definition local 2
 //        display_name s
 //        signature_documentation
-//        > var s *sg/initial.Struct
+//        > var s *Struct
 //         ^^^^^^ reference 0.1.test `sg/initial`/Struct#
 //                 ^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/Struct#MachineLearning().
 //                                 signature_documentation
@@ -282,7 +282,7 @@
 //      ^^^^^^^^^^^^^^^^^^^^^ definition local 8
 //                            display_name typeShouldNotHaveDocs
 //                            signature_documentation
-//                            > typeShouldNotHaveDocs sg/initial.typeShouldNotHaveDocs
+//                            > typeShouldNotHaveDocs typeShouldNotHaveDocs
 //                                    ^ definition local 9
 //                                      display_name a
 //                                      signature_documentation

--- a/internal/testdata/snapshots/output/initial/child_symbols.go
+++ b/internal/testdata/snapshots/output/initial/child_symbols.go
@@ -138,7 +138,7 @@
 //              signature_documentation
 //              > type Embedded struct {
 //              >     EmbeddedField string
-//              >     Field string
+//              >     Field         string
 //              > }
 //              documentation
 //              > Embedded is a struct, to be embedded in another struct.
@@ -158,7 +158,7 @@
 //            signature_documentation
 //            > type Struct struct {
 //            >     *Embedded
-//            >     Field string
+//            >     Field     string
 //            >     Anonymous struct {
 //            >         FieldA int
 //            >         FieldB int
@@ -310,9 +310,7 @@
   type Interface interface {
 //     ^^^^^^^^^ definition 0.1.test `sg/initial`/Interface#
 //               signature_documentation
-//               > type Interface interface {
-//               >     ImplementsInterface() string
-//               > }
+//               > type Interface interface{ ImplementsInterface() string }
 //               documentation
 //               > Interface has docs too
    ImplementsInterface() string
@@ -372,9 +370,7 @@
    X struct {
 // ^ definition 0.1.test `sg/initial`/X#
 //   signature_documentation
-//   > type X struct {
-//   >     bar string
-//   > }
+//   > type X struct{ bar string }
 //   documentation
 //   > Go can be fun
     bar string
@@ -386,9 +382,7 @@
    Y struct {
 // ^ definition 0.1.test `sg/initial`/Y#
 //   signature_documentation
-//   > type Y struct {
-//   >     baz float64
-//   > }
+//   > type Y struct{ baz float64 }
 //   documentation
 //   > Go can be fun
     baz float64

--- a/internal/testdata/snapshots/output/initial/func_declarations.go
+++ b/internal/testdata/snapshots/output/initial/func_declarations.go
@@ -4,10 +4,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/initial`/UsesLater().
   func UsesLater() {
 //     ^^^^^^^^^ definition 0.1.test `sg/initial`/UsesLater().
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > func UsesLater()
-//               > ```
    DefinedLater()
 // ^^^^^^^^^^^^ reference 0.1.test `sg/initial`/DefinedLater().
   }
@@ -16,9 +14,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/initial`/DefinedLater().
   func DefinedLater() {}
 //     ^^^^^^^^^^^^ definition 0.1.test `sg/initial`/DefinedLater().
-//                  documentation
-//                  > ```go
+//                  signature_documentation
 //                  > func DefinedLater()
-//                  > ```
 //                     ⌃ enclosing_range_end 0.1.test `sg/initial`/DefinedLater().
   

--- a/internal/testdata/snapshots/output/initial/methods_and_receivers.go
+++ b/internal/testdata/snapshots/output/initial/methods_and_receivers.go
@@ -7,8 +7,7 @@
   type MyStruct struct{ f, y int }
 //     ^^^^^^^^ definition 0.1.test `sg/initial`/MyStruct#
 //              signature_documentation
-//              > type MyStruct struct
-//              > struct {
+//              > type MyStruct struct {
 //              >     f int
 //              >     y int
 //              > }

--- a/internal/testdata/snapshots/output/initial/methods_and_receivers.go
+++ b/internal/testdata/snapshots/output/initial/methods_and_receivers.go
@@ -6,27 +6,18 @@
   
   type MyStruct struct{ f, y int }
 //     ^^^^^^^^ definition 0.1.test `sg/initial`/MyStruct#
-//              documentation
-//              > ```go
+//              signature_documentation
 //              > type MyStruct struct
-//              > ```
-//              documentation
-//              > ```go
 //              > struct {
 //              >     f int
 //              >     y int
 //              > }
-//              > ```
 //                      ^ definition 0.1.test `sg/initial`/MyStruct#f.
-//                        documentation
-//                        > ```go
+//                        signature_documentation
 //                        > struct field f int
-//                        > ```
 //                         ^ definition 0.1.test `sg/initial`/MyStruct#y.
-//                           documentation
-//                           > ```go
+//                           signature_documentation
 //                           > struct field y int
-//                           > ```
   
 //⌄ enclosing_range_start 0.1.test `sg/initial`/MyStruct#RecvFunction().
   func (m MyStruct) RecvFunction(b int) int { return m.f + b }
@@ -36,10 +27,8 @@
 //        > var m sg/initial.MyStruct
 //        ^^^^^^^^ reference 0.1.test `sg/initial`/MyStruct#
 //                  ^^^^^^^^^^^^ definition 0.1.test `sg/initial`/MyStruct#RecvFunction().
-//                               documentation
-//                               > ```go
+//                               signature_documentation
 //                               > func (MyStruct).RecvFunction(b int) int
-//                               > ```
 //                               ^ definition local 1
 //                                 display_name b
 //                                 signature_documentation
@@ -52,10 +41,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/initial`/SomethingElse().
   func SomethingElse() {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/SomethingElse().
-//                   documentation
-//                   > ```go
+//                   signature_documentation
 //                   > func SomethingElse()
-//                   > ```
    s := MyStruct{f: 0}
 // ^ definition local 2
 //   display_name s

--- a/internal/testdata/snapshots/output/initial/methods_and_receivers.go
+++ b/internal/testdata/snapshots/output/initial/methods_and_receivers.go
@@ -23,7 +23,7 @@
 //      ^ definition local 0
 //        display_name m
 //        signature_documentation
-//        > var m sg/initial.MyStruct
+//        > var m MyStruct
 //        ^^^^^^^^ reference 0.1.test `sg/initial`/MyStruct#
 //                  ^^^^^^^^^^^^ definition 0.1.test `sg/initial`/MyStruct#RecvFunction().
 //                               signature_documentation
@@ -46,7 +46,7 @@
 // ^ definition local 2
 //   display_name s
 //   signature_documentation
-//   > var s sg/initial.MyStruct
+//   > var s MyStruct
 //      ^^^^^^^^ reference 0.1.test `sg/initial`/MyStruct#
 //               ^ reference 0.1.test `sg/initial`/MyStruct#f.
    fmt.Println(s)

--- a/internal/testdata/snapshots/output/initial/rangefunc.go
+++ b/internal/testdata/snapshots/output/initial/rangefunc.go
@@ -9,10 +9,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/initial`/f().
   func f(xs []int) int {
 //     ^ definition 0.1.test `sg/initial`/f().
-//       documentation
-//       > ```go
+//       signature_documentation
 //       > func f(xs []int) int
-//       > ```
 //       ^^ definition local 0
 //          display_name xs
 //          signature_documentation

--- a/internal/testdata/snapshots/output/initial/toplevel_decls.go
+++ b/internal/testdata/snapshots/output/initial/toplevel_decls.go
@@ -3,25 +3,19 @@
   
   const MY_THING = 10
 //      ^^^^^^^^ definition 0.1.test `sg/initial`/MY_THING.
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > const MY_THING untyped int = 10
-//               > ```
   const OTHER_THING = MY_THING
 //      ^^^^^^^^^^^ definition 0.1.test `sg/initial`/OTHER_THING.
-//                  documentation
-//                  > ```go
+//                  signature_documentation
 //                  > const OTHER_THING untyped int = 10
-//                  > ```
 //                    ^^^^^^^^ reference 0.1.test `sg/initial`/MY_THING.
   
 //⌄ enclosing_range_start 0.1.test `sg/initial`/usesMyThing().
   func usesMyThing() {
 //     ^^^^^^^^^^^ definition 0.1.test `sg/initial`/usesMyThing().
-//                 documentation
-//                 > ```go
+//                 signature_documentation
 //                 > func usesMyThing()
-//                 > ```
    _ = MY_THING
 //     ^^^^^^^^ reference 0.1.test `sg/initial`/MY_THING.
   }
@@ -29,8 +23,6 @@
   
   var initFunctions = map[string]int{}
 //    ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/initFunctions.
-//                  documentation
-//                  > ```go
+//                  signature_documentation
 //                  > var initFunctions map[string]int
-//                  > ```
   

--- a/internal/testdata/snapshots/output/initial/type_declarations.go
+++ b/internal/testdata/snapshots/output/initial/type_declarations.go
@@ -3,48 +3,33 @@
   
   type LiteralType int
 //     ^^^^^^^^^^^ definition 0.1.test `sg/initial`/LiteralType#
-//                 documentation
-//                 > ```go
-//                 > int
-//                 > ```
+//                 signature_documentation
+//                 > type LiteralType int
   
   type FuncType func(LiteralType, int) bool
 //     ^^^^^^^^ definition 0.1.test `sg/initial`/FuncType#
-//              documentation
-//              > ```go
-//              > func(LiteralType, int) bool
-//              > ```
+//              signature_documentation
+//              > type FuncType func(LiteralType, int) bool
 //                   ^^^^^^^^^^^ reference 0.1.test `sg/initial`/LiteralType#
   
   type IfaceType interface {
 //     ^^^^^^^^^ definition 0.1.test `sg/initial`/IfaceType#
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > type IfaceType interface
-//               > ```
-//               documentation
-//               > ```go
 //               > interface {
 //               >     Method() LiteralType
 //               > }
-//               > ```
    Method() LiteralType
 // ^^^^^^ definition 0.1.test `sg/initial`/IfaceType#Method.
-//        documentation
-//        > ```go
+//        signature_documentation
 //        > func (IfaceType).Method() LiteralType
-//        > ```
 //          ^^^^^^^^^^^ reference 0.1.test `sg/initial`/LiteralType#
   }
   
   type StructType struct {
 //     ^^^^^^^^^^ definition 0.1.test `sg/initial`/StructType#
-//                documentation
-//                > ```go
+//                signature_documentation
 //                > type StructType struct
-//                > ```
-//                documentation
-//                > ```go
 //                > struct {
 //                >     m IfaceType
 //                >     f LiteralType
@@ -55,79 +40,54 @@
 //                >         AnonMethod() bool
 //                >     }
 //                > }
-//                > ```
    m IfaceType
 // ^ definition 0.1.test `sg/initial`/StructType#m.
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > struct field m sg/initial.IfaceType
-//   > ```
 //   ^^^^^^^^^ reference 0.1.test `sg/initial`/IfaceType#
    f LiteralType
 // ^ definition 0.1.test `sg/initial`/StructType#f.
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > struct field f sg/initial.LiteralType
-//   > ```
 //   ^^^^^^^^^^^ reference 0.1.test `sg/initial`/LiteralType#
   
    // anonymous struct
    anon struct {
 // ^^^^ definition 0.1.test `sg/initial`/StructType#anon.
-//      documentation
-//      > ```go
+//      signature_documentation
 //      > struct field anon struct{sub int}
-//      > ```
     sub int
 //  ^^^ definition 0.1.test `sg/initial`/StructType#$anon_0ba9ace1dcfd6761#sub.
-//      documentation
-//      > ```go
+//      signature_documentation
 //      > struct field sub int
-//      > ```
    }
   
    // interface within struct
    i interface {
 // ^ definition 0.1.test `sg/initial`/StructType#i.
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > struct field i interface{AnonMethod() bool}
-//   > ```
     AnonMethod() bool
 //  ^^^^^^^^^^ definition 0.1.test `sg/initial`/StructType#$anon_97e7de633e3ef8e8#AnonMethod.
-//             documentation
-//             > ```go
+//             signature_documentation
 //             > func (interface).AnonMethod() bool
-//             > ```
    }
   }
   
   type DeclaredBefore struct{ DeclaredAfter }
 //     ^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/DeclaredBefore#
-//                    documentation
-//                    > ```go
+//                    signature_documentation
 //                    > type DeclaredBefore struct
-//                    > ```
-//                    documentation
-//                    > ```go
 //                    > struct {
 //                    >     DeclaredAfter
 //                    > }
-//                    > ```
 //                            ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/DeclaredBefore#DeclaredAfter.
-//                                          documentation
-//                                          > ```go
+//                                          signature_documentation
 //                                          > struct field DeclaredAfter sg/initial.DeclaredAfter
-//                                          > ```
 //                            ^^^^^^^^^^^^^ reference 0.1.test `sg/initial`/DeclaredAfter#
   type DeclaredAfter struct{}
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/DeclaredAfter#
-//                   documentation
-//                   > ```go
+//                   signature_documentation
 //                   > type DeclaredAfter struct
-//                   > ```
-//                   documentation
-//                   > ```go
 //                   > struct{}
-//                   > ```
   

--- a/internal/testdata/snapshots/output/initial/type_declarations.go
+++ b/internal/testdata/snapshots/output/initial/type_declarations.go
@@ -15,8 +15,7 @@
   type IfaceType interface {
 //     ^^^^^^^^^ definition 0.1.test `sg/initial`/IfaceType#
 //               signature_documentation
-//               > type IfaceType interface
-//               > interface {
+//               > type IfaceType interface {
 //               >     Method() LiteralType
 //               > }
    Method() LiteralType
@@ -29,8 +28,7 @@
   type StructType struct {
 //     ^^^^^^^^^^ definition 0.1.test `sg/initial`/StructType#
 //                signature_documentation
-//                > type StructType struct
-//                > struct {
+//                > type StructType struct {
 //                >     m IfaceType
 //                >     f LiteralType
 //                >     anon struct {
@@ -77,8 +75,7 @@
   type DeclaredBefore struct{ DeclaredAfter }
 //     ^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/DeclaredBefore#
 //                    signature_documentation
-//                    > type DeclaredBefore struct
-//                    > struct {
+//                    > type DeclaredBefore struct {
 //                    >     DeclaredAfter
 //                    > }
 //                            ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/DeclaredBefore#DeclaredAfter.
@@ -88,6 +85,5 @@
   type DeclaredAfter struct{}
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/DeclaredAfter#
 //                   signature_documentation
-//                   > type DeclaredAfter struct
-//                   > struct{}
+//                   > type DeclaredAfter struct{}
   

--- a/internal/testdata/snapshots/output/initial/type_declarations.go
+++ b/internal/testdata/snapshots/output/initial/type_declarations.go
@@ -15,9 +15,7 @@
   type IfaceType interface {
 //     ^^^^^^^^^ definition 0.1.test `sg/initial`/IfaceType#
 //               signature_documentation
-//               > type IfaceType interface {
-//               >     Method() LiteralType
-//               > }
+//               > type IfaceType interface{ Method() LiteralType }
    Method() LiteralType
 // ^^^^^^ definition 0.1.test `sg/initial`/IfaceType#Method.
 //        signature_documentation
@@ -29,14 +27,10 @@
 //     ^^^^^^^^^^ definition 0.1.test `sg/initial`/StructType#
 //                signature_documentation
 //                > type StructType struct {
-//                >     m IfaceType
-//                >     f LiteralType
-//                >     anon struct {
-//                >         sub int
-//                >     }
-//                >     i interface {
-//                >         AnonMethod() bool
-//                >     }
+//                >     m    IfaceType
+//                >     f    LiteralType
+//                >     anon struct{ sub int }
+//                >     i    interface{ AnonMethod() bool }
 //                > }
    m IfaceType
 // ^ definition 0.1.test `sg/initial`/StructType#m.
@@ -75,9 +69,7 @@
   type DeclaredBefore struct{ DeclaredAfter }
 //     ^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/DeclaredBefore#
 //                    signature_documentation
-//                    > type DeclaredBefore struct {
-//                    >     DeclaredAfter
-//                    > }
+//                    > type DeclaredBefore struct{ DeclaredAfter }
 //                            ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/DeclaredBefore#DeclaredAfter.
 //                                          signature_documentation
 //                                          > struct field DeclaredAfter sg/initial.DeclaredAfter

--- a/internal/testdata/snapshots/output/initial/type_hovers.go
+++ b/internal/testdata/snapshots/output/initial/type_hovers.go
@@ -5,27 +5,17 @@
    // HoverTypeList is a cool struct
    HoverTypeList struct{}
 // ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/HoverTypeList#
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > type HoverTypeList struct
-//               > ```
-//               documentation
-//               > ```go
 //               > struct{}
-//               > ```
   )
   
   // This should show up as well
   type HoverType struct{}
 //     ^^^^^^^^^ definition 0.1.test `sg/initial`/HoverType#
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > type HoverType struct
-//               > ```
+//               > struct{}
 //               documentation
 //               > This should show up as well
-//               documentation
-//               > ```go
-//               > struct{}
-//               > ```
   

--- a/internal/testdata/snapshots/output/initial/type_hovers.go
+++ b/internal/testdata/snapshots/output/initial/type_hovers.go
@@ -6,16 +6,14 @@
    HoverTypeList struct{}
 // ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/HoverTypeList#
 //               signature_documentation
-//               > type HoverTypeList struct
-//               > struct{}
+//               > type HoverTypeList struct{}
   )
   
   // This should show up as well
   type HoverType struct{}
 //     ^^^^^^^^^ definition 0.1.test `sg/initial`/HoverType#
 //               signature_documentation
-//               > type HoverType struct
-//               > struct{}
+//               > type HoverType struct{}
 //               documentation
 //               > This should show up as well
   

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct.go
@@ -7,9 +7,7 @@
   type FieldInterface interface {
 //     ^^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/FieldInterface#
 //                    signature_documentation
-//                    > type FieldInterface interface {
-//                    >     SomeMethod() string
-//                    > }
+//                    > type FieldInterface interface{ SomeMethod() string }
    SomeMethod() string
 // ^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/FieldInterface#SomeMethod.
 //            signature_documentation

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct.go
@@ -7,8 +7,7 @@
   type FieldInterface interface {
 //     ^^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/FieldInterface#
 //                    signature_documentation
-//                    > type FieldInterface interface
-//                    > interface {
+//                    > type FieldInterface interface {
 //                    >     SomeMethod() string
 //                    > }
    SomeMethod() string

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct.go
@@ -6,53 +6,38 @@
   
   type FieldInterface interface {
 //     ^^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/FieldInterface#
-//                    documentation
-//                    > ```go
+//                    signature_documentation
 //                    > type FieldInterface interface
-//                    > ```
-//                    documentation
-//                    > ```go
 //                    > interface {
 //                    >     SomeMethod() string
 //                    > }
-//                    > ```
    SomeMethod() string
 // ^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/FieldInterface#SomeMethod.
-//            documentation
-//            > ```go
+//            signature_documentation
 //            > func (FieldInterface).SomeMethod() string
-//            > ```
   }
   
   var MyInline = struct {
 //    ^^^^^^^^ definition 0.1.test `sg/inlinestruct`/MyInline.
-//             documentation
-//             > ```go
+//             signature_documentation
 //             > var MyInline struct{privateField FieldInterface; PublicField FieldInterface}
-//             > ```
    privateField FieldInterface
 // ^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/MyInline:privateField.
-//              documentation
-//              > ```go
+//              signature_documentation
 //              > struct field privateField sg/inlinestruct.FieldInterface
-//              > ```
 //              ^^^^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/FieldInterface#
    PublicField  FieldInterface
 // ^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/MyInline:PublicField.
-//             documentation
-//             > ```go
+//             signature_documentation
 //             > struct field PublicField sg/inlinestruct.FieldInterface
-//             > ```
 //              ^^^^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/FieldInterface#
   }{}
   
 //⌄ enclosing_range_start 0.1.test `sg/inlinestruct`/MyFunc().
   func MyFunc() {
 //     ^^^^^^ definition 0.1.test `sg/inlinestruct`/MyFunc().
-//            documentation
-//            > ```go
+//            signature_documentation
 //            > func MyFunc()
-//            > ```
    _ = MyInline.privateField
 //     ^^^^^^^^ reference 0.1.test `sg/inlinestruct`/MyInline.
 //              ^^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/MyInline:privateField.

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_func.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_func.go
@@ -3,29 +3,20 @@
   
   type InFuncSig struct {
 //     ^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/InFuncSig#
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > type InFuncSig struct
-//               > ```
-//               documentation
-//               > ```go
 //               > struct {
 //               >     value bool
 //               > }
-//               > ```
    value bool
 // ^^^^^ definition 0.1.test `sg/inlinestruct`/InFuncSig#value.
-//       documentation
-//       > ```go
+//       signature_documentation
 //       > struct field value bool
-//       > ```
   }
   
   var rowsCloseHook = func() func(InFuncSig, *error) { return nil }
 //    ^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/rowsCloseHook.
-//                  documentation
-//                  > ```go
+//                  signature_documentation
 //                  > var rowsCloseHook func() func(InFuncSig, *error)
-//                  > ```
 //                                ^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/InFuncSig#
   

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_func.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_func.go
@@ -4,9 +4,7 @@
   type InFuncSig struct {
 //     ^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/InFuncSig#
 //               signature_documentation
-//               > type InFuncSig struct {
-//               >     value bool
-//               > }
+//               > type InFuncSig struct{ value bool }
    value bool
 // ^^^^^ definition 0.1.test `sg/inlinestruct`/InFuncSig#value.
 //       signature_documentation

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_func.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_func.go
@@ -4,8 +4,7 @@
   type InFuncSig struct {
 //     ^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/InFuncSig#
 //               signature_documentation
-//               > type InFuncSig struct
-//               > struct {
+//               > type InFuncSig struct {
 //               >     value bool
 //               > }
    value bool

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_genericindex.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_genericindex.go
@@ -42,7 +42,7 @@
 //      ^ definition local 2
 //        display_name p
 //        signature_documentation
-//        > var p *sg/inlinestruct.ProcessImpl
+//        > var p *ProcessImpl
 //         ^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/ProcessImpl#
 //                      ^^^^^^^ definition 0.1.test `sg/inlinestruct`/ProcessImpl#Process().
 //                              signature_documentation
@@ -50,7 +50,7 @@
 //                              ^^^^^^^ definition local 3
 //                                      display_name payload
 //                                      signature_documentation
-//                                      > var payload sg/inlinestruct.Limit
+//                                      > var payload Limit
 //                                      ^^^^^ reference 0.1.test `sg/inlinestruct`/Limit#
 //                                                                        ⌃ enclosing_range_end 0.1.test `sg/inlinestruct`/ProcessImpl#Process().
 //⌄ enclosing_range_start 0.1.test `sg/inlinestruct`/ProcessImpl#ProcessorType().
@@ -58,7 +58,7 @@
 //      ^ definition local 4
 //        display_name p
 //        signature_documentation
-//        > var p *sg/inlinestruct.ProcessImpl
+//        > var p *ProcessImpl
 //         ^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/ProcessImpl#
 //                      ^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/ProcessImpl#ProcessorType().
 //                                    signature_documentation

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_genericindex.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_genericindex.go
@@ -3,27 +3,20 @@
   
   type Processor[T any] interface {
 //     ^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/Processor#
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > type Processor interface
-//               > ```
-//               documentation
-//               > ```go
 //               > interface {
 //               >     Process(payload T)
 //               >     ProcessorType() string
 //               > }
-//               > ```
 //               ^ definition local 0
 //                 display_name T
 //                 signature_documentation
 //                 > T T
    Process(payload T)
 // ^^^^^^^ definition 0.1.test `sg/inlinestruct`/Processor#Process.
-//         documentation
-//         > ```go
+//         signature_documentation
 //         > func (Processor[T any]).Process(payload T)
-//         > ```
 //         ^^^^^^^ definition local 1
 //                 display_name payload
 //                 signature_documentation
@@ -31,29 +24,20 @@
 //                 ^ reference local 0
    ProcessorType() string
 // ^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/Processor#ProcessorType.
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > func (Processor[T any]).ProcessorType() string
-//               > ```
   }
   
   type Limit int
 //     ^^^^^ definition 0.1.test `sg/inlinestruct`/Limit#
-//           documentation
-//           > ```go
-//           > int
-//           > ```
+//           signature_documentation
+//           > type Limit int
   
   type ProcessImpl struct{}
 //     ^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/ProcessImpl#
-//                 documentation
-//                 > ```go
+//                 signature_documentation
 //                 > type ProcessImpl struct
-//                 > ```
-//                 documentation
-//                 > ```go
 //                 > struct{}
-//                 > ```
   
 //⌄ enclosing_range_start 0.1.test `sg/inlinestruct`/ProcessImpl#Process().
   func (p *ProcessImpl) Process(payload Limit) { panic("not implemented") }
@@ -63,10 +47,8 @@
 //        > var p *sg/inlinestruct.ProcessImpl
 //         ^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/ProcessImpl#
 //                      ^^^^^^^ definition 0.1.test `sg/inlinestruct`/ProcessImpl#Process().
-//                              documentation
-//                              > ```go
+//                              signature_documentation
 //                              > func (*ProcessImpl).Process(payload Limit)
-//                              > ```
 //                              ^^^^^^^ definition local 3
 //                                      display_name payload
 //                                      signature_documentation
@@ -81,10 +63,8 @@
 //        > var p *sg/inlinestruct.ProcessImpl
 //         ^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/ProcessImpl#
 //                      ^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/ProcessImpl#ProcessorType().
-//                                    documentation
-//                                    > ```go
+//                                    signature_documentation
 //                                    > func (*ProcessImpl).ProcessorType() string
-//                                    > ```
 //                                                                        ⌃ enclosing_range_end 0.1.test `sg/inlinestruct`/ProcessImpl#ProcessorType().
   
   var _ Processor[Limit] = &ProcessImpl{}

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_genericindex.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_genericindex.go
@@ -4,8 +4,7 @@
   type Processor[T any] interface {
 //     ^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/Processor#
 //               signature_documentation
-//               > type Processor interface
-//               > interface {
+//               > type Processor interface {
 //               >     Process(payload T)
 //               >     ProcessorType() string
 //               > }
@@ -36,8 +35,7 @@
   type ProcessImpl struct{}
 //     ^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/ProcessImpl#
 //                 signature_documentation
-//                 > type ProcessImpl struct
-//                 > struct{}
+//                 > type ProcessImpl struct{}
   
 //⌄ enclosing_range_start 0.1.test `sg/inlinestruct`/ProcessImpl#Process().
   func (p *ProcessImpl) Process(payload Limit) { panic("not implemented") }

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_interface.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_interface.go
@@ -47,7 +47,7 @@
 // ^ definition local 0
 //   display_name x
 //   signature_documentation
-//   > var x interface{AbbreviatedOID(context.Context) (string, error); Commit(context.Context) (string, error); OID(context.Context) (int, error); Type(context.Context) (int, error)}
+//   > var x interface{AbbreviatedOID(Context) (string, error); Commit(Context) (string, error); OID(Context) (int, error); Type(Context) (int, error)}
 //      ^^^^^^ reference 0.1.test `sg/inlinestruct`/Target().
    x.OID(context.Background())
 // ^ reference local 0

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_interface.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_interface.go
@@ -7,40 +7,30 @@
 //⌄ enclosing_range_start 0.1.test `sg/inlinestruct`/Target().
   func Target() interface {
 //     ^^^^^^ definition 0.1.test `sg/inlinestruct`/Target().
-//            documentation
-//            > ```go
+//            signature_documentation
 //            > func Target() interface{AbbreviatedOID(Context) (string, error); Commit(Context) (string, error); OID(Context) (int, error); Type(Context) (int, error)}
-//            > ```
    OID(context.Context) (int, error)
 // ^^^ definition 0.1.test `sg/inlinestruct`/func:Target:OID().
-//     documentation
-//     > ```go
+//     signature_documentation
 //     > func (interface).OID(Context) (int, error)
-//     > ```
 //     ^^^^^^^ reference github.com/golang/go/src go1.22 context/
 //             ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
    AbbreviatedOID(context.Context) (string, error)
 // ^^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/func:Target:AbbreviatedOID().
-//                documentation
-//                > ```go
+//                signature_documentation
 //                > func (interface).AbbreviatedOID(Context) (string, error)
-//                > ```
 //                ^^^^^^^ reference github.com/golang/go/src go1.22 context/
 //                        ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
    Commit(context.Context) (string, error)
 // ^^^^^^ definition 0.1.test `sg/inlinestruct`/func:Target:Commit().
-//        documentation
-//        > ```go
+//        signature_documentation
 //        > func (interface).Commit(Context) (string, error)
-//        > ```
 //        ^^^^^^^ reference github.com/golang/go/src go1.22 context/
 //                ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
    Type(context.Context) (int, error)
 // ^^^^ definition 0.1.test `sg/inlinestruct`/func:Target:Type().
-//      documentation
-//      > ```go
+//      signature_documentation
 //      > func (interface).Type(Context) (int, error)
-//      > ```
 //      ^^^^^^^ reference github.com/golang/go/src go1.22 context/
 //              ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
   } {
@@ -51,10 +41,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/inlinestruct`/something().
   func something() {
 //     ^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/something().
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > func something()
-//               > ```
    x := Target()
 // ^ definition local 0
 //   display_name x

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_map.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_map.go
@@ -3,8 +3,6 @@
   
   var testHook = func(map[string]string) {}
 //    ^^^^^^^^ definition 0.1.test `sg/inlinestruct`/testHook.
-//             documentation
-//             > ```go
+//             signature_documentation
 //             > var testHook func(map[string]string)
-//             > ```
   

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_multivar.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_multivar.go
@@ -4,13 +4,11 @@
   type Params struct{}
 //     ^^^^^^ definition 0.1.test `sg/inlinestruct`/Params#
 //            signature_documentation
-//            > type Params struct
-//            > struct{}
+//            > type Params struct{}
   type HighlightedCode struct{}
 //     ^^^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/HighlightedCode#
 //                     signature_documentation
-//                     > type HighlightedCode struct
-//                     > struct{}
+//                     > type HighlightedCode struct{}
   
   var Mocks, emptyMocks struct {
 //    ^^^^^ definition 0.1.test `sg/inlinestruct`/Mocks.

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_multivar.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_multivar.go
@@ -3,42 +3,26 @@
   
   type Params struct{}
 //     ^^^^^^ definition 0.1.test `sg/inlinestruct`/Params#
-//            documentation
-//            > ```go
+//            signature_documentation
 //            > type Params struct
-//            > ```
-//            documentation
-//            > ```go
 //            > struct{}
-//            > ```
   type HighlightedCode struct{}
 //     ^^^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/HighlightedCode#
-//                     documentation
-//                     > ```go
+//                     signature_documentation
 //                     > type HighlightedCode struct
-//                     > ```
-//                     documentation
-//                     > ```go
 //                     > struct{}
-//                     > ```
   
   var Mocks, emptyMocks struct {
 //    ^^^^^ definition 0.1.test `sg/inlinestruct`/Mocks.
-//          documentation
-//          > ```go
+//          signature_documentation
 //          > var Mocks struct{Code func(p Params) (response *HighlightedCode, aborted bool, err error)}
-//          > ```
 //           ^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/emptyMocks.
-//                      documentation
-//                      > ```go
+//                      signature_documentation
 //                      > var emptyMocks struct{Code func(p Params) (response *HighlightedCode, aborted bool, err error)}
-//                      > ```
    Code func(p Params) (response *HighlightedCode, aborted bool, err error)
 // ^^^^ definition 0.1.test `sg/inlinestruct`/inline-6-5:Code.
-//      documentation
-//      > ```go
+//      signature_documentation
 //      > struct field Code func(p sg/inlinestruct.Params) (response *sg/inlinestruct.HighlightedCode, aborted bool, err error)
-//      > ```
 //           ^ definition local 0
 //             display_name p
 //             signature_documentation
@@ -61,16 +45,12 @@
   
   var MocksSingle struct {
 //    ^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/MocksSingle.
-//                documentation
-//                > ```go
+//                signature_documentation
 //                > var MocksSingle struct{Code func(p Params) (response *HighlightedCode, aborted bool, err error)}
-//                > ```
    Code func(p Params) (response *HighlightedCode, aborted bool, err error)
 // ^^^^ definition 0.1.test `sg/inlinestruct`/MocksSingle:Code.
-//      documentation
-//      > ```go
+//      signature_documentation
 //      > struct field Code func(p sg/inlinestruct.Params) (response *sg/inlinestruct.HighlightedCode, aborted bool, err error)
-//      > ```
 //           ^ definition local 4
 //             display_name p
 //             signature_documentation
@@ -94,15 +74,11 @@
   var (
    okReply   interface{} = "OK"
 // ^^^^^^^ definition 0.1.test `sg/inlinestruct`/okReply.
-//         documentation
-//         > ```go
+//         signature_documentation
 //         > var okReply interface{}
-//         > ```
    pongReply interface{} = "PONG"
 // ^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/pongReply.
-//           documentation
-//           > ```go
+//           signature_documentation
 //           > var pongReply interface{}
-//           > ```
   )
   

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_multivar.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_multivar.go
@@ -24,12 +24,12 @@
 //           ^ definition local 0
 //             display_name p
 //             signature_documentation
-//             > var p sg/inlinestruct.Params
+//             > var p Params
 //             ^^^^^^ reference 0.1.test `sg/inlinestruct`/Params#
 //                      ^^^^^^^^ definition local 1
 //                               display_name response
 //                               signature_documentation
-//                               > var response *sg/inlinestruct.HighlightedCode
+//                               > var response *HighlightedCode
 //                                ^^^^^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/HighlightedCode#
 //                                                 ^^^^^^^ definition local 2
 //                                                         display_name aborted
@@ -52,12 +52,12 @@
 //           ^ definition local 4
 //             display_name p
 //             signature_documentation
-//             > var p sg/inlinestruct.Params
+//             > var p Params
 //             ^^^^^^ reference 0.1.test `sg/inlinestruct`/Params#
 //                      ^^^^^^^^ definition local 5
 //                               display_name response
 //                               signature_documentation
-//                               > var response *sg/inlinestruct.HighlightedCode
+//                               > var response *HighlightedCode
 //                                ^^^^^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/HighlightedCode#
 //                                                 ^^^^^^^ definition local 6
 //                                                         display_name aborted

--- a/internal/testdata/snapshots/output/package-documentation/primary.go
+++ b/internal/testdata/snapshots/output/package-documentation/primary.go
@@ -10,9 +10,7 @@
 //⌄ enclosing_range_start github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/package-documentation`/Exported().
   func Exported() {}
 //     ^^^^^^^^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/package-documentation`/Exported().
-//              documentation
-//              > ```go
+//              signature_documentation
 //              > func Exported()
-//              > ```
 //                 ⌃ enclosing_range_end github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/package-documentation`/Exported().
   

--- a/internal/testdata/snapshots/output/package-documentation/secondary.go
+++ b/internal/testdata/snapshots/output/package-documentation/secondary.go
@@ -4,9 +4,7 @@
 //⌄ enclosing_range_start github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/package-documentation`/AlsoExporter().
   func AlsoExporter() {}
 //     ^^^^^^^^^^^^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/package-documentation`/AlsoExporter().
-//                  documentation
-//                  > ```go
+//                  signature_documentation
 //                  > func AlsoExporter()
-//                  > ```
 //                     ⌃ enclosing_range_end github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/package-documentation`/AlsoExporter().
   

--- a/internal/testdata/snapshots/output/pr199/doc.go
+++ b/internal/testdata/snapshots/output/pr199/doc.go
@@ -16,9 +16,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr199`/FromDoc().
   func FromDoc() {}
 //     ^^^^^^^ definition 0.1.test `sg/pr199`/FromDoc().
-//             documentation
-//             > ```go
+//             signature_documentation
 //             > func FromDoc()
-//             > ```
 //                ⌃ enclosing_range_end 0.1.test `sg/pr199`/FromDoc().
   

--- a/internal/testdata/snapshots/output/pr199/no_doc.go
+++ b/internal/testdata/snapshots/output/pr199/no_doc.go
@@ -5,9 +5,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr199`/FromNoDoc().
   func FromNoDoc() {}
 //     ^^^^^^^^^ definition 0.1.test `sg/pr199`/FromNoDoc().
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > func FromNoDoc()
-//               > ```
 //                  ⌃ enclosing_range_end 0.1.test `sg/pr199`/FromNoDoc().
   

--- a/internal/testdata/snapshots/output/pr199/pr199.go
+++ b/internal/testdata/snapshots/output/pr199/pr199.go
@@ -5,9 +5,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr199`/FromMain().
   func FromMain() {}
 //     ^^^^^^^^ definition 0.1.test `sg/pr199`/FromMain().
-//              documentation
-//              > ```go
+//              signature_documentation
 //              > func FromMain()
-//              > ```
 //                 ⌃ enclosing_range_end 0.1.test `sg/pr199`/FromMain().
   

--- a/internal/testdata/snapshots/output/pr199/pr199_test.go
+++ b/internal/testdata/snapshots/output/pr199/pr199_test.go
@@ -8,10 +8,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr199`/TestExample().
   func TestExample(t *testing.T) {}
 //     ^^^^^^^^^^^ definition 0.1.test `sg/pr199`/TestExample().
-//                 documentation
-//                 > ```go
+//                 signature_documentation
 //                 > func TestExample(t *T)
-//                 > ```
 //                 ^ definition local 0
 //                   display_name t
 //                   signature_documentation

--- a/internal/testdata/snapshots/output/pr199/pr199_test.go
+++ b/internal/testdata/snapshots/output/pr199/pr199_test.go
@@ -13,7 +13,7 @@
 //                 ^ definition local 0
 //                   display_name t
 //                   signature_documentation
-//                   > var t *testing.T
+//                   > var t *T
 //                    ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
 //                            ^ reference github.com/golang/go/src go1.22 testing/T#
 //                                ⌃ enclosing_range_end 0.1.test `sg/pr199`/TestExample().

--- a/internal/testdata/snapshots/output/pr201/imports.go
+++ b/internal/testdata/snapshots/output/pr201/imports.go
@@ -27,10 +27,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr201`/UseImports().
   func UseImports() {
 //     ^^^^^^^^^^ definition 0.1.test `sg/pr201`/UseImports().
-//                documentation
-//                > ```go
+//                signature_documentation
 //                > func UseImports()
-//                > ```
    fmt.Println(context.Background())
 // ^^^ reference github.com/golang/go/src go1.22 fmt/
 //     ^^^^^^^ reference github.com/golang/go/src go1.22 fmt/Println().

--- a/internal/testdata/snapshots/output/pr202/identical_anon_types.go
+++ b/internal/testdata/snapshots/output/pr202/identical_anon_types.go
@@ -42,7 +42,7 @@
 //     ^ definition local 0
 //       display_name y
 //       signature_documentation
-//       > var y sg/pr202.IdenticalAnonFields
+//       > var y IdenticalAnonFields
 //       ^^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/pr202`/IdenticalAnonFields#
    y.x = y.z
 // ^ reference local 0

--- a/internal/testdata/snapshots/output/pr202/identical_anon_types.go
+++ b/internal/testdata/snapshots/output/pr202/identical_anon_types.go
@@ -9,8 +9,7 @@
   type IdenticalAnonFields struct {
 //     ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/IdenticalAnonFields#
 //                         signature_documentation
-//                         > type IdenticalAnonFields struct
-//                         > struct {
+//                         > type IdenticalAnonFields struct {
 //                         >     x struct {
 //                         >         t int
 //                         >     }
@@ -65,8 +64,7 @@
   type FieldOrderMatters struct {
 //     ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/FieldOrderMatters#
 //                       signature_documentation
-//                       > type FieldOrderMatters struct
-//                       > struct {
+//                       > type FieldOrderMatters struct {
 //                       >     a struct {
 //                       >         x int
 //                       >         y string
@@ -110,8 +108,7 @@
   type DifferentTags struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/DifferentTags#
 //                   signature_documentation
-//                   > type DifferentTags struct
-//                   > struct {
+//                   > type DifferentTags struct {
 //                   >     a struct {
 //                   >         Name string `json:"name"`
 //                   >     }

--- a/internal/testdata/snapshots/output/pr202/identical_anon_types.go
+++ b/internal/testdata/snapshots/output/pr202/identical_anon_types.go
@@ -10,12 +10,8 @@
 //     ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/IdenticalAnonFields#
 //                         signature_documentation
 //                         > type IdenticalAnonFields struct {
-//                         >     x struct {
-//                         >         t int
-//                         >     }
-//                         >     z struct {
-//                         >         t int
-//                         >     }
+//                         >     x struct{ t int }
+//                         >     z struct{ t int }
 //                         > }
    x struct{ t int }
 // ^ definition 0.1.test `sg/pr202`/IdenticalAnonFields#x.
@@ -110,10 +106,10 @@
 //                   signature_documentation
 //                   > type DifferentTags struct {
 //                   >     a struct {
-//                   >         Name string `json:"name"`
+//                   >         Name string "json:\"name\""
 //                   >     }
 //                   >     b struct {
-//                   >         Name string `json:"full_name"`
+//                   >         Name string "json:\"full_name\""
 //                   >     }
 //                   > }
 //                   documentation

--- a/internal/testdata/snapshots/output/pr202/identical_anon_types.go
+++ b/internal/testdata/snapshots/output/pr202/identical_anon_types.go
@@ -8,12 +8,8 @@
   
   type IdenticalAnonFields struct {
 //     ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/IdenticalAnonFields#
-//                         documentation
-//                         > ```go
+//                         signature_documentation
 //                         > type IdenticalAnonFields struct
-//                         > ```
-//                         documentation
-//                         > ```go
 //                         > struct {
 //                         >     x struct {
 //                         >         t int
@@ -22,38 +18,27 @@
 //                         >         t int
 //                         >     }
 //                         > }
-//                         > ```
    x struct{ t int }
 // ^ definition 0.1.test `sg/pr202`/IdenticalAnonFields#x.
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > struct field x struct{t int}
-//   > ```
 //           ^ definition 0.1.test `sg/pr202`/IdenticalAnonFields#$anon_44af0565eb406c15#t.
-//             documentation
-//             > ```go
+//             signature_documentation
 //             > struct field t int
-//             > ```
    z struct{ t int }
 // ^ definition 0.1.test `sg/pr202`/IdenticalAnonFields#z.
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > struct field z struct{t int}
-//   > ```
 //           ^ definition 0.1.test `sg/pr202`/IdenticalAnonFields#$anon_44af0565eb406c15#t.
-//             documentation
-//             > ```go
+//             signature_documentation
 //             > struct field t int
-//             > ```
   }
   
 //⌄ enclosing_range_start 0.1.test `sg/pr202`/useIdenticalAnonFields().
   func useIdenticalAnonFields() {
 //     ^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/useIdenticalAnonFields().
-//                            documentation
-//                            > ```go
+//                            signature_documentation
 //                            > func useIdenticalAnonFields()
-//                            > ```
    var y IdenticalAnonFields
 //     ^ definition local 0
 //       display_name y
@@ -79,14 +64,8 @@
   // Different field order means different type — symbols must NOT unify.
   type FieldOrderMatters struct {
 //     ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/FieldOrderMatters#
-//                       documentation
-//                       > ```go
+//                       signature_documentation
 //                       > type FieldOrderMatters struct
-//                       > ```
-//                       documentation
-//                       > Different field order means different type — symbols must NOT unify.
-//                       documentation
-//                       > ```go
 //                       > struct {
 //                       >     a struct {
 //                       >         x int
@@ -97,58 +76,41 @@
 //                       >         x int
 //                       >     }
 //                       > }
-//                       > ```
+//                       documentation
+//                       > Different field order means different type — symbols must NOT unify.
    a struct {
 // ^ definition 0.1.test `sg/pr202`/FieldOrderMatters#a.
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > struct field a struct{x int; y string}
-//   > ```
     x int
 //  ^ definition 0.1.test `sg/pr202`/FieldOrderMatters#$anon_c0a8952b3a214f68#x.
-//    documentation
-//    > ```go
+//    signature_documentation
 //    > struct field x int
-//    > ```
     y string
 //  ^ definition 0.1.test `sg/pr202`/FieldOrderMatters#$anon_c0a8952b3a214f68#y.
-//    documentation
-//    > ```go
+//    signature_documentation
 //    > struct field y string
-//    > ```
    }
    b struct {
 // ^ definition 0.1.test `sg/pr202`/FieldOrderMatters#b.
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > struct field b struct{y string; x int}
-//   > ```
     y string
 //  ^ definition 0.1.test `sg/pr202`/FieldOrderMatters#$anon_b8d88f3211c0d7a4#y.
-//    documentation
-//    > ```go
+//    signature_documentation
 //    > struct field y string
-//    > ```
     x int
 //  ^ definition 0.1.test `sg/pr202`/FieldOrderMatters#$anon_b8d88f3211c0d7a4#x.
-//    documentation
-//    > ```go
+//    signature_documentation
 //    > struct field x int
-//    > ```
    }
   }
   
   // Different struct tags — symbols must NOT unify.
   type DifferentTags struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/DifferentTags#
-//                   documentation
-//                   > ```go
+//                   signature_documentation
 //                   > type DifferentTags struct
-//                   > ```
-//                   documentation
-//                   > Different struct tags — symbols must NOT unify.
-//                   documentation
-//                   > ```go
 //                   > struct {
 //                   >     a struct {
 //                   >         Name string `json:"name"`
@@ -157,32 +119,25 @@
 //                   >         Name string `json:"full_name"`
 //                   >     }
 //                   > }
-//                   > ```
+//                   documentation
+//                   > Different struct tags — symbols must NOT unify.
    a struct {
 // ^ definition 0.1.test `sg/pr202`/DifferentTags#a.
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > struct field a struct{Name string `json:"name"`}
-//   > ```
     Name string `json:"name"`
 //  ^^^^ definition 0.1.test `sg/pr202`/DifferentTags#$anon_ed545d904f2246eb#Name.
-//       documentation
-//       > ```go
+//       signature_documentation
 //       > struct field Name string
-//       > ```
    }
    b struct {
 // ^ definition 0.1.test `sg/pr202`/DifferentTags#b.
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > struct field b struct{Name string `json:"full_name"`}
-//   > ```
     Name string `json:"full_name"`
 //  ^^^^ definition 0.1.test `sg/pr202`/DifferentTags#$anon_29f1ad2683b11ed0#Name.
-//       documentation
-//       > ```go
+//       signature_documentation
 //       > struct field Name string
-//       > ```
    }
   }
   

--- a/internal/testdata/snapshots/output/pr202/local_anon.go
+++ b/internal/testdata/snapshots/output/pr202/local_anon.go
@@ -6,10 +6,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr202`/localAnonymousStructs().
   func localAnonymousStructs() {
 //     ^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/localAnonymousStructs().
-//                           documentation
-//                           > ```go
+//                           signature_documentation
 //                           > func localAnonymousStructs()
-//                           > ```
    a := struct{ x int }{x: 1}
 // ^ definition local 0
 //   display_name a
@@ -42,10 +40,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr202`/paramAnonymousStruct().
   func paramAnonymousStruct(p struct{ x int }) int {
 //     ^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/paramAnonymousStruct().
-//                          documentation
-//                          > ```go
+//                          signature_documentation
 //                          > func paramAnonymousStruct(p struct{x int}) int
-//                          > ```
 //                          ^ definition local 4
 //                            display_name p
 //                            signature_documentation

--- a/internal/testdata/snapshots/output/pr202/multiname_fields.go
+++ b/internal/testdata/snapshots/output/pr202/multiname_fields.go
@@ -43,7 +43,7 @@
 //     ^ definition local 0
 //       display_name m
 //       signature_documentation
-//       > var m sg/pr202.MultiNameStruct
+//       > var m MultiNameStruct
 //       ^^^^^^^^^^^^^^^ reference 0.1.test `sg/pr202`/MultiNameStruct#
    m.a.x = 1
 // ^ reference local 0

--- a/internal/testdata/snapshots/output/pr202/multiname_fields.go
+++ b/internal/testdata/snapshots/output/pr202/multiname_fields.go
@@ -5,12 +5,8 @@
   
   type MultiNameStruct struct {
 //     ^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/MultiNameStruct#
-//                     documentation
-//                     > ```go
+//                     signature_documentation
 //                     > type MultiNameStruct struct
-//                     > ```
-//                     documentation
-//                     > ```go
 //                     > struct {
 //                     >     a struct {
 //                     >         x int
@@ -21,40 +17,29 @@
 //                     >         y string
 //                     >     }
 //                     > }
-//                     > ```
    a, b struct {
 // ^ definition 0.1.test `sg/pr202`/MultiNameStruct#a.
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > struct field a struct{x int; y string}
-//   > ```
 //    ^ definition 0.1.test `sg/pr202`/MultiNameStruct#b.
-//      documentation
-//      > ```go
+//      signature_documentation
 //      > struct field b struct{x int; y string}
-//      > ```
     x int
 //  ^ definition 0.1.test `sg/pr202`/MultiNameStruct#$anon_c0a8952b3a214f68#x.
-//    documentation
-//    > ```go
+//    signature_documentation
 //    > struct field x int
-//    > ```
     y string
 //  ^ definition 0.1.test `sg/pr202`/MultiNameStruct#$anon_c0a8952b3a214f68#y.
-//    documentation
-//    > ```go
+//    signature_documentation
 //    > struct field y string
-//    > ```
    }
   }
   
 //⌄ enclosing_range_start 0.1.test `sg/pr202`/useMultiNameFields().
   func useMultiNameFields() {
 //     ^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/useMultiNameFields().
-//                        documentation
-//                        > ```go
+//                        signature_documentation
 //                        > func useMultiNameFields()
-//                        > ```
    var m MultiNameStruct
 //     ^ definition local 0
 //       display_name m

--- a/internal/testdata/snapshots/output/pr202/multiname_fields.go
+++ b/internal/testdata/snapshots/output/pr202/multiname_fields.go
@@ -6,8 +6,7 @@
   type MultiNameStruct struct {
 //     ^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/MultiNameStruct#
 //                     signature_documentation
-//                     > type MultiNameStruct struct
-//                     > struct {
+//                     > type MultiNameStruct struct {
 //                     >     a struct {
 //                     >         x int
 //                     >         y string

--- a/internal/testdata/snapshots/output/pr202/nested_anon.go
+++ b/internal/testdata/snapshots/output/pr202/nested_anon.go
@@ -7,15 +7,9 @@
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/ContainerAnon#
 //                   signature_documentation
 //                   > type ContainerAnon struct {
-//                   >     items []struct {
-//                   >         id int
-//                   >     }
-//                   >     entries map[string]struct {
-//                   >         count int
-//                   >     }
-//                   >     ptr *struct {
-//                   >         data int
-//                   >     }
+//                   >     items   []struct{ id int }
+//                   >     entries map[string]struct{ count int }
+//                   >     ptr     *struct{ data int }
 //                   > }
    items   []struct{ id int }
 // ^^^^^ definition 0.1.test `sg/pr202`/ContainerAnon#items.
@@ -44,11 +38,7 @@
 //     ^^^^^^^^^^ definition 0.1.test `sg/pr202`/DeepNested#
 //                signature_documentation
 //                > type DeepNested struct {
-//                >     outer struct {
-//                >         inner struct {
-//                >             value int
-//                >         }
-//                >     }
+//                >     outer struct{ inner struct{ value int } }
 //                > }
    outer struct {
 // ^^^^^ definition 0.1.test `sg/pr202`/DeepNested#outer.
@@ -71,12 +61,8 @@
 //     ^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/SliceAnonShared#
 //                     signature_documentation
 //                     > type SliceAnonShared struct {
-//                     >     a []struct {
-//                     >         v int
-//                     >     }
-//                     >     b []struct {
-//                     >         v int
-//                     >     }
+//                     >     a []struct{ v int }
+//                     >     b []struct{ v int }
 //                     > }
 //                     documentation
 //                     > Two fields with identical slice-of-anonymous-struct type.

--- a/internal/testdata/snapshots/output/pr202/nested_anon.go
+++ b/internal/testdata/snapshots/output/pr202/nested_anon.go
@@ -6,8 +6,7 @@
   type ContainerAnon struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/ContainerAnon#
 //                   signature_documentation
-//                   > type ContainerAnon struct
-//                   > struct {
+//                   > type ContainerAnon struct {
 //                   >     items []struct {
 //                   >         id int
 //                   >     }
@@ -44,8 +43,7 @@
   type DeepNested struct {
 //     ^^^^^^^^^^ definition 0.1.test `sg/pr202`/DeepNested#
 //                signature_documentation
-//                > type DeepNested struct
-//                > struct {
+//                > type DeepNested struct {
 //                >     outer struct {
 //                >         inner struct {
 //                >             value int
@@ -72,8 +70,7 @@
   type SliceAnonShared struct {
 //     ^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/SliceAnonShared#
 //                     signature_documentation
-//                     > type SliceAnonShared struct
-//                     > struct {
+//                     > type SliceAnonShared struct {
 //                     >     a []struct {
 //                     >         v int
 //                     >     }

--- a/internal/testdata/snapshots/output/pr202/nested_anon.go
+++ b/internal/testdata/snapshots/output/pr202/nested_anon.go
@@ -105,7 +105,7 @@
 //     ^ definition local 0
 //       display_name c
 //       signature_documentation
-//       > var c sg/pr202.ContainerAnon
+//       > var c ContainerAnon
 //       ^^^^^^^^^^^^^ reference 0.1.test `sg/pr202`/ContainerAnon#
    if len(c.items) > 0 {
 //        ^ reference local 0
@@ -138,7 +138,7 @@
 //     ^ definition local 2
 //       display_name d
 //       signature_documentation
-//       > var d sg/pr202.DeepNested
+//       > var d DeepNested
 //       ^^^^^^^^^^ reference 0.1.test `sg/pr202`/DeepNested#
    d.outer.inner.value = 42
 // ^ reference local 2

--- a/internal/testdata/snapshots/output/pr202/nested_anon.go
+++ b/internal/testdata/snapshots/output/pr202/nested_anon.go
@@ -5,12 +5,8 @@
   
   type ContainerAnon struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/ContainerAnon#
-//                   documentation
-//                   > ```go
+//                   signature_documentation
 //                   > type ContainerAnon struct
-//                   > ```
-//                   documentation
-//                   > ```go
 //                   > struct {
 //                   >     items []struct {
 //                   >         id int
@@ -22,50 +18,33 @@
 //                   >         data int
 //                   >     }
 //                   > }
-//                   > ```
    items   []struct{ id int }
 // ^^^^^ definition 0.1.test `sg/pr202`/ContainerAnon#items.
-//       documentation
-//       > ```go
+//       signature_documentation
 //       > struct field items []struct{id int}
-//       > ```
 //                   ^^ definition 0.1.test `sg/pr202`/ContainerAnon#$anon_71c5ea8d9342795c#id.
-//                      documentation
-//                      > ```go
+//                      signature_documentation
 //                      > struct field id int
-//                      > ```
    entries map[string]struct{ count int }
 // ^^^^^^^ definition 0.1.test `sg/pr202`/ContainerAnon#entries.
-//         documentation
-//         > ```go
+//         signature_documentation
 //         > struct field entries map[string]struct{count int}
-//         > ```
 //                            ^^^^^ definition 0.1.test `sg/pr202`/ContainerAnon#$anon_721f9800014370ac#count.
-//                                  documentation
-//                                  > ```go
+//                                  signature_documentation
 //                                  > struct field count int
-//                                  > ```
    ptr     *struct{ data int }
 // ^^^ definition 0.1.test `sg/pr202`/ContainerAnon#ptr.
-//     documentation
-//     > ```go
+//     signature_documentation
 //     > struct field ptr *struct{data int}
-//     > ```
 //                  ^^^^ definition 0.1.test `sg/pr202`/ContainerAnon#$anon_944f727740dfb75d#data.
-//                       documentation
-//                       > ```go
+//                       signature_documentation
 //                       > struct field data int
-//                       > ```
   }
   
   type DeepNested struct {
 //     ^^^^^^^^^^ definition 0.1.test `sg/pr202`/DeepNested#
-//                documentation
-//                > ```go
+//                signature_documentation
 //                > type DeepNested struct
-//                > ```
-//                documentation
-//                > ```go
 //                > struct {
 //                >     outer struct {
 //                >         inner struct {
@@ -73,25 +52,18 @@
 //                >         }
 //                >     }
 //                > }
-//                > ```
    outer struct {
 // ^^^^^ definition 0.1.test `sg/pr202`/DeepNested#outer.
-//       documentation
-//       > ```go
+//       signature_documentation
 //       > struct field outer struct{inner struct{value int}}
-//       > ```
     inner struct {
 //  ^^^^^ definition 0.1.test `sg/pr202`/DeepNested#$anon_5ee0364e53e1abd6#inner.
-//        documentation
-//        > ```go
+//        signature_documentation
 //        > struct field inner struct{value int}
-//        > ```
      value int
 //   ^^^^^ definition 0.1.test `sg/pr202`/DeepNested#$anon_5ee0364e53e1abd6#$anon_77e42bf2e5c84d1a#value.
-//         documentation
-//         > ```go
+//         signature_documentation
 //         > struct field value int
-//         > ```
     }
    }
   }
@@ -99,14 +71,8 @@
   // Two fields with identical slice-of-anonymous-struct type.
   type SliceAnonShared struct {
 //     ^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/SliceAnonShared#
-//                     documentation
-//                     > ```go
+//                     signature_documentation
 //                     > type SliceAnonShared struct
-//                     > ```
-//                     documentation
-//                     > Two fields with identical slice-of-anonymous-struct type.
-//                     documentation
-//                     > ```go
 //                     > struct {
 //                     >     a []struct {
 //                     >         v int
@@ -115,38 +81,29 @@
 //                     >         v int
 //                     >     }
 //                     > }
-//                     > ```
+//                     documentation
+//                     > Two fields with identical slice-of-anonymous-struct type.
    a []struct{ v int }
 // ^ definition 0.1.test `sg/pr202`/SliceAnonShared#a.
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > struct field a []struct{v int}
-//   > ```
 //             ^ definition 0.1.test `sg/pr202`/SliceAnonShared#$anon_358bfde4cba1ecae#v.
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > struct field v int
-//               > ```
    b []struct{ v int }
 // ^ definition 0.1.test `sg/pr202`/SliceAnonShared#b.
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > struct field b []struct{v int}
-//   > ```
 //             ^ definition 0.1.test `sg/pr202`/SliceAnonShared#$anon_358bfde4cba1ecae#v.
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > struct field v int
-//               > ```
   }
   
 //⌄ enclosing_range_start 0.1.test `sg/pr202`/useContainerAnon().
   func useContainerAnon() {
 //     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/useContainerAnon().
-//                      documentation
-//                      > ```go
+//                      signature_documentation
 //                      > func useContainerAnon()
-//                      > ```
    var c ContainerAnon
 //     ^ definition local 0
 //       display_name c

--- a/internal/testdata/snapshots/output/replace-directives/replace_directives.go
+++ b/internal/testdata/snapshots/output/replace-directives/replace_directives.go
@@ -16,10 +16,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/replace-directives`/Something().
   func Something() {
 //     ^^^^^^^^^ definition 0.1.test `sg/replace-directives`/Something().
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > func Something()
-//               > ```
    fmt.Println(replaced.DefaultConfig)
 // ^^^ reference github.com/golang/go/src go1.22 fmt/
 //     ^^^^^^^ reference github.com/golang/go/src go1.22 fmt/Println().

--- a/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/cleanup.go
+++ b/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/cleanup.go
@@ -7,9 +7,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/LiterallyAnything().
   func LiterallyAnything() {}
 //     ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/LiterallyAnything().
-//                       documentation
-//                       > ```go
+//                       signature_documentation
 //                       > func LiterallyAnything()
-//                       > ```
 //                          ⌃ enclosing_range_end 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/LiterallyAnything().
   

--- a/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/cleanup_test.go
+++ b/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/cleanup_test.go
@@ -12,7 +12,7 @@
 //               ^ definition local 0
 //                 display_name t
 //                 signature_documentation
-//                 > var t *testing.T
+//                 > var t *T
 //                  ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
 //                          ^ reference github.com/golang/go/src go1.22 testing/T#
    wd := "hello"

--- a/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/cleanup_test.go
+++ b/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/cleanup_test.go
@@ -7,10 +7,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/TestStuff().
   func TestStuff(t *testing.T) {
 //     ^^^^^^^^^ definition 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/TestStuff().
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > func TestStuff(t *T)
-//               > ```
 //               ^ definition local 0
 //                 display_name t
 //                 signature_documentation

--- a/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/server.go
+++ b/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/server.go
@@ -4,9 +4,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/AnythingAtAll().
   func AnythingAtAll() {}
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/AnythingAtAll().
-//                   documentation
-//                   > ```go
+//                   signature_documentation
 //                   > func AnythingAtAll()
-//                   > ```
 //                      ⌃ enclosing_range_end 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/AnythingAtAll().
   

--- a/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/server_test.go
+++ b/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/server_test.go
@@ -7,10 +7,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/TestExecRequest().
   func TestExecRequest(t *testing.T) {
 //     ^^^^^^^^^^^^^^^ definition 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/TestExecRequest().
-//                     documentation
-//                     > ```go
+//                     signature_documentation
 //                     > func TestExecRequest(t *T)
-//                     > ```
 //                     ^ definition local 0
 //                       display_name t
 //                       signature_documentation
@@ -26,10 +24,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/runCmd().
   func runCmd(t *testing.T, dir string, cmd string, arg ...string) {}
 //     ^^^^^^ definition 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/runCmd().
-//            documentation
-//            > ```go
+//            signature_documentation
 //            > func runCmd(t *T, dir string, cmd string, arg ...string)
-//            > ```
 //            ^ definition local 1
 //              display_name t
 //              signature_documentation

--- a/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/server_test.go
+++ b/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/server_test.go
@@ -12,7 +12,7 @@
 //                     ^ definition local 0
 //                       display_name t
 //                       signature_documentation
-//                       > var t *testing.T
+//                       > var t *T
 //                        ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
 //                                ^ reference github.com/golang/go/src go1.22 testing/T#
    t.Log("hello world")
@@ -29,7 +29,7 @@
 //            ^ definition local 1
 //              display_name t
 //              signature_documentation
-//              > var t *testing.T
+//              > var t *T
 //               ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
 //                       ^ reference github.com/golang/go/src go1.22 testing/T#
 //                          ^^^ definition local 2

--- a/internal/testdata/snapshots/output/switches/switches.go
+++ b/internal/testdata/snapshots/output/switches/switches.go
@@ -8,8 +8,7 @@
   type CustomSwitch struct{}
 //     ^^^^^^^^^^^^ definition 0.1.test `sg/switches`/CustomSwitch#
 //                  signature_documentation
-//                  > type CustomSwitch struct
-//                  > struct{}
+//                  > type CustomSwitch struct{}
 //                  documentation
 //                  > CustomSwitch does the things in a switch
   

--- a/internal/testdata/snapshots/output/switches/switches.go
+++ b/internal/testdata/snapshots/output/switches/switches.go
@@ -7,16 +7,11 @@
   // CustomSwitch does the things in a switch
   type CustomSwitch struct{}
 //     ^^^^^^^^^^^^ definition 0.1.test `sg/switches`/CustomSwitch#
-//                  documentation
-//                  > ```go
+//                  signature_documentation
 //                  > type CustomSwitch struct
-//                  > ```
+//                  > struct{}
 //                  documentation
 //                  > CustomSwitch does the things in a switch
-//                  documentation
-//                  > ```go
-//                  > struct{}
-//                  > ```
   
   // Something does some things... and stuff
 //⌄ enclosing_range_start 0.1.test `sg/switches`/CustomSwitch#Something().
@@ -27,10 +22,8 @@
 //        > var c *sg/switches.CustomSwitch
 //         ^^^^^^^^^^^^ reference 0.1.test `sg/switches`/CustomSwitch#
 //                       ^^^^^^^^^ definition 0.1.test `sg/switches`/CustomSwitch#Something().
-//                                 documentation
-//                                 > ```go
+//                                 signature_documentation
 //                                 > func (*CustomSwitch).Something() bool
-//                                 > ```
 //                                 documentation
 //                                 > Something does some things... and stuff
 //                                                       ⌃ enclosing_range_end 0.1.test `sg/switches`/CustomSwitch#Something().
@@ -38,10 +31,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/switches`/Switch().
   func Switch(interfaceValue interface{}) bool {
 //     ^^^^^^ definition 0.1.test `sg/switches`/Switch().
-//            documentation
-//            > ```go
+//            signature_documentation
 //            > func Switch(interfaceValue interface{}) bool
-//            > ```
 //            ^^^^^^^^^^^^^^ definition local 1
 //                           display_name interfaceValue
 //                           signature_documentation

--- a/internal/testdata/snapshots/output/switches/switches.go
+++ b/internal/testdata/snapshots/output/switches/switches.go
@@ -18,7 +18,7 @@
 //      ^ definition local 0
 //        display_name c
 //        signature_documentation
-//        > var c *sg/switches.CustomSwitch
+//        > var c *CustomSwitch
 //         ^^^^^^^^^^^^ reference 0.1.test `sg/switches`/CustomSwitch#
 //                       ^^^^^^^^^ definition 0.1.test `sg/switches`/CustomSwitch#Something().
 //                                 signature_documentation

--- a/internal/testdata/snapshots/output/testdata/anonymous_structs.go
+++ b/internal/testdata/snapshots/output/testdata/anonymous_structs.go
@@ -110,7 +110,7 @@
 //     ^ definition local 6
 //       display_name f
 //       signature_documentation
-//       > var f sg/testdata.TypeContainingAnonymousStructs
+//       > var f TypeContainingAnonymousStructs
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#
    f.a.x = 3
 // ^ reference local 6

--- a/internal/testdata/snapshots/output/testdata/anonymous_structs.go
+++ b/internal/testdata/snapshots/output/testdata/anonymous_structs.go
@@ -10,8 +10,7 @@
   type TypeContainingAnonymousStructs struct {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#
 //                                    signature_documentation
-//                                    > type TypeContainingAnonymousStructs struct
-//                                    > struct {
+//                                    > type TypeContainingAnonymousStructs struct {
 //                                    >     a struct {
 //                                    >         x int
 //                                    >         y string

--- a/internal/testdata/snapshots/output/testdata/anonymous_structs.go
+++ b/internal/testdata/snapshots/output/testdata/anonymous_structs.go
@@ -9,12 +9,8 @@
   
   type TypeContainingAnonymousStructs struct {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#
-//                                    documentation
-//                                    > ```go
+//                                    signature_documentation
 //                                    > type TypeContainingAnonymousStructs struct
-//                                    > ```
-//                                    documentation
-//                                    > ```go
 //                                    > struct {
 //                                    >     a struct {
 //                                    >         x int
@@ -29,59 +25,42 @@
 //                                    >         Y string
 //                                    >     }
 //                                    > }
-//                                    > ```
    a, b struct {
 // ^ definition 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#a.
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > struct field a struct{x int; y string}
-//   > ```
 //    ^ definition 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#b.
-//      documentation
-//      > ```go
+//      signature_documentation
 //      > struct field b struct{x int; y string}
-//      > ```
     x int
 //  ^ definition 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#$anon_c0a8952b3a214f68#x.
-//    documentation
-//    > ```go
+//    signature_documentation
 //    > struct field x int
-//    > ```
     y string
 //  ^ definition 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#$anon_c0a8952b3a214f68#y.
-//    documentation
-//    > ```go
+//    signature_documentation
 //    > struct field y string
-//    > ```
    }
    c struct {
 // ^ definition 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#c.
-//   documentation
-//   > ```go
+//   signature_documentation
 //   > struct field c struct{X int; Y string}
-//   > ```
     X int
 //  ^ definition 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#$anon_2f238678626c0da1#X.
-//    documentation
-//    > ```go
+//    signature_documentation
 //    > struct field X int
-//    > ```
     Y string
 //  ^ definition 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#$anon_2f238678626c0da1#Y.
-//    documentation
-//    > ```go
+//    signature_documentation
 //    > struct field Y string
-//    > ```
    }
   }
   
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/funcContainingAnonymousStructs().
   func funcContainingAnonymousStructs() {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/funcContainingAnonymousStructs().
-//                                    documentation
-//                                    > ```go
+//                                    signature_documentation
 //                                    > func funcContainingAnonymousStructs()
-//                                    > ```
    d := struct {
 // ^ definition local 0
 //   display_name d

--- a/internal/testdata/snapshots/output/testdata/cmd/minimal_main/minimal_main.go
+++ b/internal/testdata/snapshots/output/testdata/cmd/minimal_main/minimal_main.go
@@ -6,47 +6,31 @@
   
   type User struct {
 //     ^^^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/User#
-//          documentation
-//          > ```go
+//          signature_documentation
 //          > type User struct
-//          > ```
-//          documentation
-//          > ```go
 //          > struct {
 //          >     Id string
 //          >     Name string
 //          > }
-//          > ```
    Id, Name string
 // ^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/User#Id.
-//    documentation
-//    > ```go
+//    signature_documentation
 //    > struct field Id string
-//    > ```
 //     ^^^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/User#Name.
-//          documentation
-//          > ```go
+//          signature_documentation
 //          > struct field Name string
-//          > ```
   }
   
   type UserResource struct{}
 //     ^^^^^^^^^^^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/UserResource#
-//                  documentation
-//                  > ```go
+//                  signature_documentation
 //                  > type UserResource struct
-//                  > ```
-//                  documentation
-//                  > ```go
 //                  > struct{}
-//                  > ```
   
 //⌄ enclosing_range_start 0.1.test `sg/testdata/cmd/minimal_main`/main().
   func main() {}
 //     ^^^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/main().
-//          documentation
-//          > ```go
+//          signature_documentation
 //          > func main()
-//          > ```
 //             ⌃ enclosing_range_end 0.1.test `sg/testdata/cmd/minimal_main`/main().
   

--- a/internal/testdata/snapshots/output/testdata/cmd/minimal_main/minimal_main.go
+++ b/internal/testdata/snapshots/output/testdata/cmd/minimal_main/minimal_main.go
@@ -8,7 +8,7 @@
 //     ^^^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/User#
 //          signature_documentation
 //          > type User struct {
-//          >     Id string
+//          >     Id   string
 //          >     Name string
 //          > }
    Id, Name string

--- a/internal/testdata/snapshots/output/testdata/cmd/minimal_main/minimal_main.go
+++ b/internal/testdata/snapshots/output/testdata/cmd/minimal_main/minimal_main.go
@@ -7,8 +7,7 @@
   type User struct {
 //     ^^^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/User#
 //          signature_documentation
-//          > type User struct
-//          > struct {
+//          > type User struct {
 //          >     Id string
 //          >     Name string
 //          > }
@@ -24,8 +23,7 @@
   type UserResource struct{}
 //     ^^^^^^^^^^^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/UserResource#
 //                  signature_documentation
-//                  > type UserResource struct
-//                  > struct{}
+//                  > type UserResource struct{}
   
 //⌄ enclosing_range_start 0.1.test `sg/testdata/cmd/minimal_main`/main().
   func main() {}

--- a/internal/testdata/snapshots/output/testdata/conflicting_test_symbols/sandbox_unsupported_test.go
+++ b/internal/testdata/snapshots/output/testdata/conflicting_test_symbols/sandbox_unsupported_test.go
@@ -16,20 +16,16 @@
   
   var ErrNotImplemented = errors.New("not implemented")
 //    ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata/conflicting_test_symbols`/ErrNotImplemented.
-//                      documentation
-//                      > ```go
+//                      signature_documentation
 //                      > var ErrNotImplemented error
-//                      > ```
 //                        ^^^^^^ reference github.com/golang/go/src go1.22 errors/
 //                               ^^^ reference github.com/golang/go/src go1.22 errors/New().
   
 //⌄ enclosing_range_start 0.1.test `sg/testdata/conflicting_test_symbols`/newKey().
   func newKey(t *testing.T) (string, error) {
 //     ^^^^^^ definition 0.1.test `sg/testdata/conflicting_test_symbols`/newKey().
-//            documentation
-//            > ```go
+//            signature_documentation
 //            > func newKey(t *T) (string, error)
-//            > ```
 //            ^ definition local 0
 //              display_name t
 //              signature_documentation
@@ -44,10 +40,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata/conflicting_test_symbols`/verifySandbox().
   func verifySandbox(t *testing.T, s string) {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/testdata/conflicting_test_symbols`/verifySandbox().
-//                   documentation
-//                   > ```go
+//                   signature_documentation
 //                   > func verifySandbox(t *T, s string)
-//                   > ```
 //                   ^ definition local 1
 //                     display_name t
 //                     signature_documentation

--- a/internal/testdata/snapshots/output/testdata/conflicting_test_symbols/sandbox_unsupported_test.go
+++ b/internal/testdata/snapshots/output/testdata/conflicting_test_symbols/sandbox_unsupported_test.go
@@ -29,7 +29,7 @@
 //            ^ definition local 0
 //              display_name t
 //              signature_documentation
-//              > var t *testing.T
+//              > var t *T
 //               ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
 //                       ^ reference github.com/golang/go/src go1.22 testing/T#
    return "", ErrNotImplemented
@@ -45,7 +45,7 @@
 //                   ^ definition local 1
 //                     display_name t
 //                     signature_documentation
-//                     > var t *testing.T
+//                     > var t *T
 //                      ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
 //                              ^ reference github.com/golang/go/src go1.22 testing/T#
 //                                 ^ definition local 2

--- a/internal/testdata/snapshots/output/testdata/data.go
+++ b/internal/testdata/snapshots/output/testdata/data.go
@@ -13,8 +13,7 @@
   type TestInterface interface {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestInterface#
 //                   signature_documentation
-//                   > type TestInterface interface
-//                   > interface {
+//                   > type TestInterface interface {
 //                   >     Do(ctx Context, data string) (score int, _ error)
 //                   > }
 //                   documentation
@@ -45,8 +44,7 @@
    TestStruct struct {
 // ^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#
 //            signature_documentation
-//            > type TestStruct struct
-//            > struct {
+//            > type TestStruct struct {
 //            >     SimpleA int
 //            >     SimpleB int
 //            >     SimpleC int
@@ -106,8 +104,7 @@
    TestEmptyStruct struct{}
 // ^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestEmptyStruct#
 //                 signature_documentation
-//                 > type TestEmptyStruct struct
-//                 > struct{}
+//                 > type TestEmptyStruct struct{}
   )
   
   // Score is just a hardcoded number.
@@ -191,8 +188,7 @@
   type StructTagRegression struct {
 //     ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/StructTagRegression#
 //                         signature_documentation
-//                         > type StructTagRegression struct
-//                         > struct {
+//                         > type StructTagRegression struct {
 //                         >     Value int `key:",range=[:}"`
 //                         > }
 //                         documentation
@@ -209,8 +205,7 @@
   type TestEqualsStruct = struct {
 //     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestEqualsStruct#
 //                      signature_documentation
-//                      > type TestEqualsStruct = struct
-//                      > struct {
+//                      > type TestEqualsStruct = struct {
 //                      >     Value int
 //                      > }
    Value int
@@ -222,8 +217,7 @@
   type ShellStruct struct {
 //     ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/ShellStruct#
 //                 signature_documentation
-//                 > type ShellStruct struct
-//                 > struct {
+//                 > type ShellStruct struct {
 //                 >     InnerStruct
 //                 > }
    // Ensure this field comes before the definition
@@ -243,6 +237,5 @@
   type InnerStruct struct{}
 //     ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InnerStruct#
 //                 signature_documentation
-//                 > type InnerStruct struct
-//                 > struct{}
+//                 > type InnerStruct struct{}
   

--- a/internal/testdata/snapshots/output/testdata/data.go
+++ b/internal/testdata/snapshots/output/testdata/data.go
@@ -26,7 +26,7 @@
 //    ^^^ definition local 0
 //        display_name ctx
 //        signature_documentation
-//        > var ctx context.Context
+//        > var ctx Context
 //        ^^^^^^^ reference github.com/golang/go/src go1.22 context/
 //                ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
 //                         ^^^^ definition local 1
@@ -151,7 +151,7 @@
 //      ^^ definition local 3
 //         display_name ts
 //         signature_documentation
-//         > var ts *sg/testdata.TestStruct
+//         > var ts *TestStruct
 //          ^^^^^^^^^^ reference 0.1.test `sg/testdata`/TestStruct#
 //                      ^^^^ definition 0.1.test `sg/testdata`/TestStruct#Doer().
 //                           signature_documentation
@@ -161,7 +161,7 @@
 //                           ^^^ definition local 4
 //                               display_name ctx
 //                               signature_documentation
-//                               > var ctx context.Context
+//                               > var ctx Context
 //                               ^^^^^^^ reference github.com/golang/go/src go1.22 context/
 //                                       ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
 //                                                ^^^^ definition local 5

--- a/internal/testdata/snapshots/output/testdata/data.go
+++ b/internal/testdata/snapshots/output/testdata/data.go
@@ -45,10 +45,10 @@
 // ^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#
 //            signature_documentation
 //            > type TestStruct struct {
-//            >     SimpleA int
-//            >     SimpleB int
-//            >     SimpleC int
-//            >     FieldWithTag string `json:"tag"`
+//            >     SimpleA                int
+//            >     SimpleB                int
+//            >     SimpleC                int
+//            >     FieldWithTag           string "json:\"tag\""
 //            >     FieldWithAnonymousType struct {
 //            >         NestedA string
 //            >         NestedB string
@@ -189,7 +189,7 @@
 //     ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/StructTagRegression#
 //                         signature_documentation
 //                         > type StructTagRegression struct {
-//                         >     Value int `key:",range=[:}"`
+//                         >     Value int "key:\",range=[:}\""
 //                         > }
 //                         documentation
 //                         > StructTagRegression is a struct that caused panic in the wild. Added here to
@@ -205,9 +205,7 @@
   type TestEqualsStruct = struct {
 //     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestEqualsStruct#
 //                      signature_documentation
-//                      > type TestEqualsStruct = struct {
-//                      >     Value int
-//                      > }
+//                      > type TestEqualsStruct = struct{ Value int }
    Value int
 // ^^^^^ definition 0.1.test `sg/testdata`/TestEqualsStruct#Value.
 //       signature_documentation
@@ -217,9 +215,7 @@
   type ShellStruct struct {
 //     ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/ShellStruct#
 //                 signature_documentation
-//                 > type ShellStruct struct {
-//                 >     InnerStruct
-//                 > }
+//                 > type ShellStruct struct{ InnerStruct }
    // Ensure this field comes before the definition
    // so that we grab the correct one in our unit
    // tests.

--- a/internal/testdata/snapshots/output/testdata/data.go
+++ b/internal/testdata/snapshots/output/testdata/data.go
@@ -12,25 +12,18 @@
   // TestInterface is an interface used for testing.
   type TestInterface interface {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestInterface#
-//                   documentation
-//                   > ```go
+//                   signature_documentation
 //                   > type TestInterface interface
-//                   > ```
-//                   documentation
-//                   > TestInterface is an interface used for testing.
-//                   documentation
-//                   > ```go
 //                   > interface {
 //                   >     Do(ctx Context, data string) (score int, _ error)
 //                   > }
-//                   > ```
+//                   documentation
+//                   > TestInterface is an interface used for testing.
    // Do does a test thing.
    Do(ctx context.Context, data string) (score int, _ error)
 // ^^ definition 0.1.test `sg/testdata`/TestInterface#Do.
-//    documentation
-//    > ```go
+//    signature_documentation
 //    > func (TestInterface).Do(ctx Context, data string) (score int, _ error)
-//    > ```
 //    ^^^ definition local 0
 //        display_name ctx
 //        signature_documentation
@@ -51,12 +44,8 @@
    // TestStruct is a struct used for testing.
    TestStruct struct {
 // ^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#
-//            documentation
-//            > ```go
+//            signature_documentation
 //            > type TestStruct struct
-//            > ```
-//            documentation
-//            > ```go
 //            > struct {
 //            >     SimpleA int
 //            >     SimpleB int
@@ -69,132 +58,94 @@
 //            >     }
 //            >     EmptyStructField struct{}
 //            > }
-//            > ```
     // SimpleA docs
     SimpleA int
 //  ^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#SimpleA.
-//          documentation
-//          > ```go
+//          signature_documentation
 //          > struct field SimpleA int
-//          > ```
     // SimpleB docs
     SimpleB int
 //  ^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#SimpleB.
-//          documentation
-//          > ```go
+//          signature_documentation
 //          > struct field SimpleB int
-//          > ```
     // SimpleC docs
     SimpleC int
 //  ^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#SimpleC.
-//          documentation
-//          > ```go
+//          signature_documentation
 //          > struct field SimpleC int
-//          > ```
   
     FieldWithTag           string `json:"tag"`
 //  ^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#FieldWithTag.
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > struct field FieldWithTag string
-//               > ```
     FieldWithAnonymousType struct {
 //  ^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#FieldWithAnonymousType.
-//                         documentation
-//                         > ```go
+//                         signature_documentation
 //                         > struct field FieldWithAnonymousType struct{NestedA string; NestedB string; NestedC string}
-//                         > ```
      NestedA string
 //   ^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#$anon_2bed88e490dc48af#NestedA.
-//           documentation
-//           > ```go
+//           signature_documentation
 //           > struct field NestedA string
-//           > ```
      NestedB string
 //   ^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#$anon_2bed88e490dc48af#NestedB.
-//           documentation
-//           > ```go
+//           signature_documentation
 //           > struct field NestedB string
-//           > ```
      // NestedC docs
      NestedC string
 //   ^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#$anon_2bed88e490dc48af#NestedC.
-//           documentation
-//           > ```go
+//           signature_documentation
 //           > struct field NestedC string
-//           > ```
     }
   
     EmptyStructField struct{}
 //  ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#EmptyStructField.
-//                   documentation
-//                   > ```go
+//                   signature_documentation
 //                   > struct field EmptyStructField struct{}
-//                   > ```
    }
   
    TestEmptyStruct struct{}
 // ^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestEmptyStruct#
-//                 documentation
-//                 > ```go
+//                 signature_documentation
 //                 > type TestEmptyStruct struct
-//                 > ```
-//                 documentation
-//                 > ```go
 //                 > struct{}
-//                 > ```
   )
   
   // Score is just a hardcoded number.
   const Score = uint64(42)
 //      ^^^^^ definition 0.1.test `sg/testdata`/Score.
-//            documentation
-//            > ```go
+//            signature_documentation
 //            > const Score uint64 = 42
-//            > ```
 //            documentation
 //            > Score is just a hardcoded number.
   const secretScore = secret.SecretScore
 //      ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/secretScore.
-//                  documentation
-//                  > ```go
+//                  signature_documentation
 //                  > const secretScore uint64 = 43
-//                  > ```
 //                    ^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/
 //                           ^^^^^^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/SecretScore.
   
   const SomeString = "foobar"
 //      ^^^^^^^^^^ definition 0.1.test `sg/testdata`/SomeString.
-//                 documentation
-//                 > ```go
+//                 signature_documentation
 //                 > const SomeString untyped string = "foobar"
-//                 > ```
   const LongString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed tincidunt viverra aliquam. Phasellus finibus, arcu eu commodo porta, dui quam dictum ante, nec porta enim leo quis felis. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Curabitur luctus orci tortor, non condimentum arcu bibendum ut. Proin sit amet vulputate lorem, ut egestas arcu. Curabitur quis sagittis mi. Aenean elit sem, imperdiet ut risus eget, varius varius erat.\nNullam lobortis tortor sed sodales consectetur. Aenean condimentum vehicula elit, eget interdum ante finibus nec. Mauris mollis, nulla eu vehicula rhoncus, eros lectus viverra tellus, ac hendrerit quam massa et felis. Nunc vestibulum diam a facilisis sollicitudin. Aenean nec varius metus. Sed nec diam nibh. Ut erat erat, suscipit et ante eget, tincidunt condimentum orci. Aenean nec facilisis augue, ac sodales ex. Nulla dictum hendrerit tempus. Aliquam fringilla tortor in massa molestie, quis bibendum nulla ullamcorper. Suspendisse congue laoreet elit, vitae consectetur orci facilisis non. Aliquam tempus ultricies sapien, rhoncus tincidunt nisl tincidunt eget. Aliquam nisi ante, rutrum eget viverra imperdiet, congue ut nunc. Donec mollis sed tellus vel placerat. Sed mi ex, fringilla a fermentum a, tincidunt eget lectus.\nPellentesque lacus nibh, accumsan eget feugiat nec, gravida eget urna. Donec quam velit, imperdiet in consequat eget, ultricies eget nunc. Curabitur interdum vel sem et euismod. Donec sed vulputate odio, sit amet bibendum tellus. Integer pellentesque nunc eu turpis cursus, vestibulum sodales ipsum posuere. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Ut at vestibulum sapien. In hac habitasse platea dictumst. Nullam sed lobortis urna, non bibendum ipsum. Sed in sapien quis purus semper fringilla. Integer ut egestas nulla, eu ornare lectus. Maecenas quis sapien condimentum, dignissim urna quis, hendrerit neque. Donec cursus sit amet metus eu mollis.\nSed scelerisque vitae odio non egestas. Cras hendrerit tortor mauris. Aenean quis imperdiet nulla, a viverra purus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Praesent finibus faucibus orci, sed ultrices justo iaculis ut. Ut libero massa, condimentum at elit non, fringilla iaculis quam. Sed sit amet ipsum placerat, tincidunt sem in, efficitur lacus. Curabitur ligula orci, tempus ut magna eget, sodales tristique odio.\nPellentesque in libero ac risus pretium ultrices. In hac habitasse platea dictumst. Curabitur a quam sed orci tempus luctus. Integer commodo nec odio quis consequat. Aenean vitae dapibus augue, nec dictum lectus. Etiam sit amet leo diam. Duis eu ligula venenatis, fermentum lacus vel, interdum odio. Vivamus sit amet libero vitae elit interdum cursus et eu erat. Cras interdum augue sit amet ex aliquet tempor. Praesent dolor nisl, convallis bibendum mauris a, euismod commodo ante. Phasellus non ipsum condimentum, molestie dolor quis, pretium nisi. Mauris augue urna, fermentum ut lacinia a, efficitur vitae odio. Praesent finibus nisl et dolor luctus faucibus. Donec eget lectus sed mi porttitor placerat ac eu odio."
 //      ^^^^^^^^^^ definition 0.1.test `sg/testdata`/LongString.
-//                 documentation
-//                 > ```go
+//                 signature_documentation
 //                 > const LongString untyped string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed tincidu...
-//                 > ```
   const ConstMath = 1 + (2+3)*5
 //      ^^^^^^^^^ definition 0.1.test `sg/testdata`/ConstMath.
-//                documentation
-//                > ```go
+//                signature_documentation
 //                > const ConstMath untyped int = 26
-//                > ```
   
   type StringAlias string
 //     ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/StringAlias#
-//                 documentation
-//                 > ```go
-//                 > string
-//                 > ```
+//                 signature_documentation
+//                 > type StringAlias string
   
   const AliasedString StringAlias = "foobar"
 //      ^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/AliasedString.
-//                    documentation
-//                    > ```go
+//                    signature_documentation
 //                    > const AliasedString StringAlias = "foobar"
-//                    > ```
 //                    ^^^^^^^^^^^ reference 0.1.test `sg/testdata`/StringAlias#
   
   // Doer is similar to the test interface (but not the same).
@@ -206,10 +157,8 @@
 //         > var ts *sg/testdata.TestStruct
 //          ^^^^^^^^^^ reference 0.1.test `sg/testdata`/TestStruct#
 //                      ^^^^ definition 0.1.test `sg/testdata`/TestStruct#Doer().
-//                           documentation
-//                           > ```go
+//                           signature_documentation
 //                           > func (*TestStruct).Doer(ctx Context, data string) (score int, err error)
-//                           > ```
 //                           documentation
 //                           > Doer is similar to the test interface (but not the same).
 //                           ^^^ definition local 4
@@ -241,70 +190,49 @@
   // See https://github.com/tal-tech/go-zero/blob/11dd3d75ecceaa3f5772024fb3f26dec1ada8e9c/core/mapping/unmarshaler_test.go#L2272.
   type StructTagRegression struct {
 //     ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/StructTagRegression#
-//                         documentation
-//                         > ```go
+//                         signature_documentation
 //                         > type StructTagRegression struct
-//                         > ```
+//                         > struct {
+//                         >     Value int `key:",range=[:}"`
+//                         > }
 //                         documentation
 //                         > StructTagRegression is a struct that caused panic in the wild. Added here to
 //                         > support a regression test.
 //                         > 
 //                         > See https://github.com/tal-tech/go-zero/blob/11dd3d75ecceaa3f5772024fb3f26dec1ada8e9c/core/mapping/unmarshaler_test.go#L2272.
-//                         documentation
-//                         > ```go
-//                         > struct {
-//                         >     Value int `key:",range=[:}"`
-//                         > }
-//                         > ```
    Value int `key:",range=[:}"`
 // ^^^^^ definition 0.1.test `sg/testdata`/StructTagRegression#Value.
-//       documentation
-//       > ```go
+//       signature_documentation
 //       > struct field Value int
-//       > ```
   }
   
   type TestEqualsStruct = struct {
 //     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestEqualsStruct#
-//                      documentation
-//                      > ```go
+//                      signature_documentation
 //                      > type TestEqualsStruct = struct
-//                      > ```
-//                      documentation
-//                      > ```go
 //                      > struct {
 //                      >     Value int
 //                      > }
-//                      > ```
    Value int
 // ^^^^^ definition 0.1.test `sg/testdata`/TestEqualsStruct#Value.
-//       documentation
-//       > ```go
+//       signature_documentation
 //       > struct field Value int
-//       > ```
   }
   
   type ShellStruct struct {
 //     ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/ShellStruct#
-//                 documentation
-//                 > ```go
+//                 signature_documentation
 //                 > type ShellStruct struct
-//                 > ```
-//                 documentation
-//                 > ```go
 //                 > struct {
 //                 >     InnerStruct
 //                 > }
-//                 > ```
    // Ensure this field comes before the definition
    // so that we grab the correct one in our unit
    // tests.
    InnerStruct
 // ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/ShellStruct#InnerStruct.
-//             documentation
-//             > ```go
+//             signature_documentation
 //             > struct field InnerStruct sg/testdata.InnerStruct
-//             > ```
 //             documentation
 //             > Ensure this field comes before the definition
 //             > so that we grab the correct one in our unit
@@ -314,12 +242,7 @@
   
   type InnerStruct struct{}
 //     ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InnerStruct#
-//                 documentation
-//                 > ```go
+//                 signature_documentation
 //                 > type InnerStruct struct
-//                 > ```
-//                 documentation
-//                 > ```go
 //                 > struct{}
-//                 > ```
   

--- a/internal/testdata/snapshots/output/testdata/duplicate_path_id/main.go
+++ b/internal/testdata/snapshots/output/testdata/duplicate_path_id/main.go
@@ -7,14 +7,12 @@
   type importMeta struct{}
 //     ^^^^^^^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/importMeta#
 //                signature_documentation
-//                > type importMeta struct
-//                > struct{}
+//                > type importMeta struct{}
   
   type sourceMeta struct{}
 //     ^^^^^^^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/sourceMeta#
 //                signature_documentation
-//                > type sourceMeta struct
-//                > struct{}
+//                > type sourceMeta struct{}
   
 //⌄ enclosing_range_start 0.1.test `sg/testdata/duplicate_path_id`/fetchMeta().
   func fetchMeta() (string, *importMeta, *sourceMeta) {

--- a/internal/testdata/snapshots/output/testdata/duplicate_path_id/main.go
+++ b/internal/testdata/snapshots/output/testdata/duplicate_path_id/main.go
@@ -6,33 +6,21 @@
   
   type importMeta struct{}
 //     ^^^^^^^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/importMeta#
-//                documentation
-//                > ```go
+//                signature_documentation
 //                > type importMeta struct
-//                > ```
-//                documentation
-//                > ```go
 //                > struct{}
-//                > ```
   
   type sourceMeta struct{}
 //     ^^^^^^^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/sourceMeta#
-//                documentation
-//                > ```go
+//                signature_documentation
 //                > type sourceMeta struct
-//                > ```
-//                documentation
-//                > ```go
 //                > struct{}
-//                > ```
   
 //⌄ enclosing_range_start 0.1.test `sg/testdata/duplicate_path_id`/fetchMeta().
   func fetchMeta() (string, *importMeta, *sourceMeta) {
 //     ^^^^^^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/fetchMeta().
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > func fetchMeta() (string, *importMeta, *sourceMeta)
-//               > ```
 //                           ^^^^^^^^^^ reference 0.1.test `sg/testdata/duplicate_path_id`/importMeta#
 //                                        ^^^^^^^^^^ reference 0.1.test `sg/testdata/duplicate_path_id`/sourceMeta#
    panic("hmm")
@@ -42,25 +30,19 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata/duplicate_path_id`/init().
   func init() {}
 //     ^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/init().
-//          documentation
-//          > ```go
+//          signature_documentation
 //          > func init()
-//          > ```
 //             ⌃ enclosing_range_end 0.1.test `sg/testdata/duplicate_path_id`/init().
 //⌄ enclosing_range_start 0.1.test `sg/testdata/duplicate_path_id`/init().
   func init() {}
 //     ^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/init().
-//          documentation
-//          > ```go
+//          signature_documentation
 //          > func init()
-//          > ```
 //             ⌃ enclosing_range_end 0.1.test `sg/testdata/duplicate_path_id`/init().
 //⌄ enclosing_range_start 0.1.test `sg/testdata/duplicate_path_id`/init().
   func init() {}
 //     ^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/init().
-//          documentation
-//          > ```go
+//          signature_documentation
 //          > func init()
-//          > ```
 //             ⌃ enclosing_range_end 0.1.test `sg/testdata/duplicate_path_id`/init().
   

--- a/internal/testdata/snapshots/output/testdata/duplicate_path_id/two.go
+++ b/internal/testdata/snapshots/output/testdata/duplicate_path_id/two.go
@@ -4,9 +4,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata/duplicate_path_id`/init().
   func init() {}
 //     ^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/init().
-//          documentation
-//          > ```go
+//          signature_documentation
 //          > func init()
-//          > ```
 //             ⌃ enclosing_range_end 0.1.test `sg/testdata/duplicate_path_id`/init().
   

--- a/internal/testdata/snapshots/output/testdata/external_composite.go
+++ b/internal/testdata/snapshots/output/testdata/external_composite.go
@@ -6,31 +6,22 @@
   
   type NestedHandler struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/NestedHandler#
-//                   documentation
-//                   > ```go
+//                   signature_documentation
 //                   > type NestedHandler struct
-//                   > ```
-//                   documentation
-//                   > ```go
 //                   > struct {
 //                   >     Handler
 //                   >     Other int
 //                   > }
-//                   > ```
 //                   relationship github.com/golang/go/src go1.22 `net/http`/Handler# implementation
    http.Handler
 // ^^^^ reference github.com/golang/go/src go1.22 `net/http`/
 //      ^^^^^^^ definition 0.1.test `sg/testdata`/NestedHandler#Handler.
-//              documentation
-//              > ```go
+//              signature_documentation
 //              > struct field Handler net/http.Handler
-//              > ```
 //      ^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/Handler#
    Other int
 // ^^^^^ definition 0.1.test `sg/testdata`/NestedHandler#Other.
-//       documentation
-//       > ```go
+//       signature_documentation
 //       > struct field Other int
-//       > ```
   }
   

--- a/internal/testdata/snapshots/output/testdata/external_composite.go
+++ b/internal/testdata/snapshots/output/testdata/external_composite.go
@@ -7,8 +7,7 @@
   type NestedHandler struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/NestedHandler#
 //                   signature_documentation
-//                   > type NestedHandler struct
-//                   > struct {
+//                   > type NestedHandler struct {
 //                   >     Handler
 //                   >     Other int
 //                   > }

--- a/internal/testdata/snapshots/output/testdata/implementations.go
+++ b/internal/testdata/snapshots/output/testdata/implementations.go
@@ -9,9 +9,7 @@
   type I1 interface {
 //     ^^ definition 0.1.test `sg/testdata`/I1#
 //        signature_documentation
-//        > type I1 interface {
-//        >     F1()
-//        > }
+//        > type I1 interface{ F1() }
    F1()
 // ^^ definition 0.1.test `sg/testdata`/I1#F1.
 //    signature_documentation
@@ -21,9 +19,7 @@
   type I2 interface {
 //     ^^ definition 0.1.test `sg/testdata`/I2#
 //        signature_documentation
-//        > type I2 interface {
-//        >     F2()
-//        > }
+//        > type I2 interface{ F2() }
    F2()
 // ^^ definition 0.1.test `sg/testdata`/I2#F2.
 //    signature_documentation
@@ -95,9 +91,7 @@
   type InterfaceWithNonExportedMethod interface {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithNonExportedMethod#
 //                                    signature_documentation
-//                                    > type InterfaceWithNonExportedMethod interface {
-//                                    >     nonExportedMethod()
-//                                    > }
+//                                    > type InterfaceWithNonExportedMethod interface{ nonExportedMethod() }
    nonExportedMethod()
 // ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithNonExportedMethod#nonExportedMethod.
 //                   signature_documentation
@@ -107,9 +101,7 @@
   type InterfaceWithExportedMethod interface {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithExportedMethod#
 //                                 signature_documentation
-//                                 > type InterfaceWithExportedMethod interface {
-//                                 >     ExportedMethod()
-//                                 > }
+//                                 > type InterfaceWithExportedMethod interface{ ExportedMethod() }
    ExportedMethod()
 // ^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithExportedMethod#ExportedMethod.
 //                signature_documentation

--- a/internal/testdata/snapshots/output/testdata/implementations.go
+++ b/internal/testdata/snapshots/output/testdata/implementations.go
@@ -4,14 +4,12 @@
   type I0 interface{}
 //     ^^ definition 0.1.test `sg/testdata`/I0#
 //        signature_documentation
-//        > type I0 interface
-//        > interface{}
+//        > type I0 interface{}
   
   type I1 interface {
 //     ^^ definition 0.1.test `sg/testdata`/I1#
 //        signature_documentation
-//        > type I1 interface
-//        > interface {
+//        > type I1 interface {
 //        >     F1()
 //        > }
    F1()
@@ -23,8 +21,7 @@
   type I2 interface {
 //     ^^ definition 0.1.test `sg/testdata`/I2#
 //        signature_documentation
-//        > type I2 interface
-//        > interface {
+//        > type I2 interface {
 //        >     F2()
 //        > }
    F2()
@@ -87,19 +84,18 @@
   type A1 = T1
 //     ^^ definition 0.1.test `sg/testdata`/A1#
 //        signature_documentation
-//        > type A1 int
+//        > type A1 = T1
 //          ^^ reference 0.1.test `sg/testdata`/T1#
   type A12 = A1
 //     ^^^ definition 0.1.test `sg/testdata`/A12#
 //         signature_documentation
-//         > type A12 int
+//         > type A12 = A1
 //           ^^ reference 0.1.test `sg/testdata`/A1#
   
   type InterfaceWithNonExportedMethod interface {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithNonExportedMethod#
 //                                    signature_documentation
-//                                    > type InterfaceWithNonExportedMethod interface
-//                                    > interface {
+//                                    > type InterfaceWithNonExportedMethod interface {
 //                                    >     nonExportedMethod()
 //                                    > }
    nonExportedMethod()
@@ -111,8 +107,7 @@
   type InterfaceWithExportedMethod interface {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithExportedMethod#
 //                                 signature_documentation
-//                                 > type InterfaceWithExportedMethod interface
-//                                 > interface {
+//                                 > type InterfaceWithExportedMethod interface {
 //                                 >     ExportedMethod()
 //                                 > }
    ExportedMethod()
@@ -171,8 +166,7 @@
   type SharedOne interface {
 //     ^^^^^^^^^ definition 0.1.test `sg/testdata`/SharedOne#
 //               signature_documentation
-//               > type SharedOne interface
-//               > interface {
+//               > type SharedOne interface {
 //               >     Distinct()
 //               >     Shared()
 //               > }
@@ -189,8 +183,7 @@
   type SharedTwo interface {
 //     ^^^^^^^^^ definition 0.1.test `sg/testdata`/SharedTwo#
 //               signature_documentation
-//               > type SharedTwo interface
-//               > interface {
+//               > type SharedTwo interface {
 //               >     Shared()
 //               >     Unique()
 //               > }
@@ -207,8 +200,7 @@
   type Between struct{}
 //     ^^^^^^^ definition 0.1.test `sg/testdata`/Between#
 //             signature_documentation
-//             > type Between struct
-//             > struct{}
+//             > type Between struct{}
 //             relationship 0.1.test `sg/testdata`/SharedOne# implementation
 //             relationship 0.1.test `sg/testdata`/SharedTwo# implementation
   

--- a/internal/testdata/snapshots/output/testdata/implementations.go
+++ b/internal/testdata/snapshots/output/testdata/implementations.go
@@ -41,7 +41,7 @@
 //      ^ definition local 0
 //        display_name r
 //        signature_documentation
-//        > var r sg/testdata.T1
+//        > var r T1
 //        ^^ reference 0.1.test `sg/testdata`/T1#
 //            ^^ definition 0.1.test `sg/testdata`/T1#F1().
 //               signature_documentation
@@ -61,7 +61,7 @@
 //      ^ definition local 1
 //        display_name r
 //        signature_documentation
-//        > var r sg/testdata.T2
+//        > var r T2
 //        ^^ reference 0.1.test `sg/testdata`/T2#
 //            ^^ definition 0.1.test `sg/testdata`/T2#F1().
 //               signature_documentation
@@ -73,7 +73,7 @@
 //      ^ definition local 2
 //        display_name r
 //        signature_documentation
-//        > var r sg/testdata.T2
+//        > var r T2
 //        ^^ reference 0.1.test `sg/testdata`/T2#
 //            ^^ definition 0.1.test `sg/testdata`/T2#F2().
 //               signature_documentation
@@ -130,7 +130,7 @@
 //      ^ definition local 3
 //        display_name r
 //        signature_documentation
-//        > var r sg/testdata.Foo
+//        > var r Foo
 //        ^^^ reference 0.1.test `sg/testdata`/Foo#
 //             ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/Foo#nonExportedMethod().
 //                               signature_documentation
@@ -142,7 +142,7 @@
 //      ^ definition local 4
 //        display_name r
 //        signature_documentation
-//        > var r sg/testdata.Foo
+//        > var r Foo
 //        ^^^ reference 0.1.test `sg/testdata`/Foo#
 //             ^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/Foo#ExportedMethod().
 //                            signature_documentation
@@ -154,7 +154,7 @@
 //      ^ definition local 5
 //        display_name r
 //        signature_documentation
-//        > var r sg/testdata.Foo
+//        > var r Foo
 //        ^^^ reference 0.1.test `sg/testdata`/Foo#
 //             ^^^^^ definition 0.1.test `sg/testdata`/Foo#Close().
 //                   signature_documentation
@@ -238,7 +238,7 @@
 //                ^^^^^^ definition local 6
 //                       display_name shared
 //                       signature_documentation
-//                       > var shared sg/testdata.SharedOne
+//                       > var shared SharedOne
 //                       ^^^^^^^^^ reference 0.1.test `sg/testdata`/SharedOne#
    shared.Shared()
 // ^^^^^^ reference local 6

--- a/internal/testdata/snapshots/output/testdata/implementations.go
+++ b/internal/testdata/snapshots/output/testdata/implementations.go
@@ -3,61 +3,40 @@
   
   type I0 interface{}
 //     ^^ definition 0.1.test `sg/testdata`/I0#
-//        documentation
-//        > ```go
+//        signature_documentation
 //        > type I0 interface
-//        > ```
-//        documentation
-//        > ```go
 //        > interface{}
-//        > ```
   
   type I1 interface {
 //     ^^ definition 0.1.test `sg/testdata`/I1#
-//        documentation
-//        > ```go
+//        signature_documentation
 //        > type I1 interface
-//        > ```
-//        documentation
-//        > ```go
 //        > interface {
 //        >     F1()
 //        > }
-//        > ```
    F1()
 // ^^ definition 0.1.test `sg/testdata`/I1#F1.
-//    documentation
-//    > ```go
+//    signature_documentation
 //    > func (I1).F1()
-//    > ```
   }
   
   type I2 interface {
 //     ^^ definition 0.1.test `sg/testdata`/I2#
-//        documentation
-//        > ```go
+//        signature_documentation
 //        > type I2 interface
-//        > ```
-//        documentation
-//        > ```go
 //        > interface {
 //        >     F2()
 //        > }
-//        > ```
    F2()
 // ^^ definition 0.1.test `sg/testdata`/I2#F2.
-//    documentation
-//    > ```go
+//    signature_documentation
 //    > func (I2).F2()
-//    > ```
   }
   
   type T1 int
 //     ^^ definition 0.1.test `sg/testdata`/T1#
-//        documentation
-//        > ```go
-//        > int
-//        > ```
+//        signature_documentation
+//        > type T1 int
 //        relationship 0.1.test `sg/testdata`/I1# implementation
   
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/T1#F1().
@@ -68,19 +47,15 @@
 //        > var r sg/testdata.T1
 //        ^^ reference 0.1.test `sg/testdata`/T1#
 //            ^^ definition 0.1.test `sg/testdata`/T1#F1().
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > func (T1).F1()
-//               > ```
 //               relationship 0.1.test `sg/testdata`/I1#F1. implementation
 //                  ⌃ enclosing_range_end 0.1.test `sg/testdata`/T1#F1().
   
   type T2 int
 //     ^^ definition 0.1.test `sg/testdata`/T2#
-//        documentation
-//        > ```go
-//        > int
-//        > ```
+//        signature_documentation
+//        > type T2 int
 //        relationship 0.1.test `sg/testdata`/I1# implementation
 //        relationship 0.1.test `sg/testdata`/I2# implementation
   
@@ -92,10 +67,8 @@
 //        > var r sg/testdata.T2
 //        ^^ reference 0.1.test `sg/testdata`/T2#
 //            ^^ definition 0.1.test `sg/testdata`/T2#F1().
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > func (T2).F1()
-//               > ```
 //               relationship 0.1.test `sg/testdata`/I1#F1. implementation
 //                  ⌃ enclosing_range_end 0.1.test `sg/testdata`/T2#F1().
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/T2#F2().
@@ -106,74 +79,52 @@
 //        > var r sg/testdata.T2
 //        ^^ reference 0.1.test `sg/testdata`/T2#
 //            ^^ definition 0.1.test `sg/testdata`/T2#F2().
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > func (T2).F2()
-//               > ```
 //               relationship 0.1.test `sg/testdata`/I2#F2. implementation
 //                  ⌃ enclosing_range_end 0.1.test `sg/testdata`/T2#F2().
   
   type A1 = T1
 //     ^^ definition 0.1.test `sg/testdata`/A1#
-//        documentation
-//        > ```go
-//        > int
-//        > ```
+//        signature_documentation
+//        > type A1 int
 //          ^^ reference 0.1.test `sg/testdata`/T1#
   type A12 = A1
 //     ^^^ definition 0.1.test `sg/testdata`/A12#
-//         documentation
-//         > ```go
-//         > int
-//         > ```
+//         signature_documentation
+//         > type A12 int
 //           ^^ reference 0.1.test `sg/testdata`/A1#
   
   type InterfaceWithNonExportedMethod interface {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithNonExportedMethod#
-//                                    documentation
-//                                    > ```go
+//                                    signature_documentation
 //                                    > type InterfaceWithNonExportedMethod interface
-//                                    > ```
-//                                    documentation
-//                                    > ```go
 //                                    > interface {
 //                                    >     nonExportedMethod()
 //                                    > }
-//                                    > ```
    nonExportedMethod()
 // ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithNonExportedMethod#nonExportedMethod.
-//                   documentation
-//                   > ```go
+//                   signature_documentation
 //                   > func (InterfaceWithNonExportedMethod).nonExportedMethod()
-//                   > ```
   }
   
   type InterfaceWithExportedMethod interface {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithExportedMethod#
-//                                 documentation
-//                                 > ```go
+//                                 signature_documentation
 //                                 > type InterfaceWithExportedMethod interface
-//                                 > ```
-//                                 documentation
-//                                 > ```go
 //                                 > interface {
 //                                 >     ExportedMethod()
 //                                 > }
-//                                 > ```
    ExportedMethod()
 // ^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithExportedMethod#ExportedMethod.
-//                documentation
-//                > ```go
+//                signature_documentation
 //                > func (InterfaceWithExportedMethod).ExportedMethod()
-//                > ```
   }
   
   type Foo int
 //     ^^^ definition 0.1.test `sg/testdata`/Foo#
-//         documentation
-//         > ```go
-//         > int
-//         > ```
+//         signature_documentation
+//         > type Foo int
 //         relationship github.com/golang/go/src go1.22 io/Closer# implementation
 //         relationship 0.1.test `sg/testdata`/I3# implementation
 //         relationship 0.1.test `sg/testdata`/InterfaceWithExportedMethod# implementation
@@ -187,10 +138,8 @@
 //        > var r sg/testdata.Foo
 //        ^^^ reference 0.1.test `sg/testdata`/Foo#
 //             ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/Foo#nonExportedMethod().
-//                               documentation
-//                               > ```go
+//                               signature_documentation
 //                               > func (Foo).nonExportedMethod()
-//                               > ```
 //                               relationship 0.1.test `sg/testdata`/InterfaceWithNonExportedMethod#nonExportedMethod. implementation
 //                                  ⌃ enclosing_range_end 0.1.test `sg/testdata`/Foo#nonExportedMethod().
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/Foo#ExportedMethod().
@@ -201,10 +150,8 @@
 //        > var r sg/testdata.Foo
 //        ^^^ reference 0.1.test `sg/testdata`/Foo#
 //             ^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/Foo#ExportedMethod().
-//                            documentation
-//                            > ```go
+//                            signature_documentation
 //                            > func (Foo).ExportedMethod()
-//                            > ```
 //                            relationship 0.1.test `sg/testdata`/InterfaceWithExportedMethod#ExportedMethod. implementation
 //                                  ⌃ enclosing_range_end 0.1.test `sg/testdata`/Foo#ExportedMethod().
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/Foo#Close().
@@ -215,78 +162,53 @@
 //        > var r sg/testdata.Foo
 //        ^^^ reference 0.1.test `sg/testdata`/Foo#
 //             ^^^^^ definition 0.1.test `sg/testdata`/Foo#Close().
-//                   documentation
-//                   > ```go
+//                   signature_documentation
 //                   > func (Foo).Close() error
-//                   > ```
 //                   relationship github.com/golang/go/src go1.22 io/Closer#Close. implementation
 //                   relationship 0.1.test `sg/testdata`/I3#Close. implementation
 //                                              ⌃ enclosing_range_end 0.1.test `sg/testdata`/Foo#Close().
   
   type SharedOne interface {
 //     ^^^^^^^^^ definition 0.1.test `sg/testdata`/SharedOne#
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > type SharedOne interface
-//               > ```
-//               documentation
-//               > ```go
 //               > interface {
 //               >     Distinct()
 //               >     Shared()
 //               > }
-//               > ```
    Shared()
 // ^^^^^^ definition 0.1.test `sg/testdata`/SharedOne#Shared.
-//        documentation
-//        > ```go
+//        signature_documentation
 //        > func (SharedOne).Shared()
-//        > ```
    Distinct()
 // ^^^^^^^^ definition 0.1.test `sg/testdata`/SharedOne#Distinct.
-//          documentation
-//          > ```go
+//          signature_documentation
 //          > func (SharedOne).Distinct()
-//          > ```
   }
   
   type SharedTwo interface {
 //     ^^^^^^^^^ definition 0.1.test `sg/testdata`/SharedTwo#
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > type SharedTwo interface
-//               > ```
-//               documentation
-//               > ```go
 //               > interface {
 //               >     Shared()
 //               >     Unique()
 //               > }
-//               > ```
    Shared()
 // ^^^^^^ definition 0.1.test `sg/testdata`/SharedTwo#Shared.
-//        documentation
-//        > ```go
+//        signature_documentation
 //        > func (SharedTwo).Shared()
-//        > ```
    Unique()
 // ^^^^^^ definition 0.1.test `sg/testdata`/SharedTwo#Unique.
-//        documentation
-//        > ```go
+//        signature_documentation
 //        > func (SharedTwo).Unique()
-//        > ```
   }
   
   type Between struct{}
 //     ^^^^^^^ definition 0.1.test `sg/testdata`/Between#
-//             documentation
-//             > ```go
+//             signature_documentation
 //             > type Between struct
-//             > ```
-//             documentation
-//             > ```go
 //             > struct{}
-//             > ```
 //             relationship 0.1.test `sg/testdata`/SharedOne# implementation
 //             relationship 0.1.test `sg/testdata`/SharedTwo# implementation
   
@@ -294,10 +216,8 @@
   func (Between) Shared()   {}
 //      ^^^^^^^ reference 0.1.test `sg/testdata`/Between#
 //               ^^^^^^ definition 0.1.test `sg/testdata`/Between#Shared().
-//                      documentation
-//                      > ```go
+//                      signature_documentation
 //                      > func (Between).Shared()
-//                      > ```
 //                      relationship 0.1.test `sg/testdata`/SharedOne#Shared. implementation
 //                      relationship 0.1.test `sg/testdata`/SharedTwo#Shared. implementation
 //                           ⌃ enclosing_range_end 0.1.test `sg/testdata`/Between#Shared().
@@ -305,30 +225,24 @@
   func (Between) Distinct() {}
 //      ^^^^^^^ reference 0.1.test `sg/testdata`/Between#
 //               ^^^^^^^^ definition 0.1.test `sg/testdata`/Between#Distinct().
-//                        documentation
-//                        > ```go
+//                        signature_documentation
 //                        > func (Between).Distinct()
-//                        > ```
 //                        relationship 0.1.test `sg/testdata`/SharedOne#Distinct. implementation
 //                           ⌃ enclosing_range_end 0.1.test `sg/testdata`/Between#Distinct().
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/Between#Unique().
   func (Between) Unique()   {}
 //      ^^^^^^^ reference 0.1.test `sg/testdata`/Between#
 //               ^^^^^^ definition 0.1.test `sg/testdata`/Between#Unique().
-//                      documentation
-//                      > ```go
+//                      signature_documentation
 //                      > func (Between).Unique()
-//                      > ```
 //                      relationship 0.1.test `sg/testdata`/SharedTwo#Unique. implementation
 //                           ⌃ enclosing_range_end 0.1.test `sg/testdata`/Between#Unique().
   
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/shouldShow().
   func shouldShow(shared SharedOne) {
 //     ^^^^^^^^^^ definition 0.1.test `sg/testdata`/shouldShow().
-//                documentation
-//                > ```go
+//                signature_documentation
 //                > func shouldShow(shared SharedOne)
-//                > ```
 //                ^^^^^^ definition local 6
 //                       display_name shared
 //                       signature_documentation

--- a/internal/testdata/snapshots/output/testdata/implementations_embedded.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_embedded.go
@@ -6,45 +6,31 @@
   
   type I3 interface {
 //     ^^ definition 0.1.test `sg/testdata`/I3#
-//        documentation
-//        > ```go
+//        signature_documentation
 //        > type I3 interface
-//        > ```
-//        documentation
-//        > ```go
 //        > interface {
 //        >     Close() error
 //        > }
-//        > ```
    Close() error
 // ^^^^^ definition 0.1.test `sg/testdata`/I3#Close.
-//       documentation
-//       > ```go
+//       signature_documentation
 //       > func (I3).Close() error
-//       > ```
   }
   
   type TClose struct {
 //     ^^^^^^ definition 0.1.test `sg/testdata`/TClose#
-//            documentation
-//            > ```go
+//            signature_documentation
 //            > type TClose struct
-//            > ```
-//            documentation
-//            > ```go
 //            > struct {
 //            >     Closer
 //            > }
-//            > ```
 //            relationship github.com/golang/go/src go1.22 io/Closer# implementation
 //            relationship 0.1.test `sg/testdata`/I3# implementation
    io.Closer
 // ^^ reference github.com/golang/go/src go1.22 io/
 //    ^^^^^^ definition 0.1.test `sg/testdata`/TClose#Closer.
-//           documentation
-//           > ```go
+//           signature_documentation
 //           > struct field Closer io.Closer
-//           > ```
 //    ^^^^^^ reference github.com/golang/go/src go1.22 io/Closer#
   }
   

--- a/internal/testdata/snapshots/output/testdata/implementations_embedded.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_embedded.go
@@ -7,8 +7,7 @@
   type I3 interface {
 //     ^^ definition 0.1.test `sg/testdata`/I3#
 //        signature_documentation
-//        > type I3 interface
-//        > interface {
+//        > type I3 interface {
 //        >     Close() error
 //        > }
    Close() error
@@ -20,8 +19,7 @@
   type TClose struct {
 //     ^^^^^^ definition 0.1.test `sg/testdata`/TClose#
 //            signature_documentation
-//            > type TClose struct
-//            > struct {
+//            > type TClose struct {
 //            >     Closer
 //            > }
 //            relationship github.com/golang/go/src go1.22 io/Closer# implementation

--- a/internal/testdata/snapshots/output/testdata/implementations_embedded.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_embedded.go
@@ -7,9 +7,7 @@
   type I3 interface {
 //     ^^ definition 0.1.test `sg/testdata`/I3#
 //        signature_documentation
-//        > type I3 interface {
-//        >     Close() error
-//        > }
+//        > type I3 interface{ Close() error }
    Close() error
 // ^^^^^ definition 0.1.test `sg/testdata`/I3#Close.
 //       signature_documentation
@@ -19,9 +17,7 @@
   type TClose struct {
 //     ^^^^^^ definition 0.1.test `sg/testdata`/TClose#
 //            signature_documentation
-//            > type TClose struct {
-//            >     Closer
-//            > }
+//            > type TClose struct{ Closer }
 //            relationship github.com/golang/go/src go1.22 io/Closer# implementation
 //            relationship 0.1.test `sg/testdata`/I3# implementation
    io.Closer

--- a/internal/testdata/snapshots/output/testdata/implementations_methods.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_methods.go
@@ -4,9 +4,7 @@
   type InterfaceWithSingleMethod interface {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithSingleMethod#
 //                               signature_documentation
-//                               > type InterfaceWithSingleMethod interface {
-//                               >     SingleMethod() float64
-//                               > }
+//                               > type InterfaceWithSingleMethod interface{ SingleMethod() float64 }
    SingleMethod() float64
 // ^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithSingleMethod#SingleMethod.
 //              signature_documentation
@@ -31,9 +29,7 @@
   type InterfaceWithSingleMethodTwoImplementers interface {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithSingleMethodTwoImplementers#
 //                                              signature_documentation
-//                                              > type InterfaceWithSingleMethodTwoImplementers interface {
-//                                              >     SingleMethodTwoImpl() float64
-//                                              > }
+//                                              > type InterfaceWithSingleMethodTwoImplementers interface{ SingleMethodTwoImpl() float64 }
    SingleMethodTwoImpl() float64
 // ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithSingleMethodTwoImplementers#SingleMethodTwoImpl.
 //                     signature_documentation

--- a/internal/testdata/snapshots/output/testdata/implementations_methods.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_methods.go
@@ -3,119 +3,82 @@
   
   type InterfaceWithSingleMethod interface {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithSingleMethod#
-//                               documentation
-//                               > ```go
+//                               signature_documentation
 //                               > type InterfaceWithSingleMethod interface
-//                               > ```
-//                               documentation
-//                               > ```go
 //                               > interface {
 //                               >     SingleMethod() float64
 //                               > }
-//                               > ```
    SingleMethod() float64
 // ^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithSingleMethod#SingleMethod.
-//              documentation
-//              > ```go
+//              signature_documentation
 //              > func (InterfaceWithSingleMethod).SingleMethod() float64
-//              > ```
   }
   
   type StructWithMethods struct{}
 //     ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/StructWithMethods#
-//                       documentation
-//                       > ```go
+//                       signature_documentation
 //                       > type StructWithMethods struct
-//                       > ```
-//                       documentation
-//                       > ```go
 //                       > struct{}
-//                       > ```
 //                       relationship 0.1.test `sg/testdata`/InterfaceWithSingleMethod# implementation
   
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/StructWithMethods#SingleMethod().
   func (StructWithMethods) SingleMethod() float64 { return 5.0 }
 //      ^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/StructWithMethods#
 //                         ^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/StructWithMethods#SingleMethod().
-//                                      documentation
-//                                      > ```go
+//                                      signature_documentation
 //                                      > func (StructWithMethods).SingleMethod() float64
-//                                      > ```
 //                                      relationship 0.1.test `sg/testdata`/InterfaceWithSingleMethod#SingleMethod. implementation
 //                                                             ⌃ enclosing_range_end 0.1.test `sg/testdata`/StructWithMethods#SingleMethod().
   
   type InterfaceWithSingleMethodTwoImplementers interface {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithSingleMethodTwoImplementers#
-//                                              documentation
-//                                              > ```go
+//                                              signature_documentation
 //                                              > type InterfaceWithSingleMethodTwoImplementers interface
-//                                              > ```
-//                                              documentation
-//                                              > ```go
 //                                              > interface {
 //                                              >     SingleMethodTwoImpl() float64
 //                                              > }
-//                                              > ```
    SingleMethodTwoImpl() float64
 // ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithSingleMethodTwoImplementers#SingleMethodTwoImpl.
-//                     documentation
-//                     > ```go
+//                     signature_documentation
 //                     > func (InterfaceWithSingleMethodTwoImplementers).SingleMethodTwoImpl() float64
-//                     > ```
   }
   
   type TwoImplOne struct{}
 //     ^^^^^^^^^^ definition 0.1.test `sg/testdata`/TwoImplOne#
-//                documentation
-//                > ```go
+//                signature_documentation
 //                > type TwoImplOne struct
-//                > ```
-//                documentation
-//                > ```go
 //                > struct{}
-//                > ```
 //                relationship 0.1.test `sg/testdata`/InterfaceWithSingleMethodTwoImplementers# implementation
   
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/TwoImplOne#SingleMethodTwoImpl().
   func (TwoImplOne) SingleMethodTwoImpl() float64 { return 5.0 }
 //      ^^^^^^^^^^ reference 0.1.test `sg/testdata`/TwoImplOne#
 //                  ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TwoImplOne#SingleMethodTwoImpl().
-//                                      documentation
-//                                      > ```go
+//                                      signature_documentation
 //                                      > func (TwoImplOne).SingleMethodTwoImpl() float64
-//                                      > ```
 //                                      relationship 0.1.test `sg/testdata`/InterfaceWithSingleMethodTwoImplementers#SingleMethodTwoImpl. implementation
 //                                                             ⌃ enclosing_range_end 0.1.test `sg/testdata`/TwoImplOne#SingleMethodTwoImpl().
   
   type TwoImplTwo struct{}
 //     ^^^^^^^^^^ definition 0.1.test `sg/testdata`/TwoImplTwo#
-//                documentation
-//                > ```go
+//                signature_documentation
 //                > type TwoImplTwo struct
-//                > ```
-//                documentation
-//                > ```go
 //                > struct{}
-//                > ```
 //                relationship 0.1.test `sg/testdata`/InterfaceWithSingleMethodTwoImplementers# implementation
   
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/TwoImplTwo#SingleMethodTwoImpl().
   func (TwoImplTwo) SingleMethodTwoImpl() float64         { return 5.0 }
 //      ^^^^^^^^^^ reference 0.1.test `sg/testdata`/TwoImplTwo#
 //                  ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TwoImplTwo#SingleMethodTwoImpl().
-//                                      documentation
-//                                      > ```go
+//                                      signature_documentation
 //                                      > func (TwoImplTwo).SingleMethodTwoImpl() float64
-//                                      > ```
 //                                      relationship 0.1.test `sg/testdata`/InterfaceWithSingleMethodTwoImplementers#SingleMethodTwoImpl. implementation
 //                                                                     ⌃ enclosing_range_end 0.1.test `sg/testdata`/TwoImplTwo#SingleMethodTwoImpl().
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/TwoImplTwo#RandomThingThatDoesntMatter().
   func (TwoImplTwo) RandomThingThatDoesntMatter() float64 { return 5.0 }
 //      ^^^^^^^^^^ reference 0.1.test `sg/testdata`/TwoImplTwo#
 //                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TwoImplTwo#RandomThingThatDoesntMatter().
-//                                              documentation
-//                                              > ```go
+//                                              signature_documentation
 //                                              > func (TwoImplTwo).RandomThingThatDoesntMatter() float64
-//                                              > ```
 //                                                                     ⌃ enclosing_range_end 0.1.test `sg/testdata`/TwoImplTwo#RandomThingThatDoesntMatter().
   

--- a/internal/testdata/snapshots/output/testdata/implementations_methods.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_methods.go
@@ -4,8 +4,7 @@
   type InterfaceWithSingleMethod interface {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithSingleMethod#
 //                               signature_documentation
-//                               > type InterfaceWithSingleMethod interface
-//                               > interface {
+//                               > type InterfaceWithSingleMethod interface {
 //                               >     SingleMethod() float64
 //                               > }
    SingleMethod() float64
@@ -17,8 +16,7 @@
   type StructWithMethods struct{}
 //     ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/StructWithMethods#
 //                       signature_documentation
-//                       > type StructWithMethods struct
-//                       > struct{}
+//                       > type StructWithMethods struct{}
 //                       relationship 0.1.test `sg/testdata`/InterfaceWithSingleMethod# implementation
   
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/StructWithMethods#SingleMethod().
@@ -33,8 +31,7 @@
   type InterfaceWithSingleMethodTwoImplementers interface {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithSingleMethodTwoImplementers#
 //                                              signature_documentation
-//                                              > type InterfaceWithSingleMethodTwoImplementers interface
-//                                              > interface {
+//                                              > type InterfaceWithSingleMethodTwoImplementers interface {
 //                                              >     SingleMethodTwoImpl() float64
 //                                              > }
    SingleMethodTwoImpl() float64
@@ -46,8 +43,7 @@
   type TwoImplOne struct{}
 //     ^^^^^^^^^^ definition 0.1.test `sg/testdata`/TwoImplOne#
 //                signature_documentation
-//                > type TwoImplOne struct
-//                > struct{}
+//                > type TwoImplOne struct{}
 //                relationship 0.1.test `sg/testdata`/InterfaceWithSingleMethodTwoImplementers# implementation
   
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/TwoImplOne#SingleMethodTwoImpl().
@@ -62,8 +58,7 @@
   type TwoImplTwo struct{}
 //     ^^^^^^^^^^ definition 0.1.test `sg/testdata`/TwoImplTwo#
 //                signature_documentation
-//                > type TwoImplTwo struct
-//                > struct{}
+//                > type TwoImplTwo struct{}
 //                relationship 0.1.test `sg/testdata`/InterfaceWithSingleMethodTwoImplementers# implementation
   
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/TwoImplTwo#SingleMethodTwoImpl().

--- a/internal/testdata/snapshots/output/testdata/implementations_remote.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_remote.go
@@ -7,8 +7,7 @@
   type implementsWriter struct{}
 //     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/implementsWriter#
 //                      signature_documentation
-//                      > type implementsWriter struct
-//                      > struct{}
+//                      > type implementsWriter struct{}
 //                      relationship github.com/golang/go/src go1.22 `crypto/tls`/transcriptHash# implementation
 //                      relationship github.com/golang/go/src go1.22 `internal/bisect`/Writer# implementation
 //                      relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter# implementation

--- a/internal/testdata/snapshots/output/testdata/implementations_remote.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_remote.go
@@ -6,14 +6,9 @@
   
   type implementsWriter struct{}
 //     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/implementsWriter#
-//                      documentation
-//                      > ```go
+//                      signature_documentation
 //                      > type implementsWriter struct
-//                      > ```
-//                      documentation
-//                      > ```go
 //                      > struct{}
-//                      > ```
 //                      relationship github.com/golang/go/src go1.22 `crypto/tls`/transcriptHash# implementation
 //                      relationship github.com/golang/go/src go1.22 `internal/bisect`/Writer# implementation
 //                      relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter# implementation
@@ -23,10 +18,8 @@
   func (implementsWriter) Header() http.Header        { panic("Just for how") }
 //      ^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/implementsWriter#
 //                        ^^^^^^ definition 0.1.test `sg/testdata`/implementsWriter#Header().
-//                               documentation
-//                               > ```go
+//                               signature_documentation
 //                               > func (implementsWriter).Header() Header
-//                               > ```
 //                               relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#Header. implementation
 //                                 ^^^^ reference github.com/golang/go/src go1.22 `net/http`/
 //                                      ^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/Header#
@@ -35,10 +28,8 @@
   func (implementsWriter) Write([]byte) (int, error)  { panic("Just for show") }
 //      ^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/implementsWriter#
 //                        ^^^^^ definition 0.1.test `sg/testdata`/implementsWriter#Write().
-//                              documentation
-//                              > ```go
+//                              signature_documentation
 //                              > func (implementsWriter).Write([]byte) (int, error)
-//                              > ```
 //                              relationship github.com/golang/go/src go1.22 `crypto/tls`/transcriptHash#Write. implementation
 //                              relationship github.com/golang/go/src go1.22 `internal/bisect`/Writer#Write. implementation
 //                              relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#Write. implementation
@@ -48,10 +39,8 @@
   func (implementsWriter) WriteHeader(statusCode int) {}
 //      ^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/implementsWriter#
 //                        ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/implementsWriter#WriteHeader().
-//                                    documentation
-//                                    > ```go
+//                                    signature_documentation
 //                                    > func (implementsWriter).WriteHeader(statusCode int)
-//                                    > ```
 //                                    relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#WriteHeader. implementation
 //                                    ^^^^^^^^^^ definition local 0
 //                                               display_name statusCode
@@ -62,10 +51,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/ShowsInSignature().
   func ShowsInSignature(respWriter http.ResponseWriter) {
 //     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/ShowsInSignature().
-//                      documentation
-//                      > ```go
+//                      signature_documentation
 //                      > func ShowsInSignature(respWriter ResponseWriter)
-//                      > ```
 //                      ^^^^^^^^^^ definition local 1
 //                                 display_name respWriter
 //                                 signature_documentation

--- a/internal/testdata/snapshots/output/testdata/implementations_remote.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_remote.go
@@ -55,7 +55,7 @@
 //                      ^^^^^^^^^^ definition local 1
 //                                 display_name respWriter
 //                                 signature_documentation
-//                                 > var respWriter net/http.ResponseWriter
+//                                 > var respWriter ResponseWriter
 //                                 ^^^^ reference github.com/golang/go/src go1.22 `net/http`/
 //                                      ^^^^^^^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/ResponseWriter#
    respWriter.WriteHeader(1)

--- a/internal/testdata/snapshots/output/testdata/internal/secret/secret.go
+++ b/internal/testdata/snapshots/output/testdata/internal/secret/secret.go
@@ -13,8 +13,7 @@
   type Burger struct {
 //     ^^^^^^ definition 0.1.test `sg/testdata/internal/secret`/Burger#
 //            signature_documentation
-//            > type Burger struct
-//            > struct {
+//            > type Burger struct {
 //            >     Field int
 //            > }
 //            documentation

--- a/internal/testdata/snapshots/output/testdata/internal/secret/secret.go
+++ b/internal/testdata/snapshots/output/testdata/internal/secret/secret.go
@@ -13,9 +13,7 @@
   type Burger struct {
 //     ^^^^^^ definition 0.1.test `sg/testdata/internal/secret`/Burger#
 //            signature_documentation
-//            > type Burger struct {
-//            >     Field int
-//            > }
+//            > type Burger struct{ Field int }
 //            documentation
 //            > Original doc
    Field int

--- a/internal/testdata/snapshots/output/testdata/internal/secret/secret.go
+++ b/internal/testdata/snapshots/output/testdata/internal/secret/secret.go
@@ -4,33 +4,24 @@
   // SecretScore is like score but _secret_.
   const SecretScore = uint64(43)
 //      ^^^^^^^^^^^ definition 0.1.test `sg/testdata/internal/secret`/SecretScore.
-//                  documentation
-//                  > ```go
+//                  signature_documentation
 //                  > const SecretScore uint64 = 43
-//                  > ```
 //                  documentation
 //                  > SecretScore is like score but _secret_.
   
   // Original doc
   type Burger struct {
 //     ^^^^^^ definition 0.1.test `sg/testdata/internal/secret`/Burger#
-//            documentation
-//            > ```go
+//            signature_documentation
 //            > type Burger struct
-//            > ```
-//            documentation
-//            > Original doc
-//            documentation
-//            > ```go
 //            > struct {
 //            >     Field int
 //            > }
-//            > ```
+//            documentation
+//            > Original doc
    Field int
 // ^^^^^ definition 0.1.test `sg/testdata/internal/secret`/Burger#Field.
-//       documentation
-//       > ```go
+//       signature_documentation
 //       > struct field Field int
-//       > ```
   }
   

--- a/internal/testdata/snapshots/output/testdata/named_import.go
+++ b/internal/testdata/snapshots/output/testdata/named_import.go
@@ -12,10 +12,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/Example().
   func Example() {
 //     ^^^^^^^ definition 0.1.test `sg/testdata`/Example().
-//             documentation
-//             > ```go
+//             signature_documentation
 //             > func Example()
-//             > ```
    Println(h.CanonicalHeaderKey("accept-encoding"))
 // ^^^^^^^ reference github.com/golang/go/src go1.22 fmt/Println().
 //         ^ reference github.com/golang/go/src go1.22 `net/http`/

--- a/internal/testdata/snapshots/output/testdata/parallel.go
+++ b/internal/testdata/snapshots/output/testdata/parallel.go
@@ -20,7 +20,7 @@
 //                             ^^^ definition local 0
 //                                 display_name ctx
 //                                 signature_documentation
-//                                 > var ctx context.Context
+//                                 > var ctx Context
 //                                 ^^^^^^^ reference github.com/golang/go/src go1.22 context/
 //                                         ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
   
@@ -37,19 +37,19 @@
 //              ^^^ definition local 1
 //                  display_name ctx
 //                  signature_documentation
-//                  > var ctx context.Context
+//                  > var ctx Context
 //                  ^^^^^^^ reference github.com/golang/go/src go1.22 context/
 //                          ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
 //                                   ^^^ definition local 2
 //                                       display_name fns
 //                                       signature_documentation
-//                                       > var fns []sg/testdata.ParallelizableFunc
+//                                       > var fns []ParallelizableFunc
 //                                          ^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/ParallelizableFunc#
    var wg sync.WaitGroup
 //     ^^ definition local 3
 //        display_name wg
 //        signature_documentation
-//        > var wg sync.WaitGroup
+//        > var wg WaitGroup
 //        ^^^^ reference github.com/golang/go/src go1.22 sync/
 //             ^^^^^^^^^ reference github.com/golang/go/src go1.22 sync/WaitGroup#
    errs := make(chan error, len(fns))
@@ -63,7 +63,7 @@
 //        ^^ definition local 5
 //           display_name fn
 //           signature_documentation
-//           > var fn sg/testdata.ParallelizableFunc
+//           > var fn ParallelizableFunc
 //                    ^^^ reference local 2
     wg.Add(1)
 //  ^^ reference local 3
@@ -73,7 +73,7 @@
 //          ^^ definition local 6
 //             display_name fn
 //             signature_documentation
-//             > var fn sg/testdata.ParallelizableFunc
+//             > var fn ParallelizableFunc
 //             ^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/ParallelizableFunc#
      errs <- fn(ctx)
 //   ^^^^ reference local 4

--- a/internal/testdata/snapshots/output/testdata/parallel.go
+++ b/internal/testdata/snapshots/output/testdata/parallel.go
@@ -12,13 +12,11 @@
   // of this function type.
   type ParallelizableFunc func(ctx context.Context) error
 //     ^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/ParallelizableFunc#
+//                        signature_documentation
+//                        > type ParallelizableFunc func(ctx Context) error
 //                        documentation
 //                        > ParallelizableFunc is a function that can be called concurrently with other instances
 //                        > of this function type.
-//                        documentation
-//                        > ```go
-//                        > func(ctx Context) error
-//                        > ```
 //                             ^^^ definition local 0
 //                                 display_name ctx
 //                                 signature_documentation
@@ -31,10 +29,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/Parallel().
   func Parallel(ctx context.Context, fns ...ParallelizableFunc) error {
 //     ^^^^^^^^ definition 0.1.test `sg/testdata`/Parallel().
-//              documentation
-//              > ```go
+//              signature_documentation
 //              > func Parallel(ctx Context, fns ...ParallelizableFunc) error
-//              > ```
 //              documentation
 //              > Parallel invokes each of the given parallelizable functions in their own goroutines and
 //              > returns the first error to occur. This method will block until all goroutines have returned.

--- a/internal/testdata/snapshots/output/testdata/typealias.go
+++ b/internal/testdata/snapshots/output/testdata/typealias.go
@@ -11,9 +11,6 @@
 //     ^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/SecretBurger#
 //                  signature_documentation
 //                  > type SecretBurger = secret.Burger
-//                  > struct {
-//                  >     Field int
-//                  > }
 //                  documentation
 //                  > Type aliased doc
 //                    ^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/
@@ -22,8 +19,7 @@
   type BadBurger = struct {
 //     ^^^^^^^^^ definition 0.1.test `sg/testdata`/BadBurger#
 //               signature_documentation
-//               > type BadBurger = struct
-//               > struct {
+//               > type BadBurger = struct {
 //               >     Field string
 //               > }
    Field string

--- a/internal/testdata/snapshots/output/testdata/typealias.go
+++ b/internal/testdata/snapshots/output/testdata/typealias.go
@@ -9,38 +9,26 @@
   // Type aliased doc
   type SecretBurger = secret.Burger
 //     ^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/SecretBurger#
-//                  documentation
-//                  > ```go
+//                  signature_documentation
 //                  > type SecretBurger = secret.Burger
-//                  > ```
-//                  documentation
-//                  > Type aliased doc
-//                  documentation
-//                  > ```go
 //                  > struct {
 //                  >     Field int
 //                  > }
-//                  > ```
+//                  documentation
+//                  > Type aliased doc
 //                    ^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/
 //                           ^^^^^^ reference 0.1.test `sg/testdata/internal/secret`/Burger#
   
   type BadBurger = struct {
 //     ^^^^^^^^^ definition 0.1.test `sg/testdata`/BadBurger#
-//               documentation
-//               > ```go
+//               signature_documentation
 //               > type BadBurger = struct
-//               > ```
-//               documentation
-//               > ```go
 //               > struct {
 //               >     Field string
 //               > }
-//               > ```
    Field string
 // ^^^^^ definition 0.1.test `sg/testdata`/BadBurger#Field.
-//       documentation
-//       > ```go
+//       signature_documentation
 //       > struct field Field string
-//       > ```
   }
   

--- a/internal/testdata/snapshots/output/testdata/typealias.go
+++ b/internal/testdata/snapshots/output/testdata/typealias.go
@@ -19,9 +19,7 @@
   type BadBurger = struct {
 //     ^^^^^^^^^ definition 0.1.test `sg/testdata`/BadBurger#
 //               signature_documentation
-//               > type BadBurger = struct {
-//               >     Field string
-//               > }
+//               > type BadBurger = struct{ Field string }
    Field string
 // ^^^^^ definition 0.1.test `sg/testdata`/BadBurger#Field.
 //       signature_documentation

--- a/internal/testdata/snapshots/output/testdata/typeswitch.go
+++ b/internal/testdata/snapshots/output/testdata/typeswitch.go
@@ -4,10 +4,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/Switch().
   func Switch(interfaceValue interface{}) bool {
 //     ^^^^^^ definition 0.1.test `sg/testdata`/Switch().
-//            documentation
-//            > ```go
+//            signature_documentation
 //            > func Switch(interfaceValue interface{}) bool
-//            > ```
 //            ^^^^^^^^^^^^^^ definition local 0
 //                           display_name interfaceValue
 //                           signature_documentation

--- a/internal/testdata/snapshots/output/testspecial/foo.go
+++ b/internal/testdata/snapshots/output/testspecial/foo.go
@@ -7,9 +7,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/testspecial`/Foo().
   func Foo() {}
 //     ^^^ definition 0.1.test `sg/testspecial`/Foo().
-//         documentation
-//         > ```go
+//         signature_documentation
 //         > func Foo()
-//         > ```
 //            ⌃ enclosing_range_end 0.1.test `sg/testspecial`/Foo().
   

--- a/internal/testdata/snapshots/output/testspecial/foo_other_test.go
+++ b/internal/testdata/snapshots/output/testspecial/foo_other_test.go
@@ -15,10 +15,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/testspecial_test`/TestFoo_Blackbox().
   func TestFoo_Blackbox(*testing.T) { testspecial.Foo() }
 //     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testspecial_test`/TestFoo_Blackbox().
-//                      documentation
-//                      > ```go
+//                      signature_documentation
 //                      > func TestFoo_Blackbox(*T)
-//                      > ```
 //                       ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
 //                               ^ reference github.com/golang/go/src go1.22 testing/T#
 //                                    ^^^^^^^^^^^ reference 0.1.test `sg/testspecial`/

--- a/internal/testdata/snapshots/output/testspecial/foo_test.go
+++ b/internal/testdata/snapshots/output/testspecial/foo_test.go
@@ -4,10 +4,8 @@
 //⌄ enclosing_range_start 0.1.test `sg/testspecial`/TestFoo_Whitebox().
   func TestFoo_Whitebox() { Foo() }
 //     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testspecial`/TestFoo_Whitebox().
-//                      documentation
-//                      > ```go
+//                      signature_documentation
 //                      > func TestFoo_Whitebox()
-//                      > ```
 //                          ^^^ reference 0.1.test `sg/testspecial`/Foo().
 //                                ⌃ enclosing_range_end 0.1.test `sg/testspecial`/TestFoo_Whitebox().
   


### PR DESCRIPTION
Now the default case returns the full 'type Name underlying' signature. We skip redundant output for non-`struct`/`interface` types.

Fixes https://github.com/sourcegraph/scip-go/issues/107