### PR TITLE
Populate `SymbolInformation.Kind`

### DIFF
--- a/internal/document/document.go
+++ b/internal/document/document.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/scip-code/scip/bindings/go/scip"
 	"github.com/sourcegraph/scip-go/internal/lookup"
+	"github.com/sourcegraph/scip-go/internal/symbols"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -94,11 +95,13 @@ func (d *Document) SetNewSymbolForPos(
 	var displayName string
 	var documentation []string
 	var sigDoc *scip.Document
+	var def types.Object
 
 	if ident != nil {
 		displayName = ident.Name
 
-		if def := d.pkg.TypesInfo.Defs[ident]; def != nil {
+		def = d.pkg.TypesInfo.Defs[ident]
+		if def != nil {
 			if signature := typeStringForObject(def); signature != "" {
 				sigDoc = &scip.Document{
 					Language: "go",
@@ -119,6 +122,7 @@ func (d *Document) SetNewSymbolForPos(
 
 	d.pkgSymbols.Set(pos, &scip.SymbolInformation{
 		Symbol:                 symbol,
+		Kind:                   symbols.KindForObject(def),
 		DisplayName:            displayName,
 		Documentation:          documentation,
 		SignatureDocumentation: sigDoc,

--- a/internal/index/scip.go
+++ b/internal/index/scip.go
@@ -210,6 +210,7 @@ func indexVisitPackages(
 
 			symInfo := &scip.SymbolInformation{
 				Symbol:        pkgSymbol,
+				Kind:          scip.SymbolInformation_Package,
 				DisplayName:   pkg.Name,
 				Documentation: findPackageDocs(pkg),
 				SignatureDocumentation: &scip.Document{

--- a/internal/symbols/kind.go
+++ b/internal/symbols/kind.go
@@ -1,0 +1,59 @@
+package symbols
+
+import (
+	"go/types"
+
+	"github.com/scip-code/scip/bindings/go/scip"
+)
+
+// KindForObject maps a Go types.Object to the corresponding SCIP SymbolInformation_Kind.
+func KindForObject(obj types.Object) scip.SymbolInformation_Kind {
+	if obj == nil {
+		return scip.SymbolInformation_UnspecifiedKind
+	}
+
+	switch obj := obj.(type) {
+	case *types.Func:
+		sig, ok := obj.Type().(*types.Signature)
+		if !ok {
+			return scip.SymbolInformation_Function
+		}
+		if sig.Recv() == nil {
+			return scip.SymbolInformation_Function
+		}
+		if types.IsInterface(sig.Recv().Type()) {
+			return scip.SymbolInformation_MethodSpecification
+		}
+		return scip.SymbolInformation_Method
+
+	case *types.TypeName:
+		if obj.IsAlias() {
+			return scip.SymbolInformation_TypeAlias
+		}
+		switch obj.Type().Underlying().(type) {
+		case *types.Struct:
+			return scip.SymbolInformation_Struct
+		case *types.Interface:
+			return scip.SymbolInformation_Interface
+		case *types.TypeParam:
+			return scip.SymbolInformation_TypeParameter
+		default:
+			return scip.SymbolInformation_Type
+		}
+
+	case *types.Var:
+		if obj.IsField() {
+			return scip.SymbolInformation_Field
+		}
+		return scip.SymbolInformation_Variable
+
+	case *types.Const:
+		return scip.SymbolInformation_Constant
+
+	case *types.PkgName:
+		return scip.SymbolInformation_Package
+
+	default:
+		return scip.SymbolInformation_UnspecifiedKind
+	}
+}

--- a/internal/testdata/snapshots/output/alias/main.go
+++ b/internal/testdata/snapshots/output/alias/main.go
@@ -1,5 +1,6 @@
   package main
 //        ^^^^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/
+//             kind Package
 //             display_name main
 //             signature_documentation
 //             > package main
@@ -9,6 +10,7 @@
   type (
    T struct{}
 // ^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/T#
+//   kind Struct
 //   display_name T
 //   signature_documentation
 //   > type T struct{}
@@ -17,6 +19,7 @@
 //   > Copied from https://github.com/golang/go/issues/68877#issuecomment-2290000187
    U = T
 // ^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/U#
+//   kind TypeAlias
 //   display_name U
 //   signature_documentation
 //   > type U = T
@@ -26,6 +29,7 @@
 //     ^ reference github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/T#
    V = U
 // ^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/V#
+//   kind TypeAlias
 //   display_name V
 //   signature_documentation
 //   > type V = U
@@ -35,6 +39,7 @@
 //     ^ reference github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/U#
    S U
 // ^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/S#
+//   kind Struct
 //   display_name S
 //   signature_documentation
 //   > type S struct{}
@@ -44,6 +49,7 @@
 //   ^ reference github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/U#
    Z int32
 // ^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/Z#
+//   kind Type
 //   display_name Z
 //   signature_documentation
 //   > type Z int32
@@ -55,10 +61,12 @@
 //⌄ enclosing_range_start github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/f().
   func f(u U) {}
 //     ^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/alias`/f().
+//       kind Function
 //       display_name f
 //       signature_documentation
 //       > func f(u U)
 //       ^ definition local 0
+//         kind Variable
 //         display_name u
 //         signature_documentation
 //         > var u U

--- a/internal/testdata/snapshots/output/embedded/embedded.go
+++ b/internal/testdata/snapshots/output/embedded/embedded.go
@@ -1,5 +1,6 @@
   package embedded
 //        ^^^^^^^^ definition 0.1.test `sg/embedded`/
+//                 kind Package
 //                 display_name embedded
 //                 signature_documentation
 //                 > package embedded
@@ -13,6 +14,7 @@
   
   type osExecCommand struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/osExecCommand#
+//                   kind Struct
 //                   display_name osExecCommand
 //                   signature_documentation
 //                   > type osExecCommand struct{ *exec.Cmd }
@@ -22,6 +24,7 @@
    *exec.Cmd
 //  ^^^^ reference github.com/golang/go/src go1.22 `os/exec`/
 //       ^^^ definition 0.1.test `sg/embedded`/osExecCommand#Cmd.
+//           kind Field
 //           display_name Cmd
 //           signature_documentation
 //           > struct field Cmd *exec.Cmd
@@ -31,10 +34,12 @@
 //⌄ enclosing_range_start 0.1.test `sg/embedded`/wrapExecCommand().
   func wrapExecCommand(c *exec.Cmd) {
 //     ^^^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/wrapExecCommand().
+//                     kind Function
 //                     display_name wrapExecCommand
 //                     signature_documentation
 //                     > func wrapExecCommand(c *exec.Cmd)
 //                     ^ definition local 0
+//                       kind Variable
 //                       display_name c
 //                       signature_documentation
 //                       > var c *Cmd
@@ -49,6 +54,7 @@
   
   type Inner struct {
 //     ^^^^^ definition 0.1.test `sg/embedded`/Inner#
+//           kind Struct
 //           display_name Inner
 //           signature_documentation
 //           > type Inner struct {
@@ -58,16 +64,19 @@
 //           > }
    X int
 // ^ definition 0.1.test `sg/embedded`/Inner#X.
+//   kind Field
 //   display_name X
 //   signature_documentation
 //   > struct field X int
    Y int
 // ^ definition 0.1.test `sg/embedded`/Inner#Y.
+//   kind Field
 //   display_name Y
 //   signature_documentation
 //   > struct field Y int
    Z int
 // ^ definition 0.1.test `sg/embedded`/Inner#Z.
+//   kind Field
 //   display_name Z
 //   signature_documentation
 //   > struct field Z int
@@ -75,6 +84,7 @@
   
   type Outer struct {
 //     ^^^^^ definition 0.1.test `sg/embedded`/Outer#
+//           kind Struct
 //           display_name Outer
 //           signature_documentation
 //           > type Outer struct {
@@ -83,12 +93,14 @@
 //           > }
    Inner
 // ^^^^^ definition 0.1.test `sg/embedded`/Outer#Inner.
+//       kind Field
 //       display_name Inner
 //       signature_documentation
 //       > struct field Inner Inner
 // ^^^^^ reference 0.1.test `sg/embedded`/Inner#
    W int
 // ^ definition 0.1.test `sg/embedded`/Outer#W.
+//   kind Field
 //   display_name W
 //   signature_documentation
 //   > struct field W int
@@ -97,11 +109,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/embedded`/useOfCompositeStructs().
   func useOfCompositeStructs() {
 //     ^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/useOfCompositeStructs().
+//                           kind Function
 //                           display_name useOfCompositeStructs
 //                           signature_documentation
 //                           > func useOfCompositeStructs()
    o := Outer{
 // ^ definition local 1
+//   kind Variable
 //   display_name o
 //   signature_documentation
 //   > var o Outer

--- a/internal/testdata/snapshots/output/embedded/internal/nested.go
+++ b/internal/testdata/snapshots/output/embedded/internal/nested.go
@@ -1,5 +1,6 @@
   package nested_internal
 //        ^^^^^^^^^^^^^^^ definition 0.1.test `sg/embedded/internal`/
+//                        kind Package
 //                        display_name nested_internal
 //                        signature_documentation
 //                        > package nested_internal
@@ -14,10 +15,12 @@
 //⌄ enclosing_range_start 0.1.test `sg/embedded/internal`/Something().
   func Something(recent embedded.RecentCommittersResults) {
 //     ^^^^^^^^^ definition 0.1.test `sg/embedded/internal`/Something().
+//               kind Function
 //               display_name Something
 //               signature_documentation
 //               > func Something(recent embedded.RecentCommittersResults)
 //               ^^^^^^ definition local 0
+//                      kind Variable
 //                      display_name recent
 //                      signature_documentation
 //                      > var recent RecentCommittersResults
@@ -25,6 +28,7 @@
 //                               ^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/embedded`/RecentCommittersResults#
    for _, commit := range recent.Nodes {
 //        ^^^^^^ definition local 1
+//               kind Variable
 //               display_name commit
 //               signature_documentation
 //               > var commit struct{Authors struct{Nodes []struct{Date string; Email string; Name string; User struct{Login string}; AvatarURL string}}}
@@ -32,6 +36,7 @@
 //                               ^^^^^ reference 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.
     for _, author := range commit.Authors.Nodes {
 //         ^^^^^^ definition local 2
+//                kind Variable
 //                display_name author
 //                signature_documentation
 //                > var author struct{Date string; Email string; Name string; User struct{Login string}; AvatarURL string}

--- a/internal/testdata/snapshots/output/embedded/nested.go
+++ b/internal/testdata/snapshots/output/embedded/nested.go
@@ -6,6 +6,7 @@
   
   type NestedHandler struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/NestedHandler#
+//                   kind Struct
 //                   display_name NestedHandler
 //                   signature_documentation
 //                   > type NestedHandler struct {
@@ -16,6 +17,7 @@
    http.Handler
 // ^^^^ reference github.com/golang/go/src go1.22 `net/http`/
 //      ^^^^^^^ definition 0.1.test `sg/embedded`/NestedHandler#Handler.
+//              kind Field
 //              display_name Handler
 //              signature_documentation
 //              > struct field Handler http.Handler
@@ -24,6 +26,7 @@
    // Wow, a great thing for integers
    Other int
 // ^^^^^ definition 0.1.test `sg/embedded`/NestedHandler#Other.
+//       kind Field
 //       display_name Other
 //       signature_documentation
 //       > struct field Other int
@@ -34,10 +37,12 @@
 //⌄ enclosing_range_start 0.1.test `sg/embedded`/NestedExample().
   func NestedExample(n NestedHandler) {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/NestedExample().
+//                   kind Function
 //                   display_name NestedExample
 //                   signature_documentation
 //                   > func NestedExample(n NestedHandler)
 //                   ^ definition local 0
+//                     kind Variable
 //                     display_name n
 //                     signature_documentation
 //                     > var n NestedHandler

--- a/internal/testdata/snapshots/output/embedded/something.go
+++ b/internal/testdata/snapshots/output/embedded/something.go
@@ -7,11 +7,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/embedded`/RecentCommittersResults#String().
   func (r *RecentCommittersResults) String() string {
 //      ^ definition local 0
+//        kind Variable
 //        display_name r
 //        signature_documentation
 //        > var r *RecentCommittersResults
 //         ^^^^^^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/embedded`/RecentCommittersResults#
 //                                  ^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#String().
+//                                         kind Method
 //                                         display_name String
 //                                         signature_documentation
 //                                         > func (*RecentCommittersResults).String() string
@@ -28,6 +30,7 @@
   
   type RecentCommittersResults struct {
 //     ^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#
+//                             kind Struct
 //                             display_name RecentCommittersResults
 //                             signature_documentation
 //                             > type RecentCommittersResults struct {
@@ -49,47 +52,56 @@
 //                             relationship github.com/golang/go/src go1.22 runtime/stringer# implementation
    Nodes []struct {
 // ^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.
+//       kind Field
 //       display_name Nodes
 //       signature_documentation
 //       > struct field Nodes []struct{Authors struct{Nodes []struct{Date string; Email string; Name string; User struct{Login string}; AvatarURL string}}}
     Authors struct {
 //  ^^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#$anon_90b32de18ec80596#Authors.
+//          kind Field
 //          display_name Authors
 //          signature_documentation
 //          > struct field Authors struct{Nodes []struct{Date string; Email string; Name string; User struct{Login string}; AvatarURL string}}
      Nodes []struct {
 //   ^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#$anon_90b32de18ec80596#$anon_bb290b1f6ea0cf58#Nodes.
+//         kind Field
 //         display_name Nodes
 //         signature_documentation
 //         > struct field Nodes []struct{Date string; Email string; Name string; User struct{Login string}; AvatarURL string}
       Date  string
 //    ^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#$anon_90b32de18ec80596#$anon_bb290b1f6ea0cf58#$anon_b2a8a16c744b2d4b#Date.
+//         kind Field
 //         display_name Date
 //         signature_documentation
 //         > struct field Date string
       Email string
 //    ^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#$anon_90b32de18ec80596#$anon_bb290b1f6ea0cf58#$anon_b2a8a16c744b2d4b#Email.
+//          kind Field
 //          display_name Email
 //          signature_documentation
 //          > struct field Email string
       Name  string
 //    ^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#$anon_90b32de18ec80596#$anon_bb290b1f6ea0cf58#$anon_b2a8a16c744b2d4b#Name.
+//         kind Field
 //         display_name Name
 //         signature_documentation
 //         > struct field Name string
       User  struct {
 //    ^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#$anon_90b32de18ec80596#$anon_bb290b1f6ea0cf58#$anon_b2a8a16c744b2d4b#User.
+//         kind Field
 //         display_name User
 //         signature_documentation
 //         > struct field User struct{Login string}
        Login string
 //     ^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#$anon_90b32de18ec80596#$anon_bb290b1f6ea0cf58#$anon_b2a8a16c744b2d4b#$anon_d4bff1f61f45b2a1#Login.
+//           kind Field
 //           display_name Login
 //           signature_documentation
 //           > struct field Login string
       }
       AvatarURL string
 //    ^^^^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#$anon_90b32de18ec80596#$anon_bb290b1f6ea0cf58#$anon_b2a8a16c744b2d4b#AvatarURL.
+//              kind Field
 //              display_name AvatarURL
 //              signature_documentation
 //              > struct field AvatarURL string
@@ -98,11 +110,13 @@
    }
    PageInfo struct {
 // ^^^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#PageInfo.
+//          kind Field
 //          display_name PageInfo
 //          signature_documentation
 //          > struct field PageInfo struct{HasNextPage bool}
     HasNextPage bool
 //  ^^^^^^^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#$anon_0a5c453971407ce4#HasNextPage.
+//              kind Field
 //              display_name HasNextPage
 //              signature_documentation
 //              > struct field HasNextPage bool

--- a/internal/testdata/snapshots/output/generallyeric/generallyeric.go
+++ b/internal/testdata/snapshots/output/generallyeric/generallyeric.go
@@ -1,6 +1,7 @@
   // generallyeric -> generic for short
   package generallyeric
 //        ^^^^^^^^^^^^^ definition 0.1.test `sg/generallyeric`/
+//                      kind Package
 //                      display_name generallyeric
 //                      signature_documentation
 //                      > package generallyeric
@@ -13,20 +14,24 @@
 //⌄ enclosing_range_start 0.1.test `sg/generallyeric`/Print().
   func Print[T any](s []T) {
 //     ^^^^^ definition 0.1.test `sg/generallyeric`/Print().
+//           kind Function
 //           display_name Print
 //           signature_documentation
 //           > func Print[T any](s []T)
 //           ^ definition local 0
+//             kind Interface
 //             display_name T
 //             signature_documentation
 //             > type parameter T any
 //                  ^ definition local 1
+//                    kind Variable
 //                    display_name s
 //                    signature_documentation
 //                    > var s []T
 //                      ^ reference local 0
    for _, v := range s {
 //        ^ definition local 2
+//          kind Variable
 //          display_name v
 //          signature_documentation
 //          > var v T

--- a/internal/testdata/snapshots/output/generallyeric/new_operators.go
+++ b/internal/testdata/snapshots/output/generallyeric/new_operators.go
@@ -3,6 +3,7 @@
   
   type Number interface {
 //     ^^^^^^ definition 0.1.test `sg/generallyeric`/Number#
+//            kind Interface
 //            display_name Number
 //            signature_documentation
 //            > type Number interface {
@@ -15,15 +16,18 @@
 //⌄ enclosing_range_start 0.1.test `sg/generallyeric`/Double().
   func Double[T Number](value T) T {
 //     ^^^^^^ definition 0.1.test `sg/generallyeric`/Double().
+//            kind Function
 //            display_name Double
 //            signature_documentation
 //            > func Double[T Number](value T) T
 //            ^ definition local 0
+//              kind Interface
 //              display_name T
 //              signature_documentation
 //              > type parameter T Number
 //              ^^^^^^ reference 0.1.test `sg/generallyeric`/Number#
 //                      ^^^^^ definition local 1
+//                            kind Variable
 //                            display_name value
 //                            signature_documentation
 //                            > var value T
@@ -36,15 +40,18 @@
   
   type Box[T any] struct {
 //     ^^^ definition 0.1.test `sg/generallyeric`/Box#
+//         kind Struct
 //         display_name Box
 //         signature_documentation
 //         > type Box struct{ Something T }
 //         ^ definition local 2
+//           kind Interface
 //           display_name T
 //           signature_documentation
 //           > type parameter T any
    Something T
 // ^^^^^^^^^ definition 0.1.test `sg/generallyeric`/Box#Something.
+//           kind Field
 //           display_name Something
 //           signature_documentation
 //           > struct field Something T
@@ -53,6 +60,7 @@
   
   type handler[T any] struct {
 //     ^^^^^^^ definition 0.1.test `sg/generallyeric`/handler#
+//             kind Struct
 //             display_name handler
 //             signature_documentation
 //             > type handler struct {
@@ -60,11 +68,13 @@
 //             >     Another string
 //             > }
 //             ^ definition local 3
+//               kind Interface
 //               display_name T
 //               signature_documentation
 //               > type parameter T any
    Box[T]
 // ^^^ definition 0.1.test `sg/generallyeric`/handler#Box.
+//     kind Field
 //     display_name Box
 //     signature_documentation
 //     > struct field Box Box[T]
@@ -72,6 +82,7 @@
 //     ^ reference local 3
    Another string
 // ^^^^^^^ definition 0.1.test `sg/generallyeric`/handler#Another.
+//         kind Field
 //         display_name Another
 //         signature_documentation
 //         > struct field Another string

--- a/internal/testdata/snapshots/output/generallyeric/person.go
+++ b/internal/testdata/snapshots/output/generallyeric/person.go
@@ -6,11 +6,13 @@
   
   type Person interface {
 //     ^^^^^^ definition 0.1.test `sg/generallyeric`/Person#
+//            kind Interface
 //            display_name Person
 //            signature_documentation
 //            > type Person interface{ Work() }
    Work()
 // ^^^^ definition 0.1.test `sg/generallyeric`/Person#Work.
+//      kind MethodSpecification
 //      display_name Work
 //      signature_documentation
 //      > func (Person).Work()
@@ -18,6 +20,7 @@
   
   type worker string
 //     ^^^^^^ definition 0.1.test `sg/generallyeric`/worker#
+//            kind Type
 //            display_name worker
 //            signature_documentation
 //            > type worker string
@@ -26,11 +29,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/generallyeric`/worker#Work().
   func (w worker) Work() {
 //      ^ definition local 0
+//        kind Variable
 //        display_name w
 //        signature_documentation
 //        > var w worker
 //        ^^^^^^ reference 0.1.test `sg/generallyeric`/worker#
 //                ^^^^ definition 0.1.test `sg/generallyeric`/worker#Work().
+//                     kind Method
 //                     display_name Work
 //                     signature_documentation
 //                     > func (worker).Work()
@@ -45,21 +50,25 @@
 //⌄ enclosing_range_start 0.1.test `sg/generallyeric`/DoWork().
   func DoWork[T Person](things []T) {
 //     ^^^^^^ definition 0.1.test `sg/generallyeric`/DoWork().
+//            kind Function
 //            display_name DoWork
 //            signature_documentation
 //            > func DoWork[T Person](things []T)
 //            ^ definition local 1
+//              kind Interface
 //              display_name T
 //              signature_documentation
 //              > type parameter T Person
 //              ^^^^^^ reference 0.1.test `sg/generallyeric`/Person#
 //                      ^^^^^^ definition local 2
+//                             kind Variable
 //                             display_name things
 //                             signature_documentation
 //                             > var things []T
 //                               ^ reference local 1
    for _, v := range things {
 //        ^ definition local 3
+//          kind Variable
 //          display_name v
 //          signature_documentation
 //          > var v T
@@ -74,19 +83,23 @@
 //⌄ enclosing_range_start 0.1.test `sg/generallyeric`/main().
   func main() {
 //     ^^^^ definition 0.1.test `sg/generallyeric`/main().
+//          kind Function
 //          display_name main
 //          signature_documentation
 //          > func main()
    var a, b, c worker
 //     ^ definition local 4
+//       kind Variable
 //       display_name a
 //       signature_documentation
 //       > var a worker
 //        ^ definition local 5
+//          kind Variable
 //          display_name b
 //          signature_documentation
 //          > var b worker
 //           ^ definition local 6
+//             kind Variable
 //             display_name c
 //             signature_documentation
 //             > var c worker

--- a/internal/testdata/snapshots/output/impls/impls.go
+++ b/internal/testdata/snapshots/output/impls/impls.go
@@ -1,16 +1,19 @@
   package impls
 //        ^^^^^ definition 0.1.test `sg/impls`/
+//              kind Package
 //              display_name impls
 //              signature_documentation
 //              > package impls
   
   type I1 interface {
 //     ^^ definition 0.1.test `sg/impls`/I1#
+//        kind Interface
 //        display_name I1
 //        signature_documentation
 //        > type I1 interface{ F1() }
    F1()
 // ^^ definition 0.1.test `sg/impls`/I1#F1.
+//    kind MethodSpecification
 //    display_name F1
 //    signature_documentation
 //    > func (I1).F1()
@@ -18,11 +21,13 @@
   
   type I1Clone interface {
 //     ^^^^^^^ definition 0.1.test `sg/impls`/I1Clone#
+//             kind Interface
 //             display_name I1Clone
 //             signature_documentation
 //             > type I1Clone interface{ F1() }
    F1()
 // ^^ definition 0.1.test `sg/impls`/I1Clone#F1.
+//    kind MethodSpecification
 //    display_name F1
 //    signature_documentation
 //    > func (I1Clone).F1()
@@ -30,6 +35,7 @@
   
   type IfaceOther interface {
 //     ^^^^^^^^^^ definition 0.1.test `sg/impls`/IfaceOther#
+//                kind Interface
 //                display_name IfaceOther
 //                signature_documentation
 //                > type IfaceOther interface {
@@ -38,11 +44,13 @@
 //                > }
    Something()
 // ^^^^^^^^^ definition 0.1.test `sg/impls`/IfaceOther#Something.
+//           kind MethodSpecification
 //           display_name Something
 //           signature_documentation
 //           > func (IfaceOther).Something()
    Another()
 // ^^^^^^^ definition 0.1.test `sg/impls`/IfaceOther#Another.
+//         kind MethodSpecification
 //         display_name Another
 //         signature_documentation
 //         > func (IfaceOther).Another()
@@ -50,6 +58,7 @@
   
   type T1 int
 //     ^^ definition 0.1.test `sg/impls`/T1#
+//        kind Type
 //        display_name T1
 //        signature_documentation
 //        > type T1 int
@@ -59,11 +68,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/impls`/T1#F1().
   func (r T1) F1() {}
 //      ^ definition local 0
+//        kind Variable
 //        display_name r
 //        signature_documentation
 //        > var r T1
 //        ^^ reference 0.1.test `sg/impls`/T1#
 //            ^^ definition 0.1.test `sg/impls`/T1#F1().
+//               kind Method
 //               display_name F1
 //               signature_documentation
 //               > func (T1).F1()
@@ -73,6 +84,7 @@
   
   type T2 int
 //     ^^ definition 0.1.test `sg/impls`/T2#
+//        kind Type
 //        display_name T2
 //        signature_documentation
 //        > type T2 int
@@ -82,11 +94,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/impls`/T2#F1().
   func (r T2) F1() {}
 //      ^ definition local 1
+//        kind Variable
 //        display_name r
 //        signature_documentation
 //        > var r T2
 //        ^^ reference 0.1.test `sg/impls`/T2#
 //            ^^ definition 0.1.test `sg/impls`/T2#F1().
+//               kind Method
 //               display_name F1
 //               signature_documentation
 //               > func (T2).F1()
@@ -96,11 +110,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/impls`/T2#F2().
   func (r T2) F2() {}
 //      ^ definition local 2
+//        kind Variable
 //        display_name r
 //        signature_documentation
 //        > var r T2
 //        ^^ reference 0.1.test `sg/impls`/T2#
 //            ^^ definition 0.1.test `sg/impls`/T2#F2().
+//               kind Method
 //               display_name F2
 //               signature_documentation
 //               > func (T2).F2()

--- a/internal/testdata/snapshots/output/impls/remote_impls.go
+++ b/internal/testdata/snapshots/output/impls/remote_impls.go
@@ -7,10 +7,12 @@
 //⌄ enclosing_range_start 0.1.test `sg/impls`/Something().
   func Something(r http.ResponseWriter) {}
 //     ^^^^^^^^^ definition 0.1.test `sg/impls`/Something().
+//               kind Function
 //               display_name Something
 //               signature_documentation
 //               > func Something(r http.ResponseWriter)
 //               ^ definition local 0
+//                 kind Variable
 //                 display_name r
 //                 signature_documentation
 //                 > var r ResponseWriter
@@ -20,6 +22,7 @@
   
   type MyWriter struct{}
 //     ^^^^^^^^ definition 0.1.test `sg/impls`/MyWriter#
+//              kind Struct
 //              display_name MyWriter
 //              signature_documentation
 //              > type MyWriter struct{}
@@ -31,11 +34,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/impls`/MyWriter#Header().
   func (w MyWriter) Header() http.Header        { panic("") }
 //      ^ definition local 1
+//        kind Variable
 //        display_name w
 //        signature_documentation
 //        > var w MyWriter
 //        ^^^^^^^^ reference 0.1.test `sg/impls`/MyWriter#
 //                  ^^^^^^ definition 0.1.test `sg/impls`/MyWriter#Header().
+//                         kind Method
 //                         display_name Header
 //                         signature_documentation
 //                         > func (MyWriter).Header() http.Header
@@ -46,11 +51,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/impls`/MyWriter#Write().
   func (w MyWriter) Write([]byte) (int, error)  { panic("") }
 //      ^ definition local 2
+//        kind Variable
 //        display_name w
 //        signature_documentation
 //        > var w MyWriter
 //        ^^^^^^^^ reference 0.1.test `sg/impls`/MyWriter#
 //                  ^^^^^ definition 0.1.test `sg/impls`/MyWriter#Write().
+//                        kind Method
 //                        display_name Write
 //                        signature_documentation
 //                        > func (MyWriter).Write([]byte) (int, error)
@@ -62,16 +69,19 @@
 //⌄ enclosing_range_start 0.1.test `sg/impls`/MyWriter#WriteHeader().
   func (w MyWriter) WriteHeader(statusCode int) { panic("") }
 //      ^ definition local 3
+//        kind Variable
 //        display_name w
 //        signature_documentation
 //        > var w MyWriter
 //        ^^^^^^^^ reference 0.1.test `sg/impls`/MyWriter#
 //                  ^^^^^^^^^^^ definition 0.1.test `sg/impls`/MyWriter#WriteHeader().
+//                              kind Method
 //                              display_name WriteHeader
 //                              signature_documentation
 //                              > func (MyWriter).WriteHeader(statusCode int)
 //                              relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#WriteHeader. implementation
 //                              ^^^^^^^^^^ definition local 4
+//                                         kind Variable
 //                                         display_name statusCode
 //                                         signature_documentation
 //                                         > var statusCode int
@@ -80,6 +90,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/impls`/Another().
   func Another() {
 //     ^^^^^^^ definition 0.1.test `sg/impls`/Another().
+//             kind Function
 //             display_name Another
 //             signature_documentation
 //             > func Another()

--- a/internal/testdata/snapshots/output/initial/builtin_types.go
+++ b/internal/testdata/snapshots/output/initial/builtin_types.go
@@ -1,5 +1,6 @@
   package initial
 //        ^^^^^^^ definition 0.1.test `sg/initial`/
+//                kind Package
 //                display_name initial
 //                signature_documentation
 //                > package initial
@@ -10,11 +11,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/initial`/UsesBuiltin().
   func UsesBuiltin() int {
 //     ^^^^^^^^^^^ definition 0.1.test `sg/initial`/UsesBuiltin().
+//                 kind Function
 //                 display_name UsesBuiltin
 //                 signature_documentation
 //                 > func UsesBuiltin() int
    var x int = 5
 //     ^ definition local 0
+//       kind Variable
 //       display_name x
 //       signature_documentation
 //       > var x int

--- a/internal/testdata/snapshots/output/initial/child_symbols.go
+++ b/internal/testdata/snapshots/output/initial/child_symbols.go
@@ -4,6 +4,7 @@
   // Const is a constant equal to 5. It's the best constant I've ever written. 😹
   const Const = 5
 //      ^^^^^ definition 0.1.test `sg/initial`/Const.
+//            kind Constant
 //            display_name Const
 //            signature_documentation
 //            > const Const untyped int = 5
@@ -15,6 +16,7 @@
    // ConstBlock1 is a constant in a block.
    ConstBlock1 = 1
 // ^^^^^^^^^^^ definition 0.1.test `sg/initial`/ConstBlock1.
+//             kind Constant
 //             display_name ConstBlock1
 //             signature_documentation
 //             > const ConstBlock1 untyped int = 1
@@ -26,6 +28,7 @@
    // ConstBlock2 is a constant in a block.
    ConstBlock2 = 2
 // ^^^^^^^^^^^ definition 0.1.test `sg/initial`/ConstBlock2.
+//             kind Constant
 //             display_name ConstBlock2
 //             signature_documentation
 //             > const ConstBlock2 untyped int = 2
@@ -38,6 +41,7 @@
   // Var is a variable interface.
   var Var Interface = &Struct{Field: "bar!"}
 //    ^^^ definition 0.1.test `sg/initial`/Var.
+//        kind Variable
 //        display_name Var
 //        signature_documentation
 //        > var Var Interface
@@ -50,6 +54,7 @@
   // unexportedVar is an unexported variable interface.
   var unexportedVar Interface = &Struct{Field: "bar!"}
 //    ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/unexportedVar.
+//                  kind Variable
 //                  display_name unexportedVar
 //                  signature_documentation
 //                  > var unexportedVar Interface
@@ -62,6 +67,7 @@
   // x has a builtin error type
   var x error
 //    ^ definition 0.1.test `sg/initial`/x.
+//      kind Variable
 //      display_name x
 //      signature_documentation
 //      > var x error
@@ -70,6 +76,7 @@
   
   var BigVar Interface = &Struct{
 //    ^^^^^^ definition 0.1.test `sg/initial`/BigVar.
+//           kind Variable
 //           display_name BigVar
 //           signature_documentation
 //           > var BigVar Interface
@@ -81,16 +88,19 @@
 // ^^^^^^^^^ reference 0.1.test `sg/initial`/Struct#Anonymous.
     FieldA int
 //  ^^^^^^ definition 0.1.test `sg/initial`/BigVar:FieldA.
+//         kind Field
 //         display_name FieldA
 //         signature_documentation
 //         > struct field FieldA int
     FieldB int
 //  ^^^^^^ definition 0.1.test `sg/initial`/BigVar:FieldB.
+//         kind Field
 //         display_name FieldB
 //         signature_documentation
 //         > struct field FieldB int
     FieldC int
 //  ^^^^^^ definition 0.1.test `sg/initial`/BigVar:FieldC.
+//         kind Field
 //         display_name FieldC
 //         signature_documentation
 //         > struct field FieldC int
@@ -113,6 +123,7 @@
    // This has some docs
    VarBlock1 = "if you're reading this"
 // ^^^^^^^^^ definition 0.1.test `sg/initial`/VarBlock1.
+//           kind Variable
 //           display_name VarBlock1
 //           signature_documentation
 //           > var VarBlock1 string
@@ -133,6 +144,7 @@
   
    VarBlock2 = "hi"
 // ^^^^^^^^^ definition 0.1.test `sg/initial`/VarBlock2.
+//           kind Variable
 //           display_name VarBlock2
 //           signature_documentation
 //           > var VarBlock2 string
@@ -153,6 +165,7 @@
   // Embedded is a struct, to be embedded in another struct.
   type Embedded struct {
 //     ^^^^^^^^ definition 0.1.test `sg/initial`/Embedded#
+//              kind Struct
 //              display_name Embedded
 //              signature_documentation
 //              > type Embedded struct {
@@ -164,6 +177,7 @@
    // EmbeddedField has some docs!
    EmbeddedField string
 // ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/Embedded#EmbeddedField.
+//               kind Field
 //               display_name EmbeddedField
 //               signature_documentation
 //               > struct field EmbeddedField string
@@ -171,6 +185,7 @@
 //               > EmbeddedField has some docs!
    Field         string // conflicts with parent "Field"
 // ^^^^^ definition 0.1.test `sg/initial`/Embedded#Field.
+//       kind Field
 //       display_name Field
 //       signature_documentation
 //       > struct field Field string
@@ -180,6 +195,7 @@
   
   type Struct struct {
 //     ^^^^^^ definition 0.1.test `sg/initial`/Struct#
+//            kind Struct
 //            display_name Struct
 //            signature_documentation
 //            > type Struct struct {
@@ -194,32 +210,38 @@
 //            relationship 0.1.test `sg/initial`/Interface# implementation
    *Embedded
 //  ^^^^^^^^ definition 0.1.test `sg/initial`/Struct#Embedded.
+//           kind Field
 //           display_name Embedded
 //           signature_documentation
 //           > struct field Embedded *Embedded
 //  ^^^^^^^^ reference 0.1.test `sg/initial`/Embedded#
    Field     string
 // ^^^^^ definition 0.1.test `sg/initial`/Struct#Field.
+//       kind Field
 //       display_name Field
 //       signature_documentation
 //       > struct field Field string
    Anonymous struct {
 // ^^^^^^^^^ definition 0.1.test `sg/initial`/Struct#Anonymous.
+//           kind Field
 //           display_name Anonymous
 //           signature_documentation
 //           > struct field Anonymous struct{FieldA int; FieldB int; FieldC int}
     FieldA int
 //  ^^^^^^ definition 0.1.test `sg/initial`/Struct#$anon_81475a76ba757de7#FieldA.
+//         kind Field
 //         display_name FieldA
 //         signature_documentation
 //         > struct field FieldA int
     FieldB int
 //  ^^^^^^ definition 0.1.test `sg/initial`/Struct#$anon_81475a76ba757de7#FieldB.
+//         kind Field
 //         display_name FieldB
 //         signature_documentation
 //         > struct field FieldB int
     FieldC int
 //  ^^^^^^ definition 0.1.test `sg/initial`/Struct#$anon_81475a76ba757de7#FieldC.
+//         kind Field
 //         display_name FieldC
 //         signature_documentation
 //         > struct field FieldC int
@@ -230,11 +252,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/initial`/Struct#StructMethod().
   func (s *Struct) StructMethod() {}
 //      ^ definition local 0
+//        kind Variable
 //        display_name s
 //        signature_documentation
 //        > var s *Struct
 //         ^^^^^^ reference 0.1.test `sg/initial`/Struct#
 //                 ^^^^^^^^^^^^ definition 0.1.test `sg/initial`/Struct#StructMethod().
+//                              kind Method
 //                              display_name StructMethod
 //                              signature_documentation
 //                              > func (*Struct).StructMethod()
@@ -245,11 +269,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/initial`/Struct#ImplementsInterface().
   func (s *Struct) ImplementsInterface() string { return "hi!" }
 //      ^ definition local 1
+//        kind Variable
 //        display_name s
 //        signature_documentation
 //        > var s *Struct
 //         ^^^^^^ reference 0.1.test `sg/initial`/Struct#
 //                 ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/Struct#ImplementsInterface().
+//                                     kind Method
 //                                     display_name ImplementsInterface
 //                                     signature_documentation
 //                                     > func (*Struct).ImplementsInterface() string
@@ -259,16 +285,19 @@
 //⌄ enclosing_range_start 0.1.test `sg/initial`/Struct#MachineLearning().
   func (s *Struct) MachineLearning(
 //      ^ definition local 2
+//        kind Variable
 //        display_name s
 //        signature_documentation
 //        > var s *Struct
 //         ^^^^^^ reference 0.1.test `sg/initial`/Struct#
 //                 ^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/Struct#MachineLearning().
+//                                 kind Method
 //                                 display_name MachineLearning
 //                                 signature_documentation
 //                                 > func (*Struct).MachineLearning(param1 float32, hyperparam2 float32, hyperparam3 float32) float32
    param1 float32, // It's ML, I can't describe what this param is.
 // ^^^^^^ definition local 3
+//        kind Variable
 //        display_name param1
 //        signature_documentation
 //        > var param1 float32
@@ -289,11 +318,13 @@
    //
    hyperparam2 float32,
 // ^^^^^^^^^^^ definition local 4
+//             kind Variable
 //             display_name hyperparam2
 //             signature_documentation
 //             > var hyperparam2 float32
    hyperparam3 float32,
 // ^^^^^^^^^^^ definition local 5
+//             kind Variable
 //             display_name hyperparam3
 //             signature_documentation
 //             > var hyperparam3 float32
@@ -301,6 +332,7 @@
    // varShouldNotHaveDocs is in a function, should not have docs emitted.
    var varShouldNotHaveDocs int32
 //     ^^^^^^^^^^^^^^^^^^^^ definition local 6
+//                          kind Variable
 //                          display_name varShouldNotHaveDocs
 //                          signature_documentation
 //                          > var varShouldNotHaveDocs int32
@@ -308,6 +340,7 @@
    // constShouldNotHaveDocs is in a function, should not have docs emitted.
    const constShouldNotHaveDocs = 5
 //       ^^^^^^^^^^^^^^^^^^^^^^ definition local 7
+//                              kind Constant
 //                              display_name constShouldNotHaveDocs
 //                              signature_documentation
 //                              > const constShouldNotHaveDocs untyped int
@@ -315,10 +348,12 @@
    // typeShouldNotHaveDocs is in a function, should not have docs emitted.
    type typeShouldNotHaveDocs struct{ a string }
 //      ^^^^^^^^^^^^^^^^^^^^^ definition local 8
+//                            kind Struct
 //                            display_name typeShouldNotHaveDocs
 //                            signature_documentation
 //                            > type typeShouldNotHaveDocs struct{a string}
 //                                    ^ definition local 9
+//                                      kind Field
 //                                      display_name a
 //                                      signature_documentation
 //                                      > field a string
@@ -326,10 +361,12 @@
    // funcShouldNotHaveDocs is in a function, should not have docs emitted.
    funcShouldNotHaveDocs := func(a string) string { return "hello" }
 // ^^^^^^^^^^^^^^^^^^^^^ definition local 10
+//                       kind Variable
 //                       display_name funcShouldNotHaveDocs
 //                       signature_documentation
 //                       > var funcShouldNotHaveDocs func(a string) string
 //                               ^ definition local 11
+//                                 kind Variable
 //                                 display_name a
 //                                 signature_documentation
 //                                 > var a string
@@ -344,6 +381,7 @@
   // Interface has docs too
   type Interface interface {
 //     ^^^^^^^^^ definition 0.1.test `sg/initial`/Interface#
+//               kind Interface
 //               display_name Interface
 //               signature_documentation
 //               > type Interface interface{ ImplementsInterface() string }
@@ -351,6 +389,7 @@
 //               > Interface has docs too
    ImplementsInterface() string
 // ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/Interface#ImplementsInterface.
+//                     kind MethodSpecification
 //                     display_name ImplementsInterface
 //                     signature_documentation
 //                     > func (Interface).ImplementsInterface() string
@@ -359,6 +398,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/initial`/NewInterface().
   func NewInterface() Interface { return nil }
 //     ^^^^^^^^^^^^ definition 0.1.test `sg/initial`/NewInterface().
+//                  kind Function
 //                  display_name NewInterface
 //                  signature_documentation
 //                  > func NewInterface() Interface
@@ -367,18 +407,21 @@
   
   var SortExportedFirst = 1
 //    ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/SortExportedFirst.
+//                      kind Variable
 //                      display_name SortExportedFirst
 //                      signature_documentation
 //                      > var SortExportedFirst int
   
   var sortUnexportedSecond = 2
 //    ^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/sortUnexportedSecond.
+//                         kind Variable
 //                         display_name sortUnexportedSecond
 //                         signature_documentation
 //                         > var sortUnexportedSecond int
   
   var _sortUnderscoreLast = 3
 //    ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/_sortUnderscoreLast.
+//                        kind Variable
 //                        display_name _sortUnderscoreLast
 //                        signature_documentation
 //                        > var _sortUnderscoreLast int
@@ -410,6 +453,7 @@
    // And confusing
    X struct {
 // ^ definition 0.1.test `sg/initial`/X#
+//   kind Struct
 //   display_name X
 //   signature_documentation
 //   > type X struct{ bar string }
@@ -419,6 +463,7 @@
 //   > Go can be fun
     bar string
 //  ^^^ definition 0.1.test `sg/initial`/X#bar.
+//      kind Field
 //      display_name bar
 //      signature_documentation
 //      > struct field bar string
@@ -426,6 +471,7 @@
   
    Y struct {
 // ^ definition 0.1.test `sg/initial`/Y#
+//   kind Struct
 //   display_name Y
 //   signature_documentation
 //   > type Y struct{ baz float64 }
@@ -433,6 +479,7 @@
 //   > Go can be fun
     baz float64
 //  ^^^ definition 0.1.test `sg/initial`/Y#baz.
+//      kind Field
 //      display_name baz
 //      signature_documentation
 //      > struct field baz float64

--- a/internal/testdata/snapshots/output/initial/func_declarations.go
+++ b/internal/testdata/snapshots/output/initial/func_declarations.go
@@ -4,6 +4,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/initial`/UsesLater().
   func UsesLater() {
 //     ^^^^^^^^^ definition 0.1.test `sg/initial`/UsesLater().
+//               kind Function
 //               display_name UsesLater
 //               signature_documentation
 //               > func UsesLater()
@@ -15,6 +16,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/initial`/DefinedLater().
   func DefinedLater() {}
 //     ^^^^^^^^^^^^ definition 0.1.test `sg/initial`/DefinedLater().
+//                  kind Function
 //                  display_name DefinedLater
 //                  signature_documentation
 //                  > func DefinedLater()

--- a/internal/testdata/snapshots/output/initial/methods_and_receivers.go
+++ b/internal/testdata/snapshots/output/initial/methods_and_receivers.go
@@ -6,6 +6,7 @@
   
   type MyStruct struct{ f, y int }
 //     ^^^^^^^^ definition 0.1.test `sg/initial`/MyStruct#
+//              kind Struct
 //              display_name MyStruct
 //              signature_documentation
 //              > type MyStruct struct {
@@ -13,10 +14,12 @@
 //              >     y int
 //              > }
 //                      ^ definition 0.1.test `sg/initial`/MyStruct#f.
+//                        kind Field
 //                        display_name f
 //                        signature_documentation
 //                        > struct field f int
 //                         ^ definition 0.1.test `sg/initial`/MyStruct#y.
+//                           kind Field
 //                           display_name y
 //                           signature_documentation
 //                           > struct field y int
@@ -24,15 +27,18 @@
 //⌄ enclosing_range_start 0.1.test `sg/initial`/MyStruct#RecvFunction().
   func (m MyStruct) RecvFunction(b int) int { return m.f + b }
 //      ^ definition local 0
+//        kind Variable
 //        display_name m
 //        signature_documentation
 //        > var m MyStruct
 //        ^^^^^^^^ reference 0.1.test `sg/initial`/MyStruct#
 //                  ^^^^^^^^^^^^ definition 0.1.test `sg/initial`/MyStruct#RecvFunction().
+//                               kind Method
 //                               display_name RecvFunction
 //                               signature_documentation
 //                               > func (MyStruct).RecvFunction(b int) int
 //                               ^ definition local 1
+//                                 kind Variable
 //                                 display_name b
 //                                 signature_documentation
 //                                 > var b int
@@ -44,11 +50,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/initial`/SomethingElse().
   func SomethingElse() {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/SomethingElse().
+//                   kind Function
 //                   display_name SomethingElse
 //                   signature_documentation
 //                   > func SomethingElse()
    s := MyStruct{f: 0}
 // ^ definition local 2
+//   kind Variable
 //   display_name s
 //   signature_documentation
 //   > var s MyStruct

--- a/internal/testdata/snapshots/output/initial/rangefunc.go
+++ b/internal/testdata/snapshots/output/initial/rangefunc.go
@@ -9,15 +9,18 @@
 //⌄ enclosing_range_start 0.1.test `sg/initial`/f().
   func f(xs []int) int {
 //     ^ definition 0.1.test `sg/initial`/f().
+//       kind Function
 //       display_name f
 //       signature_documentation
 //       > func f(xs []int) int
 //       ^^ definition local 0
+//          kind Variable
 //          display_name xs
 //          signature_documentation
 //          > var xs []int
    for _, x := range slices.All(xs) {
 //        ^ definition local 1
+//          kind Variable
 //          display_name x
 //          signature_documentation
 //          > var x int

--- a/internal/testdata/snapshots/output/initial/toplevel_decls.go
+++ b/internal/testdata/snapshots/output/initial/toplevel_decls.go
@@ -3,11 +3,13 @@
   
   const MY_THING = 10
 //      ^^^^^^^^ definition 0.1.test `sg/initial`/MY_THING.
+//               kind Constant
 //               display_name MY_THING
 //               signature_documentation
 //               > const MY_THING untyped int = 10
   const OTHER_THING = MY_THING
 //      ^^^^^^^^^^^ definition 0.1.test `sg/initial`/OTHER_THING.
+//                  kind Constant
 //                  display_name OTHER_THING
 //                  signature_documentation
 //                  > const OTHER_THING untyped int = 10
@@ -16,6 +18,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/initial`/usesMyThing().
   func usesMyThing() {
 //     ^^^^^^^^^^^ definition 0.1.test `sg/initial`/usesMyThing().
+//                 kind Function
 //                 display_name usesMyThing
 //                 signature_documentation
 //                 > func usesMyThing()
@@ -26,6 +29,7 @@
   
   var initFunctions = map[string]int{}
 //    ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/initFunctions.
+//                  kind Variable
 //                  display_name initFunctions
 //                  signature_documentation
 //                  > var initFunctions map[string]int

--- a/internal/testdata/snapshots/output/initial/type_declarations.go
+++ b/internal/testdata/snapshots/output/initial/type_declarations.go
@@ -3,12 +3,14 @@
   
   type LiteralType int
 //     ^^^^^^^^^^^ definition 0.1.test `sg/initial`/LiteralType#
+//                 kind Type
 //                 display_name LiteralType
 //                 signature_documentation
 //                 > type LiteralType int
   
   type FuncType func(LiteralType, int) bool
 //     ^^^^^^^^ definition 0.1.test `sg/initial`/FuncType#
+//              kind Type
 //              display_name FuncType
 //              signature_documentation
 //              > type FuncType func(LiteralType, int) bool
@@ -16,11 +18,13 @@
   
   type IfaceType interface {
 //     ^^^^^^^^^ definition 0.1.test `sg/initial`/IfaceType#
+//               kind Interface
 //               display_name IfaceType
 //               signature_documentation
 //               > type IfaceType interface{ Method() LiteralType }
    Method() LiteralType
 // ^^^^^^ definition 0.1.test `sg/initial`/IfaceType#Method.
+//        kind MethodSpecification
 //        display_name Method
 //        signature_documentation
 //        > func (IfaceType).Method() LiteralType
@@ -29,6 +33,7 @@
   
   type StructType struct {
 //     ^^^^^^^^^^ definition 0.1.test `sg/initial`/StructType#
+//                kind Struct
 //                display_name StructType
 //                signature_documentation
 //                > type StructType struct {
@@ -39,12 +44,14 @@
 //                > }
    m IfaceType
 // ^ definition 0.1.test `sg/initial`/StructType#m.
+//   kind Field
 //   display_name m
 //   signature_documentation
 //   > struct field m IfaceType
 //   ^^^^^^^^^ reference 0.1.test `sg/initial`/IfaceType#
    f LiteralType
 // ^ definition 0.1.test `sg/initial`/StructType#f.
+//   kind Field
 //   display_name f
 //   signature_documentation
 //   > struct field f LiteralType
@@ -53,6 +60,7 @@
    // anonymous struct
    anon struct {
 // ^^^^ definition 0.1.test `sg/initial`/StructType#anon.
+//      kind Field
 //      display_name anon
 //      signature_documentation
 //      > struct field anon struct{sub int}
@@ -60,6 +68,7 @@
 //      > anonymous struct
     sub int
 //  ^^^ definition 0.1.test `sg/initial`/StructType#$anon_0ba9ace1dcfd6761#sub.
+//      kind Field
 //      display_name sub
 //      signature_documentation
 //      > struct field sub int
@@ -68,6 +77,7 @@
    // interface within struct
    i interface {
 // ^ definition 0.1.test `sg/initial`/StructType#i.
+//   kind Field
 //   display_name i
 //   signature_documentation
 //   > struct field i interface{AnonMethod() bool}
@@ -75,6 +85,7 @@
 //   > interface within struct
     AnonMethod() bool
 //  ^^^^^^^^^^ definition 0.1.test `sg/initial`/StructType#$anon_97e7de633e3ef8e8#AnonMethod.
+//             kind MethodSpecification
 //             display_name AnonMethod
 //             signature_documentation
 //             > func (interface).AnonMethod() bool
@@ -83,16 +94,19 @@
   
   type DeclaredBefore struct{ DeclaredAfter }
 //     ^^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/DeclaredBefore#
+//                    kind Struct
 //                    display_name DeclaredBefore
 //                    signature_documentation
 //                    > type DeclaredBefore struct{ DeclaredAfter }
 //                            ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/DeclaredBefore#DeclaredAfter.
+//                                          kind Field
 //                                          display_name DeclaredAfter
 //                                          signature_documentation
 //                                          > struct field DeclaredAfter DeclaredAfter
 //                            ^^^^^^^^^^^^^ reference 0.1.test `sg/initial`/DeclaredAfter#
   type DeclaredAfter struct{}
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/DeclaredAfter#
+//                   kind Struct
 //                   display_name DeclaredAfter
 //                   signature_documentation
 //                   > type DeclaredAfter struct{}

--- a/internal/testdata/snapshots/output/initial/type_hovers.go
+++ b/internal/testdata/snapshots/output/initial/type_hovers.go
@@ -5,6 +5,7 @@
    // HoverTypeList is a cool struct
    HoverTypeList struct{}
 // ^^^^^^^^^^^^^ definition 0.1.test `sg/initial`/HoverTypeList#
+//               kind Struct
 //               display_name HoverTypeList
 //               signature_documentation
 //               > type HoverTypeList struct{}
@@ -15,6 +16,7 @@
   // This should show up as well
   type HoverType struct{}
 //     ^^^^^^^^^ definition 0.1.test `sg/initial`/HoverType#
+//               kind Struct
 //               display_name HoverType
 //               signature_documentation
 //               > type HoverType struct{}

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct.go
@@ -1,16 +1,19 @@
   package inlinestruct
 //        ^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/
+//                     kind Package
 //                     display_name inlinestruct
 //                     signature_documentation
 //                     > package inlinestruct
   
   type FieldInterface interface {
 //     ^^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/FieldInterface#
+//                    kind Interface
 //                    display_name FieldInterface
 //                    signature_documentation
 //                    > type FieldInterface interface{ SomeMethod() string }
    SomeMethod() string
 // ^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/FieldInterface#SomeMethod.
+//            kind MethodSpecification
 //            display_name SomeMethod
 //            signature_documentation
 //            > func (FieldInterface).SomeMethod() string
@@ -18,17 +21,20 @@
   
   var MyInline = struct {
 //    ^^^^^^^^ definition 0.1.test `sg/inlinestruct`/MyInline.
+//             kind Variable
 //             display_name MyInline
 //             signature_documentation
 //             > var MyInline struct{privateField FieldInterface; PublicField FieldInterface}
    privateField FieldInterface
 // ^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/MyInline:privateField.
+//              kind Field
 //              display_name privateField
 //              signature_documentation
 //              > struct field privateField FieldInterface
 //              ^^^^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/FieldInterface#
    PublicField  FieldInterface
 // ^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/MyInline:PublicField.
+//             kind Field
 //             display_name PublicField
 //             signature_documentation
 //             > struct field PublicField FieldInterface
@@ -38,6 +44,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/inlinestruct`/MyFunc().
   func MyFunc() {
 //     ^^^^^^ definition 0.1.test `sg/inlinestruct`/MyFunc().
+//            kind Function
 //            display_name MyFunc
 //            signature_documentation
 //            > func MyFunc()

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_func.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_func.go
@@ -3,11 +3,13 @@
   
   type InFuncSig struct {
 //     ^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/InFuncSig#
+//               kind Struct
 //               display_name InFuncSig
 //               signature_documentation
 //               > type InFuncSig struct{ value bool }
    value bool
 // ^^^^^ definition 0.1.test `sg/inlinestruct`/InFuncSig#value.
+//       kind Field
 //       display_name value
 //       signature_documentation
 //       > struct field value bool
@@ -15,6 +17,7 @@
   
   var rowsCloseHook = func() func(InFuncSig, *error) { return nil }
 //    ^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/rowsCloseHook.
+//                  kind Variable
 //                  display_name rowsCloseHook
 //                  signature_documentation
 //                  > var rowsCloseHook func() func(InFuncSig, *error)

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_genericindex.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_genericindex.go
@@ -3,6 +3,7 @@
   
   type Processor[T any] interface {
 //     ^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/Processor#
+//               kind Interface
 //               display_name Processor
 //               signature_documentation
 //               > type Processor interface {
@@ -10,21 +11,25 @@
 //               >     ProcessorType() string
 //               > }
 //               ^ definition local 0
+//                 kind Interface
 //                 display_name T
 //                 signature_documentation
 //                 > type parameter T any
    Process(payload T)
 // ^^^^^^^ definition 0.1.test `sg/inlinestruct`/Processor#Process.
+//         kind MethodSpecification
 //         display_name Process
 //         signature_documentation
 //         > func (Processor[T any]).Process(payload T)
 //         ^^^^^^^ definition local 1
+//                 kind Variable
 //                 display_name payload
 //                 signature_documentation
 //                 > var payload T
 //                 ^ reference local 0
    ProcessorType() string
 // ^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/Processor#ProcessorType.
+//               kind MethodSpecification
 //               display_name ProcessorType
 //               signature_documentation
 //               > func (Processor[T any]).ProcessorType() string
@@ -32,12 +37,14 @@
   
   type Limit int
 //     ^^^^^ definition 0.1.test `sg/inlinestruct`/Limit#
+//           kind Type
 //           display_name Limit
 //           signature_documentation
 //           > type Limit int
   
   type ProcessImpl struct{}
 //     ^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/ProcessImpl#
+//                 kind Struct
 //                 display_name ProcessImpl
 //                 signature_documentation
 //                 > type ProcessImpl struct{}
@@ -45,15 +52,18 @@
 //⌄ enclosing_range_start 0.1.test `sg/inlinestruct`/ProcessImpl#Process().
   func (p *ProcessImpl) Process(payload Limit) { panic("not implemented") }
 //      ^ definition local 2
+//        kind Variable
 //        display_name p
 //        signature_documentation
 //        > var p *ProcessImpl
 //         ^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/ProcessImpl#
 //                      ^^^^^^^ definition 0.1.test `sg/inlinestruct`/ProcessImpl#Process().
+//                              kind Method
 //                              display_name Process
 //                              signature_documentation
 //                              > func (*ProcessImpl).Process(payload Limit)
 //                              ^^^^^^^ definition local 3
+//                                      kind Variable
 //                                      display_name payload
 //                                      signature_documentation
 //                                      > var payload Limit
@@ -62,11 +72,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/inlinestruct`/ProcessImpl#ProcessorType().
   func (p *ProcessImpl) ProcessorType() string { panic("not implemented") }
 //      ^ definition local 4
+//        kind Variable
 //        display_name p
 //        signature_documentation
 //        > var p *ProcessImpl
 //         ^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/ProcessImpl#
 //                      ^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/ProcessImpl#ProcessorType().
+//                                    kind Method
 //                                    display_name ProcessorType
 //                                    signature_documentation
 //                                    > func (*ProcessImpl).ProcessorType() string

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_interface.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_interface.go
@@ -7,11 +7,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/inlinestruct`/Target().
   func Target() interface {
 //     ^^^^^^ definition 0.1.test `sg/inlinestruct`/Target().
+//            kind Function
 //            display_name Target
 //            signature_documentation
 //            > func Target() interface{AbbreviatedOID(context.Context) (string, error); Commit(context.Context) (string, error); OID(context.Context) (int, error); Type(context.Context) (int, error)}
    OID(context.Context) (int, error)
 // ^^^ definition 0.1.test `sg/inlinestruct`/func:Target:OID().
+//     kind MethodSpecification
 //     display_name OID
 //     signature_documentation
 //     > func (interface).OID(context.Context) (int, error)
@@ -19,6 +21,7 @@
 //             ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
    AbbreviatedOID(context.Context) (string, error)
 // ^^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/func:Target:AbbreviatedOID().
+//                kind MethodSpecification
 //                display_name AbbreviatedOID
 //                signature_documentation
 //                > func (interface).AbbreviatedOID(context.Context) (string, error)
@@ -26,6 +29,7 @@
 //                        ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
    Commit(context.Context) (string, error)
 // ^^^^^^ definition 0.1.test `sg/inlinestruct`/func:Target:Commit().
+//        kind MethodSpecification
 //        display_name Commit
 //        signature_documentation
 //        > func (interface).Commit(context.Context) (string, error)
@@ -33,6 +37,7 @@
 //                ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
    Type(context.Context) (int, error)
 // ^^^^ definition 0.1.test `sg/inlinestruct`/func:Target:Type().
+//      kind MethodSpecification
 //      display_name Type
 //      signature_documentation
 //      > func (interface).Type(context.Context) (int, error)
@@ -46,11 +51,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/inlinestruct`/something().
   func something() {
 //     ^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/something().
+//               kind Function
 //               display_name something
 //               signature_documentation
 //               > func something()
    x := Target()
 // ^ definition local 0
+//   kind Variable
 //   display_name x
 //   signature_documentation
 //   > var x interface{AbbreviatedOID(Context) (string, error); Commit(Context) (string, error); OID(Context) (int, error); Type(Context) (int, error)}

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_map.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_map.go
@@ -3,6 +3,7 @@
   
   var testHook = func(map[string]string) {}
 //    ^^^^^^^^ definition 0.1.test `sg/inlinestruct`/testHook.
+//             kind Variable
 //             display_name testHook
 //             signature_documentation
 //             > var testHook func(map[string]string)

--- a/internal/testdata/snapshots/output/inlinestruct/inlinestruct_multivar.go
+++ b/internal/testdata/snapshots/output/inlinestruct/inlinestruct_multivar.go
@@ -3,44 +3,53 @@
   
   type Params struct{}
 //     ^^^^^^ definition 0.1.test `sg/inlinestruct`/Params#
+//            kind Struct
 //            display_name Params
 //            signature_documentation
 //            > type Params struct{}
   type HighlightedCode struct{}
 //     ^^^^^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/HighlightedCode#
+//                     kind Struct
 //                     display_name HighlightedCode
 //                     signature_documentation
 //                     > type HighlightedCode struct{}
   
   var Mocks, emptyMocks struct {
 //    ^^^^^ definition 0.1.test `sg/inlinestruct`/Mocks.
+//          kind Variable
 //          display_name Mocks
 //          signature_documentation
 //          > var Mocks struct{Code func(p Params) (response *HighlightedCode, aborted bool, err error)}
 //           ^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/emptyMocks.
+//                      kind Variable
 //                      display_name emptyMocks
 //                      signature_documentation
 //                      > var emptyMocks struct{Code func(p Params) (response *HighlightedCode, aborted bool, err error)}
    Code func(p Params) (response *HighlightedCode, aborted bool, err error)
 // ^^^^ definition 0.1.test `sg/inlinestruct`/inline-6-5:Code.
+//      kind Field
 //      display_name Code
 //      signature_documentation
 //      > struct field Code func(p Params) (response *HighlightedCode, aborted bool, err error)
 //           ^ definition local 0
+//             kind Variable
 //             display_name p
 //             signature_documentation
 //             > var p Params
 //             ^^^^^^ reference 0.1.test `sg/inlinestruct`/Params#
 //                      ^^^^^^^^ definition local 1
+//                               kind Variable
 //                               display_name response
 //                               signature_documentation
 //                               > var response *HighlightedCode
 //                                ^^^^^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/HighlightedCode#
 //                                                 ^^^^^^^ definition local 2
+//                                                         kind Variable
 //                                                         display_name aborted
 //                                                         signature_documentation
 //                                                         > var aborted bool
 //                                                               ^^^ definition local 3
+//                                                                   kind Variable
 //                                                                   display_name err
 //                                                                   signature_documentation
 //                                                                   > var err error
@@ -48,29 +57,35 @@
   
   var MocksSingle struct {
 //    ^^^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/MocksSingle.
+//                kind Variable
 //                display_name MocksSingle
 //                signature_documentation
 //                > var MocksSingle struct{Code func(p Params) (response *HighlightedCode, aborted bool, err error)}
    Code func(p Params) (response *HighlightedCode, aborted bool, err error)
 // ^^^^ definition 0.1.test `sg/inlinestruct`/MocksSingle:Code.
+//      kind Field
 //      display_name Code
 //      signature_documentation
 //      > struct field Code func(p Params) (response *HighlightedCode, aborted bool, err error)
 //           ^ definition local 4
+//             kind Variable
 //             display_name p
 //             signature_documentation
 //             > var p Params
 //             ^^^^^^ reference 0.1.test `sg/inlinestruct`/Params#
 //                      ^^^^^^^^ definition local 5
+//                               kind Variable
 //                               display_name response
 //                               signature_documentation
 //                               > var response *HighlightedCode
 //                                ^^^^^^^^^^^^^^^ reference 0.1.test `sg/inlinestruct`/HighlightedCode#
 //                                                 ^^^^^^^ definition local 6
+//                                                         kind Variable
 //                                                         display_name aborted
 //                                                         signature_documentation
 //                                                         > var aborted bool
 //                                                               ^^^ definition local 7
+//                                                                   kind Variable
 //                                                                   display_name err
 //                                                                   signature_documentation
 //                                                                   > var err error
@@ -79,11 +94,13 @@
   var (
    okReply   interface{} = "OK"
 // ^^^^^^^ definition 0.1.test `sg/inlinestruct`/okReply.
+//         kind Variable
 //         display_name okReply
 //         signature_documentation
 //         > var okReply interface{}
    pongReply interface{} = "PONG"
 // ^^^^^^^^^ definition 0.1.test `sg/inlinestruct`/pongReply.
+//           kind Variable
 //           display_name pongReply
 //           signature_documentation
 //           > var pongReply interface{}

--- a/internal/testdata/snapshots/output/package-documentation/primary.go
+++ b/internal/testdata/snapshots/output/package-documentation/primary.go
@@ -1,6 +1,7 @@
   // This is documentation for this package.
   package packagedocumentation
 //        ^^^^^^^^^^^^^^^^^^^^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/package-documentation`/
+//                             kind Package
 //                             display_name packagedocumentation
 //                             signature_documentation
 //                             > package packagedocumentation
@@ -10,6 +11,7 @@
 //⌄ enclosing_range_start github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/package-documentation`/Exported().
   func Exported() {}
 //     ^^^^^^^^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/package-documentation`/Exported().
+//              kind Function
 //              display_name Exported
 //              signature_documentation
 //              > func Exported()

--- a/internal/testdata/snapshots/output/package-documentation/secondary.go
+++ b/internal/testdata/snapshots/output/package-documentation/secondary.go
@@ -4,6 +4,7 @@
 //⌄ enclosing_range_start github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/package-documentation`/AlsoExporter().
   func AlsoExporter() {}
 //     ^^^^^^^^^^^^ definition github.com/sourcegraph/scip-go 0.1.test `github.com/sourcegraph/scip-go/internal/testdata/snapshots/input/package-documentation`/AlsoExporter().
+//                  kind Function
 //                  display_name AlsoExporter
 //                  signature_documentation
 //                  > func AlsoExporter()

--- a/internal/testdata/snapshots/output/pr198/pr198.go
+++ b/internal/testdata/snapshots/output/pr198/pr198.go
@@ -1,5 +1,6 @@
   package pr198
 //        ^^^^^ definition 0.1.test `sg/pr198`/
+//              kind Package
 //              display_name pr198
 //              signature_documentation
 //              > package pr198
@@ -13,6 +14,7 @@
   // pointing to Foo.
   type Foo interface {
 //     ^^^ definition 0.1.test `sg/pr198`/Foo#
+//         kind Interface
 //         display_name Foo
 //         signature_documentation
 //         > type Foo interface{ Bar() }
@@ -23,6 +25,7 @@
 //         > pointing to Foo.
    Bar()
 // ^^^ definition 0.1.test `sg/pr198`/Foo#Bar.
+//     kind MethodSpecification
 //     display_name Bar
 //     signature_documentation
 //     > func (Foo).Bar()
@@ -31,10 +34,12 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr198`/UseFoo().
   func UseFoo(f Foo) {}
 //     ^^^^^^ definition 0.1.test `sg/pr198`/UseFoo().
+//            kind Function
 //            display_name UseFoo
 //            signature_documentation
 //            > func UseFoo(f Foo)
 //            ^ definition local 0
+//              kind Variable
 //              display_name f
 //              signature_documentation
 //              > var f Foo
@@ -44,6 +49,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr198`/Example().
   func Example() {
 //     ^^^^^^^ definition 0.1.test `sg/pr198`/Example().
+//             kind Function
 //             display_name Example
 //             signature_documentation
 //             > func Example()

--- a/internal/testdata/snapshots/output/pr199/doc.go
+++ b/internal/testdata/snapshots/output/pr199/doc.go
@@ -1,6 +1,7 @@
   // Package pr199 tests package definition and documentation handling.
   package pr199
 //        ^^^^^ definition 0.1.test `sg/pr199`/
+//              kind Package
 //              display_name pr199
 //              signature_documentation
 //              > package pr199
@@ -16,6 +17,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr199`/FromDoc().
   func FromDoc() {}
 //     ^^^^^^^ definition 0.1.test `sg/pr199`/FromDoc().
+//             kind Function
 //             display_name FromDoc
 //             signature_documentation
 //             > func FromDoc()

--- a/internal/testdata/snapshots/output/pr199/no_doc.go
+++ b/internal/testdata/snapshots/output/pr199/no_doc.go
@@ -5,6 +5,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr199`/FromNoDoc().
   func FromNoDoc() {}
 //     ^^^^^^^^^ definition 0.1.test `sg/pr199`/FromNoDoc().
+//               kind Function
 //               display_name FromNoDoc
 //               signature_documentation
 //               > func FromNoDoc()

--- a/internal/testdata/snapshots/output/pr199/pr199.go
+++ b/internal/testdata/snapshots/output/pr199/pr199.go
@@ -5,6 +5,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr199`/FromMain().
   func FromMain() {}
 //     ^^^^^^^^ definition 0.1.test `sg/pr199`/FromMain().
+//              kind Function
 //              display_name FromMain
 //              signature_documentation
 //              > func FromMain()

--- a/internal/testdata/snapshots/output/pr199/pr199_test.go
+++ b/internal/testdata/snapshots/output/pr199/pr199_test.go
@@ -8,10 +8,12 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr199`/TestExample().
   func TestExample(t *testing.T) {}
 //     ^^^^^^^^^^^ definition 0.1.test `sg/pr199`/TestExample().
+//                 kind Function
 //                 display_name TestExample
 //                 signature_documentation
 //                 > func TestExample(t *testing.T)
 //                 ^ definition local 0
+//                   kind Variable
 //                   display_name t
 //                   signature_documentation
 //                   > var t *T

--- a/internal/testdata/snapshots/output/pr201/imports.go
+++ b/internal/testdata/snapshots/output/pr201/imports.go
@@ -1,5 +1,6 @@
   package pr201
 //        ^^^^^ definition 0.1.test `sg/pr201`/
+//              kind Package
 //              display_name pr201
 //              signature_documentation
 //              > package pr201
@@ -27,6 +28,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr201`/UseImports().
   func UseImports() {
 //     ^^^^^^^^^^ definition 0.1.test `sg/pr201`/UseImports().
+//                kind Function
 //                display_name UseImports
 //                signature_documentation
 //                > func UseImports()

--- a/internal/testdata/snapshots/output/pr202/identical_anon_types.go
+++ b/internal/testdata/snapshots/output/pr202/identical_anon_types.go
@@ -1,5 +1,6 @@
   package pr202
 //        ^^^^^ definition 0.1.test `sg/pr202`/
+//              kind Package
 //              display_name pr202
 //              signature_documentation
 //              > package pr202
@@ -8,6 +9,7 @@
   
   type IdenticalAnonFields struct {
 //     ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/IdenticalAnonFields#
+//                         kind Struct
 //                         display_name IdenticalAnonFields
 //                         signature_documentation
 //                         > type IdenticalAnonFields struct {
@@ -16,19 +18,23 @@
 //                         > }
    x struct{ t int }
 // ^ definition 0.1.test `sg/pr202`/IdenticalAnonFields#x.
+//   kind Field
 //   display_name x
 //   signature_documentation
 //   > struct field x struct{t int}
 //           ^ definition 0.1.test `sg/pr202`/IdenticalAnonFields#$anon_44af0565eb406c15#t.
+//             kind Field
 //             display_name t
 //             signature_documentation
 //             > struct field t int
    z struct{ t int }
 // ^ definition 0.1.test `sg/pr202`/IdenticalAnonFields#z.
+//   kind Field
 //   display_name z
 //   signature_documentation
 //   > struct field z struct{t int}
 //           ^ definition 0.1.test `sg/pr202`/IdenticalAnonFields#$anon_44af0565eb406c15#t.
+//             kind Field
 //             display_name t
 //             signature_documentation
 //             > struct field t int
@@ -37,11 +43,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr202`/useIdenticalAnonFields().
   func useIdenticalAnonFields() {
 //     ^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/useIdenticalAnonFields().
+//                            kind Function
 //                            display_name useIdenticalAnonFields
 //                            signature_documentation
 //                            > func useIdenticalAnonFields()
    var y IdenticalAnonFields
 //     ^ definition local 0
+//       kind Variable
 //       display_name y
 //       signature_documentation
 //       > var y IdenticalAnonFields
@@ -65,6 +73,7 @@
   // Different field order means different type — symbols must NOT unify.
   type FieldOrderMatters struct {
 //     ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/FieldOrderMatters#
+//                       kind Struct
 //                       display_name FieldOrderMatters
 //                       signature_documentation
 //                       > type FieldOrderMatters struct {
@@ -81,32 +90,38 @@
 //                       > Different field order means different type — symbols must NOT unify.
    a struct {
 // ^ definition 0.1.test `sg/pr202`/FieldOrderMatters#a.
+//   kind Field
 //   display_name a
 //   signature_documentation
 //   > struct field a struct{x int; y string}
     x int
 //  ^ definition 0.1.test `sg/pr202`/FieldOrderMatters#$anon_c0a8952b3a214f68#x.
+//    kind Field
 //    display_name x
 //    signature_documentation
 //    > struct field x int
     y string
 //  ^ definition 0.1.test `sg/pr202`/FieldOrderMatters#$anon_c0a8952b3a214f68#y.
+//    kind Field
 //    display_name y
 //    signature_documentation
 //    > struct field y string
    }
    b struct {
 // ^ definition 0.1.test `sg/pr202`/FieldOrderMatters#b.
+//   kind Field
 //   display_name b
 //   signature_documentation
 //   > struct field b struct{y string; x int}
     y string
 //  ^ definition 0.1.test `sg/pr202`/FieldOrderMatters#$anon_b8d88f3211c0d7a4#y.
+//    kind Field
 //    display_name y
 //    signature_documentation
 //    > struct field y string
     x int
 //  ^ definition 0.1.test `sg/pr202`/FieldOrderMatters#$anon_b8d88f3211c0d7a4#x.
+//    kind Field
 //    display_name x
 //    signature_documentation
 //    > struct field x int
@@ -116,6 +131,7 @@
   // Different struct tags — symbols must NOT unify.
   type DifferentTags struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/DifferentTags#
+//                   kind Struct
 //                   display_name DifferentTags
 //                   signature_documentation
 //                   > type DifferentTags struct {
@@ -130,22 +146,26 @@
 //                   > Different struct tags — symbols must NOT unify.
    a struct {
 // ^ definition 0.1.test `sg/pr202`/DifferentTags#a.
+//   kind Field
 //   display_name a
 //   signature_documentation
 //   > struct field a struct{Name string `json:"name"`}
     Name string `json:"name"`
 //  ^^^^ definition 0.1.test `sg/pr202`/DifferentTags#$anon_ed545d904f2246eb#Name.
+//       kind Field
 //       display_name Name
 //       signature_documentation
 //       > struct field Name string
    }
    b struct {
 // ^ definition 0.1.test `sg/pr202`/DifferentTags#b.
+//   kind Field
 //   display_name b
 //   signature_documentation
 //   > struct field b struct{Name string `json:"full_name"`}
     Name string `json:"full_name"`
 //  ^^^^ definition 0.1.test `sg/pr202`/DifferentTags#$anon_29f1ad2683b11ed0#Name.
+//       kind Field
 //       display_name Name
 //       signature_documentation
 //       > struct field Name string

--- a/internal/testdata/snapshots/output/pr202/local_anon.go
+++ b/internal/testdata/snapshots/output/pr202/local_anon.go
@@ -6,25 +6,30 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr202`/localAnonymousStructs().
   func localAnonymousStructs() {
 //     ^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/localAnonymousStructs().
+//                           kind Function
 //                           display_name localAnonymousStructs
 //                           signature_documentation
 //                           > func localAnonymousStructs()
    a := struct{ x int }{x: 1}
 // ^ definition local 0
+//   kind Variable
 //   display_name a
 //   signature_documentation
 //   > var a struct{x int}
 //              ^ definition local 1
+//                kind Field
 //                display_name x
 //                signature_documentation
 //                > field x int
 //                      ^ reference local 1
    b := struct{ x int }{x: 2}
 // ^ definition local 2
+//   kind Variable
 //   display_name b
 //   signature_documentation
 //   > var b struct{x int}
 //              ^ definition local 3
+//                kind Field
 //                display_name x
 //                signature_documentation
 //                > field x int
@@ -41,14 +46,17 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr202`/paramAnonymousStruct().
   func paramAnonymousStruct(p struct{ x int }) int {
 //     ^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/paramAnonymousStruct().
+//                          kind Function
 //                          display_name paramAnonymousStruct
 //                          signature_documentation
 //                          > func paramAnonymousStruct(p struct{x int}) int
 //                          ^ definition local 4
+//                            kind Variable
 //                            display_name p
 //                            signature_documentation
 //                            > var p struct{x int}
 //                                    ^ definition local 5
+//                                      kind Field
 //                                      display_name x
 //                                      signature_documentation
 //                                      > field x int

--- a/internal/testdata/snapshots/output/pr202/multiname_fields.go
+++ b/internal/testdata/snapshots/output/pr202/multiname_fields.go
@@ -5,6 +5,7 @@
   
   type MultiNameStruct struct {
 //     ^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/MultiNameStruct#
+//                     kind Struct
 //                     display_name MultiNameStruct
 //                     signature_documentation
 //                     > type MultiNameStruct struct {
@@ -19,20 +20,24 @@
 //                     > }
    a, b struct {
 // ^ definition 0.1.test `sg/pr202`/MultiNameStruct#a.
+//   kind Field
 //   display_name a
 //   signature_documentation
 //   > struct field a struct{x int; y string}
 //    ^ definition 0.1.test `sg/pr202`/MultiNameStruct#b.
+//      kind Field
 //      display_name b
 //      signature_documentation
 //      > struct field b struct{x int; y string}
     x int
 //  ^ definition 0.1.test `sg/pr202`/MultiNameStruct#$anon_c0a8952b3a214f68#x.
+//    kind Field
 //    display_name x
 //    signature_documentation
 //    > struct field x int
     y string
 //  ^ definition 0.1.test `sg/pr202`/MultiNameStruct#$anon_c0a8952b3a214f68#y.
+//    kind Field
 //    display_name y
 //    signature_documentation
 //    > struct field y string
@@ -42,11 +47,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr202`/useMultiNameFields().
   func useMultiNameFields() {
 //     ^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/useMultiNameFields().
+//                        kind Function
 //                        display_name useMultiNameFields
 //                        signature_documentation
 //                        > func useMultiNameFields()
    var m MultiNameStruct
 //     ^ definition local 0
+//       kind Variable
 //       display_name m
 //       signature_documentation
 //       > var m MultiNameStruct

--- a/internal/testdata/snapshots/output/pr202/nested_anon.go
+++ b/internal/testdata/snapshots/output/pr202/nested_anon.go
@@ -5,6 +5,7 @@
   
   type ContainerAnon struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/ContainerAnon#
+//                   kind Struct
 //                   display_name ContainerAnon
 //                   signature_documentation
 //                   > type ContainerAnon struct {
@@ -14,28 +15,34 @@
 //                   > }
    items   []struct{ id int }
 // ^^^^^ definition 0.1.test `sg/pr202`/ContainerAnon#items.
+//       kind Field
 //       display_name items
 //       signature_documentation
 //       > struct field items []struct{id int}
 //                   ^^ definition 0.1.test `sg/pr202`/ContainerAnon#$anon_71c5ea8d9342795c#id.
+//                      kind Field
 //                      display_name id
 //                      signature_documentation
 //                      > struct field id int
    entries map[string]struct{ count int }
 // ^^^^^^^ definition 0.1.test `sg/pr202`/ContainerAnon#entries.
+//         kind Field
 //         display_name entries
 //         signature_documentation
 //         > struct field entries map[string]struct{count int}
 //                            ^^^^^ definition 0.1.test `sg/pr202`/ContainerAnon#$anon_721f9800014370ac#count.
+//                                  kind Field
 //                                  display_name count
 //                                  signature_documentation
 //                                  > struct field count int
    ptr     *struct{ data int }
 // ^^^ definition 0.1.test `sg/pr202`/ContainerAnon#ptr.
+//     kind Field
 //     display_name ptr
 //     signature_documentation
 //     > struct field ptr *struct{data int}
 //                  ^^^^ definition 0.1.test `sg/pr202`/ContainerAnon#$anon_944f727740dfb75d#data.
+//                       kind Field
 //                       display_name data
 //                       signature_documentation
 //                       > struct field data int
@@ -43,6 +50,7 @@
   
   type DeepNested struct {
 //     ^^^^^^^^^^ definition 0.1.test `sg/pr202`/DeepNested#
+//                kind Struct
 //                display_name DeepNested
 //                signature_documentation
 //                > type DeepNested struct {
@@ -50,16 +58,19 @@
 //                > }
    outer struct {
 // ^^^^^ definition 0.1.test `sg/pr202`/DeepNested#outer.
+//       kind Field
 //       display_name outer
 //       signature_documentation
 //       > struct field outer struct{inner struct{value int}}
     inner struct {
 //  ^^^^^ definition 0.1.test `sg/pr202`/DeepNested#$anon_5ee0364e53e1abd6#inner.
+//        kind Field
 //        display_name inner
 //        signature_documentation
 //        > struct field inner struct{value int}
      value int
 //   ^^^^^ definition 0.1.test `sg/pr202`/DeepNested#$anon_5ee0364e53e1abd6#$anon_77e42bf2e5c84d1a#value.
+//         kind Field
 //         display_name value
 //         signature_documentation
 //         > struct field value int
@@ -70,6 +81,7 @@
   // Two fields with identical slice-of-anonymous-struct type.
   type SliceAnonShared struct {
 //     ^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/SliceAnonShared#
+//                     kind Struct
 //                     display_name SliceAnonShared
 //                     signature_documentation
 //                     > type SliceAnonShared struct {
@@ -80,19 +92,23 @@
 //                     > Two fields with identical slice-of-anonymous-struct type.
    a []struct{ v int }
 // ^ definition 0.1.test `sg/pr202`/SliceAnonShared#a.
+//   kind Field
 //   display_name a
 //   signature_documentation
 //   > struct field a []struct{v int}
 //             ^ definition 0.1.test `sg/pr202`/SliceAnonShared#$anon_358bfde4cba1ecae#v.
+//               kind Field
 //               display_name v
 //               signature_documentation
 //               > struct field v int
    b []struct{ v int }
 // ^ definition 0.1.test `sg/pr202`/SliceAnonShared#b.
+//   kind Field
 //   display_name b
 //   signature_documentation
 //   > struct field b []struct{v int}
 //             ^ definition 0.1.test `sg/pr202`/SliceAnonShared#$anon_358bfde4cba1ecae#v.
+//               kind Field
 //               display_name v
 //               signature_documentation
 //               > struct field v int
@@ -101,11 +117,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr202`/useContainerAnon().
   func useContainerAnon() {
 //     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr202`/useContainerAnon().
+//                      kind Function
 //                      display_name useContainerAnon
 //                      signature_documentation
 //                      > func useContainerAnon()
    var c ContainerAnon
 //     ^ definition local 0
+//       kind Variable
 //       display_name c
 //       signature_documentation
 //       > var c ContainerAnon
@@ -120,6 +138,7 @@
    }
    entry := c.entries["key"]
 // ^^^^^ definition local 1
+//       kind Variable
 //       display_name entry
 //       signature_documentation
 //       > var entry struct{count int}
@@ -139,6 +158,7 @@
   
    var d DeepNested
 //     ^ definition local 2
+//       kind Variable
 //       display_name d
 //       signature_documentation
 //       > var d DeepNested

--- a/internal/testdata/snapshots/output/pr206/const_docs.go
+++ b/internal/testdata/snapshots/output/pr206/const_docs.go
@@ -1,5 +1,6 @@
   package pr206
 //        ^^^^^ definition 0.1.test `sg/pr206`/
+//              kind Package
 //              display_name pr206
 //              signature_documentation
 //              > package pr206
@@ -10,6 +11,7 @@
    // It spans two lines.
    BlockConst1 = 1
 // ^^^^^^^^^^^ definition 0.1.test `sg/pr206`/BlockConst1.
+//             kind Constant
 //             display_name BlockConst1
 //             signature_documentation
 //             > const BlockConst1 untyped int = 1
@@ -21,6 +23,7 @@
   
    BlockConstNoDoc = 2
 // ^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr206`/BlockConstNoDoc.
+//                 kind Constant
 //                 display_name BlockConstNoDoc
 //                 signature_documentation
 //                 > const BlockConstNoDoc untyped int = 2
@@ -29,6 +32,7 @@
   
    BlockConstTrailing = 3 // trailing comment on const
 // ^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/pr206`/BlockConstTrailing.
+//                    kind Constant
 //                    display_name BlockConstTrailing
 //                    signature_documentation
 //                    > const BlockConstTrailing untyped int = 3
@@ -42,6 +46,7 @@
    // OrphanConst lives in a block with no block-level doc.
    OrphanConst = 99
 // ^^^^^^^^^^^ definition 0.1.test `sg/pr206`/OrphanConst.
+//             kind Constant
 //             display_name OrphanConst
 //             signature_documentation
 //             > const OrphanConst untyped int = 99

--- a/internal/testdata/snapshots/output/pr206/embedded_field_docs.go
+++ b/internal/testdata/snapshots/output/pr206/embedded_field_docs.go
@@ -3,18 +3,21 @@
   
   type Base struct{}
 //     ^^^^ definition 0.1.test `sg/pr206`/Base#
+//          kind Struct
 //          display_name Base
 //          signature_documentation
 //          > type Base struct{}
   
   type Container struct {
 //     ^^^^^^^^^ definition 0.1.test `sg/pr206`/Container#
+//               kind Struct
 //               display_name Container
 //               signature_documentation
 //               > type Container struct{ Base }
    // Base is embedded to inherit shared fields.
    Base
 // ^^^^ definition 0.1.test `sg/pr206`/Container#Base.
+//      kind Field
 //      display_name Base
 //      signature_documentation
 //      > struct field Base Base

--- a/internal/testdata/snapshots/output/pr206/interface_method_docs.go
+++ b/internal/testdata/snapshots/output/pr206/interface_method_docs.go
@@ -3,12 +3,14 @@
   
   type Doer interface {
 //     ^^^^ definition 0.1.test `sg/pr206`/Doer#
+//          kind Interface
 //          display_name Doer
 //          signature_documentation
 //          > type Doer interface{ Do() error }
    // Do performs the action and returns an error if it fails.
    Do() error
 // ^^ definition 0.1.test `sg/pr206`/Doer#Do.
+//    kind MethodSpecification
 //    display_name Do
 //    signature_documentation
 //    > func (Doer).Do() error

--- a/internal/testdata/snapshots/output/pr211/generic_alias.go
+++ b/internal/testdata/snapshots/output/pr211/generic_alias.go
@@ -1,5 +1,6 @@
   package pr211
 //        ^^^^^ definition 0.1.test `sg/pr211`/
+//              kind Package
 //              display_name pr211
 //              signature_documentation
 //              > package pr211
@@ -7,21 +8,25 @@
   // Map is a generic map type.
   type Map[K comparable, V any] struct {
 //     ^^^ definition 0.1.test `sg/pr211`/Map#
+//         kind Struct
 //         display_name Map
 //         signature_documentation
 //         > type Map struct{ entries []entry[K, V] }
 //         documentation
 //         > Map is a generic map type.
 //         ^ definition local 0
+//           kind Interface
 //           display_name K
 //           signature_documentation
 //           > type parameter K comparable
 //                       ^ definition local 1
+//                         kind Interface
 //                         display_name V
 //                         signature_documentation
 //                         > type parameter V any
    entries []entry[K, V]
 // ^^^^^^^ definition 0.1.test `sg/pr211`/Map#entries.
+//         kind Field
 //         display_name entries
 //         signature_documentation
 //         > struct field entries []entry[K, V]
@@ -32,6 +37,7 @@
   
   type entry[K comparable, V any] struct {
 //     ^^^^^ definition 0.1.test `sg/pr211`/entry#
+//           kind Struct
 //           display_name entry
 //           signature_documentation
 //           > type entry struct {
@@ -39,21 +45,25 @@
 //           >     value V
 //           > }
 //           ^ definition local 2
+//             kind Interface
 //             display_name K
 //             signature_documentation
 //             > type parameter K comparable
 //                         ^ definition local 3
+//                           kind Interface
 //                           display_name V
 //                           signature_documentation
 //                           > type parameter V any
    key   K
 // ^^^ definition 0.1.test `sg/pr211`/entry#key.
+//     kind Field
 //     display_name key
 //     signature_documentation
 //     > struct field key K
 //       ^ reference local 2
    value V
 // ^^^^^ definition 0.1.test `sg/pr211`/entry#value.
+//       kind Field
 //       display_name value
 //       signature_documentation
 //       > struct field value V
@@ -63,12 +73,14 @@
   // Set is a generic alias that partially instantiates Map.
   type Set[K comparable] = Map[K, bool]
 //     ^^^ definition 0.1.test `sg/pr211`/Set#
+//         kind TypeAlias
 //         display_name Set
 //         signature_documentation
 //         > type Set[K comparable] = Map[K, bool]
 //         documentation
 //         > Set is a generic alias that partially instantiates Map.
 //         ^ definition local 4
+//           kind Interface
 //           display_name K
 //           signature_documentation
 //           > type parameter K comparable
@@ -78,12 +90,14 @@
   // Alias with a tighter constraint.
   type OrderedSet[K ~int | ~string] = Set[K]
 //     ^^^^^^^^^^ definition 0.1.test `sg/pr211`/OrderedSet#
+//                kind TypeAlias
 //                display_name OrderedSet
 //                signature_documentation
 //                > type OrderedSet[K ~int | ~string] = Set[K]
 //                documentation
 //                > Alias with a tighter constraint.
 //                ^ definition local 5
+//                  kind Interface
 //                  display_name K
 //                  signature_documentation
 //                  > type parameter K ~int | ~string
@@ -93,6 +107,7 @@
   // Alias of an alias (chained).
   type StringSet = Set[string]
 //     ^^^^^^^^^ definition 0.1.test `sg/pr211`/StringSet#
+//               kind TypeAlias
 //               display_name StringSet
 //               signature_documentation
 //               > type StringSet = Set[string]
@@ -103,16 +118,19 @@
   // Alias with all params forwarded.
   type PairMap[K comparable, V any] = Map[K, V]
 //     ^^^^^^^ definition 0.1.test `sg/pr211`/PairMap#
+//             kind TypeAlias
 //             display_name PairMap
 //             signature_documentation
 //             > type PairMap[K comparable, V any] = Map[K, V]
 //             documentation
 //             > Alias with all params forwarded.
 //             ^ definition local 6
+//               kind Interface
 //               display_name K
 //               signature_documentation
 //               > type parameter K comparable
 //                           ^ definition local 7
+//                             kind Interface
 //                             display_name V
 //                             signature_documentation
 //                             > type parameter V any
@@ -123,6 +141,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/pr211`/UseAliases().
   func UseAliases() {
 //     ^^^^^^^^^^ definition 0.1.test `sg/pr211`/UseAliases().
+//                kind Function
 //                display_name UseAliases
 //                signature_documentation
 //                > func UseAliases()

--- a/internal/testdata/snapshots/output/replace-directives/replace_directives.go
+++ b/internal/testdata/snapshots/output/replace-directives/replace_directives.go
@@ -1,5 +1,6 @@
   package replacers
 //        ^^^^^^^^^ definition 0.1.test `sg/replace-directives`/
+//                  kind Package
 //                  display_name replacers
 //                  signature_documentation
 //                  > package replacers
@@ -16,6 +17,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/replace-directives`/Something().
   func Something() {
 //     ^^^^^^^^^ definition 0.1.test `sg/replace-directives`/Something().
+//               kind Function
 //               display_name Something
 //               signature_documentation
 //               > func Something()

--- a/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/cleanup.go
+++ b/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/cleanup.go
@@ -1,5 +1,6 @@
   package server
 //        ^^^^^^ definition 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/
+//               kind Package
 //               display_name server
 //               signature_documentation
 //               > package server
@@ -7,6 +8,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/LiterallyAnything().
   func LiterallyAnything() {}
 //     ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/LiterallyAnything().
+//                       kind Function
 //                       display_name LiterallyAnything
 //                       signature_documentation
 //                       > func LiterallyAnything()

--- a/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/cleanup_test.go
+++ b/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/cleanup_test.go
@@ -7,10 +7,12 @@
 //⌄ enclosing_range_start 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/TestStuff().
   func TestStuff(t *testing.T) {
 //     ^^^^^^^^^ definition 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/TestStuff().
+//               kind Function
 //               display_name TestStuff
 //               signature_documentation
 //               > func TestStuff(t *testing.T)
 //               ^ definition local 0
+//                 kind Variable
 //                 display_name t
 //                 signature_documentation
 //                 > var t *T
@@ -18,11 +20,13 @@
 //                          ^ reference github.com/golang/go/src go1.22 testing/T#
    wd := "hello"
 // ^^ definition local 1
+//    kind Variable
 //    display_name wd
 //    signature_documentation
 //    > var wd string
    repo := "world"
 // ^^^^ definition local 2
+//      kind Variable
 //      display_name repo
 //      signature_documentation
 //      > var repo string

--- a/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/server.go
+++ b/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/server.go
@@ -4,6 +4,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/AnythingAtAll().
   func AnythingAtAll() {}
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/AnythingAtAll().
+//                   kind Function
 //                   display_name AnythingAtAll
 //                   signature_documentation
 //                   > func AnythingAtAll()

--- a/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/server_test.go
+++ b/internal/testdata/snapshots/output/sharedtestmodule/cmd/gitserver/server/server_test.go
@@ -7,10 +7,12 @@
 //⌄ enclosing_range_start 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/TestExecRequest().
   func TestExecRequest(t *testing.T) {
 //     ^^^^^^^^^^^^^^^ definition 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/TestExecRequest().
+//                     kind Function
 //                     display_name TestExecRequest
 //                     signature_documentation
 //                     > func TestExecRequest(t *testing.T)
 //                     ^ definition local 0
+//                       kind Variable
 //                       display_name t
 //                       signature_documentation
 //                       > var t *T
@@ -25,24 +27,29 @@
 //⌄ enclosing_range_start 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/runCmd().
   func runCmd(t *testing.T, dir string, cmd string, arg ...string) {}
 //     ^^^^^^ definition 0.1.test `sg/sharedtestmodule/cmd/gitserver/server`/runCmd().
+//            kind Function
 //            display_name runCmd
 //            signature_documentation
 //            > func runCmd(t *testing.T, dir string, cmd string, arg ...string)
 //            ^ definition local 1
+//              kind Variable
 //              display_name t
 //              signature_documentation
 //              > var t *T
 //               ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
 //                       ^ reference github.com/golang/go/src go1.22 testing/T#
 //                          ^^^ definition local 2
+//                              kind Variable
 //                              display_name dir
 //                              signature_documentation
 //                              > var dir string
 //                                      ^^^ definition local 3
+//                                          kind Variable
 //                                          display_name cmd
 //                                          signature_documentation
 //                                          > var cmd string
 //                                                  ^^^ definition local 4
+//                                                      kind Variable
 //                                                      display_name arg
 //                                                      signature_documentation
 //                                                      > var arg []string

--- a/internal/testdata/snapshots/output/switches/switches.go
+++ b/internal/testdata/snapshots/output/switches/switches.go
@@ -1,5 +1,6 @@
   package switches
 //        ^^^^^^^^ definition 0.1.test `sg/switches`/
+//                 kind Package
 //                 display_name switches
 //                 signature_documentation
 //                 > package switches
@@ -7,6 +8,7 @@
   // CustomSwitch does the things in a switch
   type CustomSwitch struct{}
 //     ^^^^^^^^^^^^ definition 0.1.test `sg/switches`/CustomSwitch#
+//                  kind Struct
 //                  display_name CustomSwitch
 //                  signature_documentation
 //                  > type CustomSwitch struct{}
@@ -17,11 +19,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/switches`/CustomSwitch#Something().
   func (c *CustomSwitch) Something() bool { return false }
 //      ^ definition local 0
+//        kind Variable
 //        display_name c
 //        signature_documentation
 //        > var c *CustomSwitch
 //         ^^^^^^^^^^^^ reference 0.1.test `sg/switches`/CustomSwitch#
 //                       ^^^^^^^^^ definition 0.1.test `sg/switches`/CustomSwitch#Something().
+//                                 kind Method
 //                                 display_name Something
 //                                 signature_documentation
 //                                 > func (*CustomSwitch).Something() bool
@@ -32,15 +36,18 @@
 //⌄ enclosing_range_start 0.1.test `sg/switches`/Switch().
   func Switch(interfaceValue interface{}) bool {
 //     ^^^^^^ definition 0.1.test `sg/switches`/Switch().
+//            kind Function
 //            display_name Switch
 //            signature_documentation
 //            > func Switch(interfaceValue interface{}) bool
 //            ^^^^^^^^^^^^^^ definition local 1
+//                           kind Variable
 //                           display_name interfaceValue
 //                           signature_documentation
 //                           > var interfaceValue interface{}
    switch concreteValue := interfaceValue.(type) {
 //        ^^^^^^^^^^^^^ definition local 2
+//                      kind Variable
 //                      display_name concreteValue
 //                         ^^^^^^^^^^^^^^ reference local 1
    case int:

--- a/internal/testdata/snapshots/output/testdata/anonymous_structs.go
+++ b/internal/testdata/snapshots/output/testdata/anonymous_structs.go
@@ -1,5 +1,6 @@
   package testdata
 //        ^^^^^^^^ definition 0.1.test `sg/testdata`/
+//                 kind Package
 //                 display_name testdata
 //                 signature_documentation
 //                 > package testdata
@@ -9,6 +10,7 @@
   
   type TypeContainingAnonymousStructs struct {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#
+//                                    kind Struct
 //                                    display_name TypeContainingAnonymousStructs
 //                                    signature_documentation
 //                                    > type TypeContainingAnonymousStructs struct {
@@ -27,36 +29,43 @@
 //                                    > }
    a, b struct {
 // ^ definition 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#a.
+//   kind Field
 //   display_name a
 //   signature_documentation
 //   > struct field a struct{x int; y string}
 //    ^ definition 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#b.
+//      kind Field
 //      display_name b
 //      signature_documentation
 //      > struct field b struct{x int; y string}
     x int
 //  ^ definition 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#$anon_c0a8952b3a214f68#x.
+//    kind Field
 //    display_name x
 //    signature_documentation
 //    > struct field x int
     y string
 //  ^ definition 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#$anon_c0a8952b3a214f68#y.
+//    kind Field
 //    display_name y
 //    signature_documentation
 //    > struct field y string
    }
    c struct {
 // ^ definition 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#c.
+//   kind Field
 //   display_name c
 //   signature_documentation
 //   > struct field c struct{X int; Y string}
     X int
 //  ^ definition 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#$anon_2f238678626c0da1#X.
+//    kind Field
 //    display_name X
 //    signature_documentation
 //    > struct field X int
     Y string
 //  ^ definition 0.1.test `sg/testdata`/TypeContainingAnonymousStructs#$anon_2f238678626c0da1#Y.
+//    kind Field
 //    display_name Y
 //    signature_documentation
 //    > struct field Y string
@@ -66,21 +75,25 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/funcContainingAnonymousStructs().
   func funcContainingAnonymousStructs() {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/funcContainingAnonymousStructs().
+//                                    kind Function
 //                                    display_name funcContainingAnonymousStructs
 //                                    signature_documentation
 //                                    > func funcContainingAnonymousStructs()
    d := struct {
 // ^ definition local 0
+//   kind Variable
 //   display_name d
 //   signature_documentation
 //   > var d struct{x int; y string}
     x int
 //  ^ definition local 1
+//    kind Field
 //    display_name x
 //    signature_documentation
 //    > field x int
     y string
 //  ^ definition local 2
+//    kind Field
 //    display_name y
 //    signature_documentation
 //    > field y string
@@ -93,16 +106,19 @@
   
    var e struct {
 //     ^ definition local 3
+//       kind Variable
 //       display_name e
 //       signature_documentation
 //       > var e struct{x int; y string}
     x int
 //  ^ definition local 4
+//    kind Field
 //    display_name x
 //    signature_documentation
 //    > field x int
     y string
 //  ^ definition local 5
+//    kind Field
 //    display_name y
 //    signature_documentation
 //    > field y string
@@ -117,6 +133,7 @@
   
    var f TypeContainingAnonymousStructs
 //     ^ definition local 6
+//       kind Variable
 //       display_name f
 //       signature_documentation
 //       > var f TypeContainingAnonymousStructs

--- a/internal/testdata/snapshots/output/testdata/cmd/minimal_main/minimal_main.go
+++ b/internal/testdata/snapshots/output/testdata/cmd/minimal_main/minimal_main.go
@@ -1,11 +1,13 @@
   package main
 //        ^^^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/
+//             kind Package
 //             display_name main
 //             signature_documentation
 //             > package main
   
   type User struct {
 //     ^^^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/User#
+//          kind Struct
 //          display_name User
 //          signature_documentation
 //          > type User struct {
@@ -14,10 +16,12 @@
 //          > }
    Id, Name string
 // ^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/User#Id.
+//    kind Field
 //    display_name Id
 //    signature_documentation
 //    > struct field Id string
 //     ^^^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/User#Name.
+//          kind Field
 //          display_name Name
 //          signature_documentation
 //          > struct field Name string
@@ -25,6 +29,7 @@
   
   type UserResource struct{}
 //     ^^^^^^^^^^^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/UserResource#
+//                  kind Struct
 //                  display_name UserResource
 //                  signature_documentation
 //                  > type UserResource struct{}
@@ -32,6 +37,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata/cmd/minimal_main`/main().
   func main() {}
 //     ^^^^ definition 0.1.test `sg/testdata/cmd/minimal_main`/main().
+//          kind Function
 //          display_name main
 //          signature_documentation
 //          > func main()

--- a/internal/testdata/snapshots/output/testdata/conflicting_test_symbols/sandbox_unsupported_test.go
+++ b/internal/testdata/snapshots/output/testdata/conflicting_test_symbols/sandbox_unsupported_test.go
@@ -3,6 +3,7 @@
   
   package osl
 //        ^^^ definition 0.1.test `sg/testdata/conflicting_test_symbols`/
+//            kind Package
 //            display_name osl
 //            signature_documentation
 //            > package osl
@@ -16,6 +17,7 @@
   
   var ErrNotImplemented = errors.New("not implemented")
 //    ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata/conflicting_test_symbols`/ErrNotImplemented.
+//                      kind Variable
 //                      display_name ErrNotImplemented
 //                      signature_documentation
 //                      > var ErrNotImplemented error
@@ -25,10 +27,12 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata/conflicting_test_symbols`/newKey().
   func newKey(t *testing.T) (string, error) {
 //     ^^^^^^ definition 0.1.test `sg/testdata/conflicting_test_symbols`/newKey().
+//            kind Function
 //            display_name newKey
 //            signature_documentation
 //            > func newKey(t *testing.T) (string, error)
 //            ^ definition local 0
+//              kind Variable
 //              display_name t
 //              signature_documentation
 //              > var t *T
@@ -42,16 +46,19 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata/conflicting_test_symbols`/verifySandbox().
   func verifySandbox(t *testing.T, s string) {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/testdata/conflicting_test_symbols`/verifySandbox().
+//                   kind Function
 //                   display_name verifySandbox
 //                   signature_documentation
 //                   > func verifySandbox(t *testing.T, s string)
 //                   ^ definition local 1
+//                     kind Variable
 //                     display_name t
 //                     signature_documentation
 //                     > var t *T
 //                      ^^^^^^^ reference github.com/golang/go/src go1.22 testing/
 //                              ^ reference github.com/golang/go/src go1.22 testing/T#
 //                                 ^ definition local 2
+//                                   kind Variable
 //                                   display_name s
 //                                   signature_documentation
 //                                   > var s string

--- a/internal/testdata/snapshots/output/testdata/data.go
+++ b/internal/testdata/snapshots/output/testdata/data.go
@@ -12,6 +12,7 @@
   // TestInterface is an interface used for testing.
   type TestInterface interface {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestInterface#
+//                   kind Interface
 //                   display_name TestInterface
 //                   signature_documentation
 //                   > type TestInterface interface {
@@ -22,22 +23,26 @@
    // Do does a test thing.
    Do(ctx context.Context, data string) (score int, _ error)
 // ^^ definition 0.1.test `sg/testdata`/TestInterface#Do.
+//    kind MethodSpecification
 //    display_name Do
 //    signature_documentation
 //    > func (TestInterface).Do(ctx context.Context, data string) (score int, _ error)
 //    documentation
 //    > Do does a test thing.
 //    ^^^ definition local 0
+//        kind Variable
 //        display_name ctx
 //        signature_documentation
 //        > var ctx Context
 //        ^^^^^^^ reference github.com/golang/go/src go1.22 context/
 //                ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
 //                         ^^^^ definition local 1
+//                              kind Variable
 //                              display_name data
 //                              signature_documentation
 //                              > var data string
 //                                       ^^^^^ definition local 2
+//                                             kind Variable
 //                                             display_name score
 //                                             signature_documentation
 //                                             > var score int
@@ -47,6 +52,7 @@
    // TestStruct is a struct used for testing.
    TestStruct struct {
 // ^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#
+//            kind Struct
 //            display_name TestStruct
 //            signature_documentation
 //            > type TestStruct struct {
@@ -66,6 +72,7 @@
     // SimpleA docs
     SimpleA int
 //  ^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#SimpleA.
+//          kind Field
 //          display_name SimpleA
 //          signature_documentation
 //          > struct field SimpleA int
@@ -74,6 +81,7 @@
     // SimpleB docs
     SimpleB int
 //  ^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#SimpleB.
+//          kind Field
 //          display_name SimpleB
 //          signature_documentation
 //          > struct field SimpleB int
@@ -82,6 +90,7 @@
     // SimpleC docs
     SimpleC int
 //  ^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#SimpleC.
+//          kind Field
 //          display_name SimpleC
 //          signature_documentation
 //          > struct field SimpleC int
@@ -90,27 +99,32 @@
   
     FieldWithTag           string `json:"tag"`
 //  ^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#FieldWithTag.
+//               kind Field
 //               display_name FieldWithTag
 //               signature_documentation
 //               > struct field FieldWithTag string
     FieldWithAnonymousType struct {
 //  ^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#FieldWithAnonymousType.
+//                         kind Field
 //                         display_name FieldWithAnonymousType
 //                         signature_documentation
 //                         > struct field FieldWithAnonymousType struct{NestedA string; NestedB string; NestedC string}
      NestedA string
 //   ^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#$anon_2bed88e490dc48af#NestedA.
+//           kind Field
 //           display_name NestedA
 //           signature_documentation
 //           > struct field NestedA string
      NestedB string
 //   ^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#$anon_2bed88e490dc48af#NestedB.
+//           kind Field
 //           display_name NestedB
 //           signature_documentation
 //           > struct field NestedB string
      // NestedC docs
      NestedC string
 //   ^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#$anon_2bed88e490dc48af#NestedC.
+//           kind Field
 //           display_name NestedC
 //           signature_documentation
 //           > struct field NestedC string
@@ -120,6 +134,7 @@
   
     EmptyStructField struct{}
 //  ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestStruct#EmptyStructField.
+//                   kind Field
 //                   display_name EmptyStructField
 //                   signature_documentation
 //                   > struct field EmptyStructField struct{}
@@ -127,6 +142,7 @@
   
    TestEmptyStruct struct{}
 // ^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestEmptyStruct#
+//                 kind Struct
 //                 display_name TestEmptyStruct
 //                 signature_documentation
 //                 > type TestEmptyStruct struct{}
@@ -135,6 +151,7 @@
   // Score is just a hardcoded number.
   const Score = uint64(42)
 //      ^^^^^ definition 0.1.test `sg/testdata`/Score.
+//            kind Constant
 //            display_name Score
 //            signature_documentation
 //            > const Score uint64 = 42
@@ -142,6 +159,7 @@
 //            > Score is just a hardcoded number.
   const secretScore = secret.SecretScore
 //      ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/secretScore.
+//                  kind Constant
 //                  display_name secretScore
 //                  signature_documentation
 //                  > const secretScore uint64 = 43
@@ -150,28 +168,33 @@
   
   const SomeString = "foobar"
 //      ^^^^^^^^^^ definition 0.1.test `sg/testdata`/SomeString.
+//                 kind Constant
 //                 display_name SomeString
 //                 signature_documentation
 //                 > const SomeString untyped string = "foobar"
   const LongString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed tincidunt viverra aliquam. Phasellus finibus, arcu eu commodo porta, dui quam dictum ante, nec porta enim leo quis felis. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Curabitur luctus orci tortor, non condimentum arcu bibendum ut. Proin sit amet vulputate lorem, ut egestas arcu. Curabitur quis sagittis mi. Aenean elit sem, imperdiet ut risus eget, varius varius erat.\nNullam lobortis tortor sed sodales consectetur. Aenean condimentum vehicula elit, eget interdum ante finibus nec. Mauris mollis, nulla eu vehicula rhoncus, eros lectus viverra tellus, ac hendrerit quam massa et felis. Nunc vestibulum diam a facilisis sollicitudin. Aenean nec varius metus. Sed nec diam nibh. Ut erat erat, suscipit et ante eget, tincidunt condimentum orci. Aenean nec facilisis augue, ac sodales ex. Nulla dictum hendrerit tempus. Aliquam fringilla tortor in massa molestie, quis bibendum nulla ullamcorper. Suspendisse congue laoreet elit, vitae consectetur orci facilisis non. Aliquam tempus ultricies sapien, rhoncus tincidunt nisl tincidunt eget. Aliquam nisi ante, rutrum eget viverra imperdiet, congue ut nunc. Donec mollis sed tellus vel placerat. Sed mi ex, fringilla a fermentum a, tincidunt eget lectus.\nPellentesque lacus nibh, accumsan eget feugiat nec, gravida eget urna. Donec quam velit, imperdiet in consequat eget, ultricies eget nunc. Curabitur interdum vel sem et euismod. Donec sed vulputate odio, sit amet bibendum tellus. Integer pellentesque nunc eu turpis cursus, vestibulum sodales ipsum posuere. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Ut at vestibulum sapien. In hac habitasse platea dictumst. Nullam sed lobortis urna, non bibendum ipsum. Sed in sapien quis purus semper fringilla. Integer ut egestas nulla, eu ornare lectus. Maecenas quis sapien condimentum, dignissim urna quis, hendrerit neque. Donec cursus sit amet metus eu mollis.\nSed scelerisque vitae odio non egestas. Cras hendrerit tortor mauris. Aenean quis imperdiet nulla, a viverra purus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Praesent finibus faucibus orci, sed ultrices justo iaculis ut. Ut libero massa, condimentum at elit non, fringilla iaculis quam. Sed sit amet ipsum placerat, tincidunt sem in, efficitur lacus. Curabitur ligula orci, tempus ut magna eget, sodales tristique odio.\nPellentesque in libero ac risus pretium ultrices. In hac habitasse platea dictumst. Curabitur a quam sed orci tempus luctus. Integer commodo nec odio quis consequat. Aenean vitae dapibus augue, nec dictum lectus. Etiam sit amet leo diam. Duis eu ligula venenatis, fermentum lacus vel, interdum odio. Vivamus sit amet libero vitae elit interdum cursus et eu erat. Cras interdum augue sit amet ex aliquet tempor. Praesent dolor nisl, convallis bibendum mauris a, euismod commodo ante. Phasellus non ipsum condimentum, molestie dolor quis, pretium nisi. Mauris augue urna, fermentum ut lacinia a, efficitur vitae odio. Praesent finibus nisl et dolor luctus faucibus. Donec eget lectus sed mi porttitor placerat ac eu odio."
 //      ^^^^^^^^^^ definition 0.1.test `sg/testdata`/LongString.
+//                 kind Constant
 //                 display_name LongString
 //                 signature_documentation
 //                 > const LongString untyped string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed tincidu...
   const ConstMath = 1 + (2+3)*5
 //      ^^^^^^^^^ definition 0.1.test `sg/testdata`/ConstMath.
+//                kind Constant
 //                display_name ConstMath
 //                signature_documentation
 //                > const ConstMath untyped int = 26
   
   type StringAlias string
 //     ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/StringAlias#
+//                 kind Type
 //                 display_name StringAlias
 //                 signature_documentation
 //                 > type StringAlias string
   
   const AliasedString StringAlias = "foobar"
 //      ^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/AliasedString.
+//                    kind Constant
 //                    display_name AliasedString
 //                    signature_documentation
 //                    > const AliasedString StringAlias = "foobar"
@@ -181,31 +204,37 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/TestStruct#Doer().
   func (ts *TestStruct) Doer(ctx context.Context, data string) (score int, err error) {
 //      ^^ definition local 3
+//         kind Variable
 //         display_name ts
 //         signature_documentation
 //         > var ts *TestStruct
 //          ^^^^^^^^^^ reference 0.1.test `sg/testdata`/TestStruct#
 //                      ^^^^ definition 0.1.test `sg/testdata`/TestStruct#Doer().
+//                           kind Method
 //                           display_name Doer
 //                           signature_documentation
 //                           > func (*TestStruct).Doer(ctx context.Context, data string) (score int, err error)
 //                           documentation
 //                           > Doer is similar to the test interface (but not the same).
 //                           ^^^ definition local 4
+//                               kind Variable
 //                               display_name ctx
 //                               signature_documentation
 //                               > var ctx Context
 //                               ^^^^^^^ reference github.com/golang/go/src go1.22 context/
 //                                       ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
 //                                                ^^^^ definition local 5
+//                                                     kind Variable
 //                                                     display_name data
 //                                                     signature_documentation
 //                                                     > var data string
 //                                                              ^^^^^ definition local 6
+//                                                                    kind Variable
 //                                                                    display_name score
 //                                                                    signature_documentation
 //                                                                    > var score int
 //                                                                         ^^^ definition local 7
+//                                                                             kind Variable
 //                                                                             display_name err
 //                                                                             signature_documentation
 //                                                                             > var err error
@@ -220,6 +249,7 @@
   // See https://github.com/tal-tech/go-zero/blob/11dd3d75ecceaa3f5772024fb3f26dec1ada8e9c/core/mapping/unmarshaler_test.go#L2272.
   type StructTagRegression struct {
 //     ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/StructTagRegression#
+//                         kind Struct
 //                         display_name StructTagRegression
 //                         signature_documentation
 //                         > type StructTagRegression struct {
@@ -232,6 +262,7 @@
 //                         > See https://github.com/tal-tech/go-zero/blob/11dd3d75ecceaa3f5772024fb3f26dec1ada8e9c/core/mapping/unmarshaler_test.go#L2272.
    Value int `key:",range=[:}"`
 // ^^^^^ definition 0.1.test `sg/testdata`/StructTagRegression#Value.
+//       kind Field
 //       display_name Value
 //       signature_documentation
 //       > struct field Value int
@@ -239,11 +270,13 @@
   
   type TestEqualsStruct = struct {
 //     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TestEqualsStruct#
+//                      kind TypeAlias
 //                      display_name TestEqualsStruct
 //                      signature_documentation
 //                      > type TestEqualsStruct = struct{ Value int }
    Value int
 // ^^^^^ definition 0.1.test `sg/testdata`/TestEqualsStruct#Value.
+//       kind Field
 //       display_name Value
 //       signature_documentation
 //       > struct field Value int
@@ -251,6 +284,7 @@
   
   type ShellStruct struct {
 //     ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/ShellStruct#
+//                 kind Struct
 //                 display_name ShellStruct
 //                 signature_documentation
 //                 > type ShellStruct struct{ InnerStruct }
@@ -259,6 +293,7 @@
    // tests.
    InnerStruct
 // ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/ShellStruct#InnerStruct.
+//             kind Field
 //             display_name InnerStruct
 //             signature_documentation
 //             > struct field InnerStruct InnerStruct
@@ -271,6 +306,7 @@
   
   type InnerStruct struct{}
 //     ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InnerStruct#
+//                 kind Struct
 //                 display_name InnerStruct
 //                 signature_documentation
 //                 > type InnerStruct struct{}

--- a/internal/testdata/snapshots/output/testdata/duplicate_path_id/main.go
+++ b/internal/testdata/snapshots/output/testdata/duplicate_path_id/main.go
@@ -1,17 +1,20 @@
   package gosrc
 //        ^^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/
+//              kind Package
 //              display_name gosrc
 //              signature_documentation
 //              > package gosrc
   
   type importMeta struct{}
 //     ^^^^^^^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/importMeta#
+//                kind Struct
 //                display_name importMeta
 //                signature_documentation
 //                > type importMeta struct{}
   
   type sourceMeta struct{}
 //     ^^^^^^^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/sourceMeta#
+//                kind Struct
 //                display_name sourceMeta
 //                signature_documentation
 //                > type sourceMeta struct{}
@@ -19,6 +22,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata/duplicate_path_id`/fetchMeta().
   func fetchMeta() (string, *importMeta, *sourceMeta) {
 //     ^^^^^^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/fetchMeta().
+//               kind Function
 //               display_name fetchMeta
 //               signature_documentation
 //               > func fetchMeta() (string, *importMeta, *sourceMeta)
@@ -31,6 +35,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata/duplicate_path_id`/init().
   func init() {}
 //     ^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/init().
+//          kind Function
 //          display_name init
 //          signature_documentation
 //          > func init()
@@ -38,6 +43,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata/duplicate_path_id`/init().
   func init() {}
 //     ^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/init().
+//          kind Function
 //          display_name init
 //          signature_documentation
 //          > func init()
@@ -45,6 +51,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata/duplicate_path_id`/init().
   func init() {}
 //     ^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/init().
+//          kind Function
 //          display_name init
 //          signature_documentation
 //          > func init()

--- a/internal/testdata/snapshots/output/testdata/duplicate_path_id/two.go
+++ b/internal/testdata/snapshots/output/testdata/duplicate_path_id/two.go
@@ -4,6 +4,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata/duplicate_path_id`/init().
   func init() {}
 //     ^^^^ definition 0.1.test `sg/testdata/duplicate_path_id`/init().
+//          kind Function
 //          display_name init
 //          signature_documentation
 //          > func init()

--- a/internal/testdata/snapshots/output/testdata/external_composite.go
+++ b/internal/testdata/snapshots/output/testdata/external_composite.go
@@ -6,6 +6,7 @@
   
   type NestedHandler struct {
 //     ^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/NestedHandler#
+//                   kind Struct
 //                   display_name NestedHandler
 //                   signature_documentation
 //                   > type NestedHandler struct {
@@ -16,12 +17,14 @@
    http.Handler
 // ^^^^ reference github.com/golang/go/src go1.22 `net/http`/
 //      ^^^^^^^ definition 0.1.test `sg/testdata`/NestedHandler#Handler.
+//              kind Field
 //              display_name Handler
 //              signature_documentation
 //              > struct field Handler http.Handler
 //      ^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/Handler#
    Other int
 // ^^^^^ definition 0.1.test `sg/testdata`/NestedHandler#Other.
+//       kind Field
 //       display_name Other
 //       signature_documentation
 //       > struct field Other int

--- a/internal/testdata/snapshots/output/testdata/implementations.go
+++ b/internal/testdata/snapshots/output/testdata/implementations.go
@@ -3,17 +3,20 @@
   
   type I0 interface{}
 //     ^^ definition 0.1.test `sg/testdata`/I0#
+//        kind Interface
 //        display_name I0
 //        signature_documentation
 //        > type I0 interface{}
   
   type I1 interface {
 //     ^^ definition 0.1.test `sg/testdata`/I1#
+//        kind Interface
 //        display_name I1
 //        signature_documentation
 //        > type I1 interface{ F1() }
    F1()
 // ^^ definition 0.1.test `sg/testdata`/I1#F1.
+//    kind MethodSpecification
 //    display_name F1
 //    signature_documentation
 //    > func (I1).F1()
@@ -21,11 +24,13 @@
   
   type I2 interface {
 //     ^^ definition 0.1.test `sg/testdata`/I2#
+//        kind Interface
 //        display_name I2
 //        signature_documentation
 //        > type I2 interface{ F2() }
    F2()
 // ^^ definition 0.1.test `sg/testdata`/I2#F2.
+//    kind MethodSpecification
 //    display_name F2
 //    signature_documentation
 //    > func (I2).F2()
@@ -33,6 +38,7 @@
   
   type T1 int
 //     ^^ definition 0.1.test `sg/testdata`/T1#
+//        kind Type
 //        display_name T1
 //        signature_documentation
 //        > type T1 int
@@ -41,11 +47,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/T1#F1().
   func (r T1) F1() {}
 //      ^ definition local 0
+//        kind Variable
 //        display_name r
 //        signature_documentation
 //        > var r T1
 //        ^^ reference 0.1.test `sg/testdata`/T1#
 //            ^^ definition 0.1.test `sg/testdata`/T1#F1().
+//               kind Method
 //               display_name F1
 //               signature_documentation
 //               > func (T1).F1()
@@ -54,6 +62,7 @@
   
   type T2 int
 //     ^^ definition 0.1.test `sg/testdata`/T2#
+//        kind Type
 //        display_name T2
 //        signature_documentation
 //        > type T2 int
@@ -63,11 +72,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/T2#F1().
   func (r T2) F1() {}
 //      ^ definition local 1
+//        kind Variable
 //        display_name r
 //        signature_documentation
 //        > var r T2
 //        ^^ reference 0.1.test `sg/testdata`/T2#
 //            ^^ definition 0.1.test `sg/testdata`/T2#F1().
+//               kind Method
 //               display_name F1
 //               signature_documentation
 //               > func (T2).F1()
@@ -76,11 +87,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/T2#F2().
   func (r T2) F2() {}
 //      ^ definition local 2
+//        kind Variable
 //        display_name r
 //        signature_documentation
 //        > var r T2
 //        ^^ reference 0.1.test `sg/testdata`/T2#
 //            ^^ definition 0.1.test `sg/testdata`/T2#F2().
+//               kind Method
 //               display_name F2
 //               signature_documentation
 //               > func (T2).F2()
@@ -89,12 +102,14 @@
   
   type A1 = T1
 //     ^^ definition 0.1.test `sg/testdata`/A1#
+//        kind TypeAlias
 //        display_name A1
 //        signature_documentation
 //        > type A1 = T1
 //          ^^ reference 0.1.test `sg/testdata`/T1#
   type A12 = A1
 //     ^^^ definition 0.1.test `sg/testdata`/A12#
+//         kind TypeAlias
 //         display_name A12
 //         signature_documentation
 //         > type A12 = A1
@@ -102,11 +117,13 @@
   
   type InterfaceWithNonExportedMethod interface {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithNonExportedMethod#
+//                                    kind Interface
 //                                    display_name InterfaceWithNonExportedMethod
 //                                    signature_documentation
 //                                    > type InterfaceWithNonExportedMethod interface{ nonExportedMethod() }
    nonExportedMethod()
 // ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithNonExportedMethod#nonExportedMethod.
+//                   kind MethodSpecification
 //                   display_name nonExportedMethod
 //                   signature_documentation
 //                   > func (InterfaceWithNonExportedMethod).nonExportedMethod()
@@ -114,11 +131,13 @@
   
   type InterfaceWithExportedMethod interface {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithExportedMethod#
+//                                 kind Interface
 //                                 display_name InterfaceWithExportedMethod
 //                                 signature_documentation
 //                                 > type InterfaceWithExportedMethod interface{ ExportedMethod() }
    ExportedMethod()
 // ^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithExportedMethod#ExportedMethod.
+//                kind MethodSpecification
 //                display_name ExportedMethod
 //                signature_documentation
 //                > func (InterfaceWithExportedMethod).ExportedMethod()
@@ -126,6 +145,7 @@
   
   type Foo int
 //     ^^^ definition 0.1.test `sg/testdata`/Foo#
+//         kind Type
 //         display_name Foo
 //         signature_documentation
 //         > type Foo int
@@ -137,11 +157,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/Foo#nonExportedMethod().
   func (r Foo) nonExportedMethod() {}
 //      ^ definition local 3
+//        kind Variable
 //        display_name r
 //        signature_documentation
 //        > var r Foo
 //        ^^^ reference 0.1.test `sg/testdata`/Foo#
 //             ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/Foo#nonExportedMethod().
+//                               kind Method
 //                               display_name nonExportedMethod
 //                               signature_documentation
 //                               > func (Foo).nonExportedMethod()
@@ -150,11 +172,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/Foo#ExportedMethod().
   func (r Foo) ExportedMethod()    {}
 //      ^ definition local 4
+//        kind Variable
 //        display_name r
 //        signature_documentation
 //        > var r Foo
 //        ^^^ reference 0.1.test `sg/testdata`/Foo#
 //             ^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/Foo#ExportedMethod().
+//                            kind Method
 //                            display_name ExportedMethod
 //                            signature_documentation
 //                            > func (Foo).ExportedMethod()
@@ -163,11 +187,13 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/Foo#ScipTestMethod().
   func (r Foo) ScipTestMethod()    {}
 //      ^ definition local 5
+//        kind Variable
 //        display_name r
 //        signature_documentation
 //        > var r Foo
 //        ^^^ reference 0.1.test `sg/testdata`/Foo#
 //             ^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/Foo#ScipTestMethod().
+//                            kind Method
 //                            display_name ScipTestMethod
 //                            signature_documentation
 //                            > func (Foo).ScipTestMethod()
@@ -177,6 +203,7 @@
   
   type SharedOne interface {
 //     ^^^^^^^^^ definition 0.1.test `sg/testdata`/SharedOne#
+//               kind Interface
 //               display_name SharedOne
 //               signature_documentation
 //               > type SharedOne interface {
@@ -185,11 +212,13 @@
 //               > }
    Shared()
 // ^^^^^^ definition 0.1.test `sg/testdata`/SharedOne#Shared.
+//        kind MethodSpecification
 //        display_name Shared
 //        signature_documentation
 //        > func (SharedOne).Shared()
    Distinct()
 // ^^^^^^^^ definition 0.1.test `sg/testdata`/SharedOne#Distinct.
+//          kind MethodSpecification
 //          display_name Distinct
 //          signature_documentation
 //          > func (SharedOne).Distinct()
@@ -197,6 +226,7 @@
   
   type SharedTwo interface {
 //     ^^^^^^^^^ definition 0.1.test `sg/testdata`/SharedTwo#
+//               kind Interface
 //               display_name SharedTwo
 //               signature_documentation
 //               > type SharedTwo interface {
@@ -205,11 +235,13 @@
 //               > }
    Shared()
 // ^^^^^^ definition 0.1.test `sg/testdata`/SharedTwo#Shared.
+//        kind MethodSpecification
 //        display_name Shared
 //        signature_documentation
 //        > func (SharedTwo).Shared()
    Unique()
 // ^^^^^^ definition 0.1.test `sg/testdata`/SharedTwo#Unique.
+//        kind MethodSpecification
 //        display_name Unique
 //        signature_documentation
 //        > func (SharedTwo).Unique()
@@ -217,6 +249,7 @@
   
   type Between struct{}
 //     ^^^^^^^ definition 0.1.test `sg/testdata`/Between#
+//             kind Struct
 //             display_name Between
 //             signature_documentation
 //             > type Between struct{}
@@ -227,6 +260,7 @@
   func (Between) Shared()   {}
 //      ^^^^^^^ reference 0.1.test `sg/testdata`/Between#
 //               ^^^^^^ definition 0.1.test `sg/testdata`/Between#Shared().
+//                      kind Method
 //                      display_name Shared
 //                      signature_documentation
 //                      > func (Between).Shared()
@@ -237,6 +271,7 @@
   func (Between) Distinct() {}
 //      ^^^^^^^ reference 0.1.test `sg/testdata`/Between#
 //               ^^^^^^^^ definition 0.1.test `sg/testdata`/Between#Distinct().
+//                        kind Method
 //                        display_name Distinct
 //                        signature_documentation
 //                        > func (Between).Distinct()
@@ -246,6 +281,7 @@
   func (Between) Unique()   {}
 //      ^^^^^^^ reference 0.1.test `sg/testdata`/Between#
 //               ^^^^^^ definition 0.1.test `sg/testdata`/Between#Unique().
+//                      kind Method
 //                      display_name Unique
 //                      signature_documentation
 //                      > func (Between).Unique()
@@ -255,10 +291,12 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/shouldShow().
   func shouldShow(shared SharedOne) {
 //     ^^^^^^^^^^ definition 0.1.test `sg/testdata`/shouldShow().
+//                kind Function
 //                display_name shouldShow
 //                signature_documentation
 //                > func shouldShow(shared SharedOne)
 //                ^^^^^^ definition local 6
+//                       kind Variable
 //                       display_name shared
 //                       signature_documentation
 //                       > var shared SharedOne

--- a/internal/testdata/snapshots/output/testdata/implementations_embedded.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_embedded.go
@@ -3,11 +3,13 @@
   
   type I3 interface {
 //     ^^ definition 0.1.test `sg/testdata`/I3#
+//        kind Interface
 //        display_name I3
 //        signature_documentation
 //        > type I3 interface{ ScipTestMethod() }
    ScipTestMethod()
 // ^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/I3#ScipTestMethod.
+//                kind MethodSpecification
 //                display_name ScipTestMethod
 //                signature_documentation
 //                > func (I3).ScipTestMethod()
@@ -15,11 +17,13 @@
   
   type EmbeddedI3 interface {
 //     ^^^^^^^^^^ definition 0.1.test `sg/testdata`/EmbeddedI3#
+//                kind Interface
 //                display_name EmbeddedI3
 //                signature_documentation
 //                > type EmbeddedI3 interface{ ScipTestMethod() }
    ScipTestMethod()
 // ^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/EmbeddedI3#ScipTestMethod.
+//                kind MethodSpecification
 //                display_name ScipTestMethod
 //                signature_documentation
 //                > func (EmbeddedI3).ScipTestMethod()
@@ -29,6 +33,7 @@
   
   type TClose struct {
 //     ^^^^^^ definition 0.1.test `sg/testdata`/TClose#
+//            kind Struct
 //            display_name TClose
 //            signature_documentation
 //            > type TClose struct{ EmbeddedI3 }
@@ -36,6 +41,7 @@
 //            relationship 0.1.test `sg/testdata`/I3# implementation
    EmbeddedI3
 // ^^^^^^^^^^ definition 0.1.test `sg/testdata`/TClose#EmbeddedI3.
+//            kind Field
 //            display_name EmbeddedI3
 //            signature_documentation
 //            > struct field EmbeddedI3 EmbeddedI3

--- a/internal/testdata/snapshots/output/testdata/implementations_methods.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_methods.go
@@ -3,11 +3,13 @@
   
   type InterfaceWithSingleMethod interface {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithSingleMethod#
+//                               kind Interface
 //                               display_name InterfaceWithSingleMethod
 //                               signature_documentation
 //                               > type InterfaceWithSingleMethod interface{ SingleMethod() float64 }
    SingleMethod() float64
 // ^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithSingleMethod#SingleMethod.
+//              kind MethodSpecification
 //              display_name SingleMethod
 //              signature_documentation
 //              > func (InterfaceWithSingleMethod).SingleMethod() float64
@@ -15,6 +17,7 @@
   
   type StructWithMethods struct{}
 //     ^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/StructWithMethods#
+//                       kind Struct
 //                       display_name StructWithMethods
 //                       signature_documentation
 //                       > type StructWithMethods struct{}
@@ -24,6 +27,7 @@
   func (StructWithMethods) SingleMethod() float64 { return 5.0 }
 //      ^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/StructWithMethods#
 //                         ^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/StructWithMethods#SingleMethod().
+//                                      kind Method
 //                                      display_name SingleMethod
 //                                      signature_documentation
 //                                      > func (StructWithMethods).SingleMethod() float64
@@ -32,11 +36,13 @@
   
   type InterfaceWithSingleMethodTwoImplementers interface {
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithSingleMethodTwoImplementers#
+//                                              kind Interface
 //                                              display_name InterfaceWithSingleMethodTwoImplementers
 //                                              signature_documentation
 //                                              > type InterfaceWithSingleMethodTwoImplementers interface{ SingleMethodTwoImpl() float64 }
    SingleMethodTwoImpl() float64
 // ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/InterfaceWithSingleMethodTwoImplementers#SingleMethodTwoImpl.
+//                     kind MethodSpecification
 //                     display_name SingleMethodTwoImpl
 //                     signature_documentation
 //                     > func (InterfaceWithSingleMethodTwoImplementers).SingleMethodTwoImpl() float64
@@ -44,6 +50,7 @@
   
   type TwoImplOne struct{}
 //     ^^^^^^^^^^ definition 0.1.test `sg/testdata`/TwoImplOne#
+//                kind Struct
 //                display_name TwoImplOne
 //                signature_documentation
 //                > type TwoImplOne struct{}
@@ -53,6 +60,7 @@
   func (TwoImplOne) SingleMethodTwoImpl() float64 { return 5.0 }
 //      ^^^^^^^^^^ reference 0.1.test `sg/testdata`/TwoImplOne#
 //                  ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TwoImplOne#SingleMethodTwoImpl().
+//                                      kind Method
 //                                      display_name SingleMethodTwoImpl
 //                                      signature_documentation
 //                                      > func (TwoImplOne).SingleMethodTwoImpl() float64
@@ -61,6 +69,7 @@
   
   type TwoImplTwo struct{}
 //     ^^^^^^^^^^ definition 0.1.test `sg/testdata`/TwoImplTwo#
+//                kind Struct
 //                display_name TwoImplTwo
 //                signature_documentation
 //                > type TwoImplTwo struct{}
@@ -70,6 +79,7 @@
   func (TwoImplTwo) SingleMethodTwoImpl() float64         { return 5.0 }
 //      ^^^^^^^^^^ reference 0.1.test `sg/testdata`/TwoImplTwo#
 //                  ^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TwoImplTwo#SingleMethodTwoImpl().
+//                                      kind Method
 //                                      display_name SingleMethodTwoImpl
 //                                      signature_documentation
 //                                      > func (TwoImplTwo).SingleMethodTwoImpl() float64
@@ -79,6 +89,7 @@
   func (TwoImplTwo) RandomThingThatDoesntMatter() float64 { return 5.0 }
 //      ^^^^^^^^^^ reference 0.1.test `sg/testdata`/TwoImplTwo#
 //                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/TwoImplTwo#RandomThingThatDoesntMatter().
+//                                              kind Method
 //                                              display_name RandomThingThatDoesntMatter
 //                                              signature_documentation
 //                                              > func (TwoImplTwo).RandomThingThatDoesntMatter() float64

--- a/internal/testdata/snapshots/output/testdata/implementations_remote.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_remote.go
@@ -6,6 +6,7 @@
   
   type implementsWriter struct{}
 //     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/implementsWriter#
+//                      kind Struct
 //                      display_name implementsWriter
 //                      signature_documentation
 //                      > type implementsWriter struct{}
@@ -18,6 +19,7 @@
   func (implementsWriter) Header() http.Header        { panic("Just for how") }
 //      ^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/implementsWriter#
 //                        ^^^^^^ definition 0.1.test `sg/testdata`/implementsWriter#Header().
+//                               kind Method
 //                               display_name Header
 //                               signature_documentation
 //                               > func (implementsWriter).Header() http.Header
@@ -29,6 +31,7 @@
   func (implementsWriter) Write([]byte) (int, error)  { panic("Just for show") }
 //      ^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/implementsWriter#
 //                        ^^^^^ definition 0.1.test `sg/testdata`/implementsWriter#Write().
+//                              kind Method
 //                              display_name Write
 //                              signature_documentation
 //                              > func (implementsWriter).Write([]byte) (int, error)
@@ -41,11 +44,13 @@
   func (implementsWriter) WriteHeader(statusCode int) {}
 //      ^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/implementsWriter#
 //                        ^^^^^^^^^^^ definition 0.1.test `sg/testdata`/implementsWriter#WriteHeader().
+//                                    kind Method
 //                                    display_name WriteHeader
 //                                    signature_documentation
 //                                    > func (implementsWriter).WriteHeader(statusCode int)
 //                                    relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#WriteHeader. implementation
 //                                    ^^^^^^^^^^ definition local 0
+//                                               kind Variable
 //                                               display_name statusCode
 //                                               signature_documentation
 //                                               > var statusCode int
@@ -54,10 +59,12 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/ShowsInSignature().
   func ShowsInSignature(respWriter http.ResponseWriter) {
 //     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/ShowsInSignature().
+//                      kind Function
 //                      display_name ShowsInSignature
 //                      signature_documentation
 //                      > func ShowsInSignature(respWriter http.ResponseWriter)
 //                      ^^^^^^^^^^ definition local 1
+//                                 kind Variable
 //                                 display_name respWriter
 //                                 signature_documentation
 //                                 > var respWriter ResponseWriter

--- a/internal/testdata/snapshots/output/testdata/internal/secret/doc.go
+++ b/internal/testdata/snapshots/output/testdata/internal/secret/doc.go
@@ -1,6 +1,7 @@
   // secret is a package that holds secrets.
   package secret
 //        ^^^^^^ definition 0.1.test `sg/testdata/internal/secret`/
+//               kind Package
 //               display_name secret
 //               signature_documentation
 //               > package secret

--- a/internal/testdata/snapshots/output/testdata/internal/secret/secret.go
+++ b/internal/testdata/snapshots/output/testdata/internal/secret/secret.go
@@ -4,6 +4,7 @@
   // SecretScore is like score but _secret_.
   const SecretScore = uint64(43)
 //      ^^^^^^^^^^^ definition 0.1.test `sg/testdata/internal/secret`/SecretScore.
+//                  kind Constant
 //                  display_name SecretScore
 //                  signature_documentation
 //                  > const SecretScore uint64 = 43
@@ -13,6 +14,7 @@
   // Original doc
   type Burger struct {
 //     ^^^^^^ definition 0.1.test `sg/testdata/internal/secret`/Burger#
+//            kind Struct
 //            display_name Burger
 //            signature_documentation
 //            > type Burger struct{ Field int }
@@ -20,6 +22,7 @@
 //            > Original doc
    Field int
 // ^^^^^ definition 0.1.test `sg/testdata/internal/secret`/Burger#Field.
+//       kind Field
 //       display_name Field
 //       signature_documentation
 //       > struct field Field int

--- a/internal/testdata/snapshots/output/testdata/named_import.go
+++ b/internal/testdata/snapshots/output/testdata/named_import.go
@@ -12,6 +12,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/Example().
   func Example() {
 //     ^^^^^^^ definition 0.1.test `sg/testdata`/Example().
+//             kind Function
 //             display_name Example
 //             signature_documentation
 //             > func Example()

--- a/internal/testdata/snapshots/output/testdata/parallel.go
+++ b/internal/testdata/snapshots/output/testdata/parallel.go
@@ -12,6 +12,7 @@
   // of this function type.
   type ParallelizableFunc func(ctx context.Context) error
 //     ^^^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/ParallelizableFunc#
+//                        kind Type
 //                        display_name ParallelizableFunc
 //                        signature_documentation
 //                        > type ParallelizableFunc func(ctx context.Context) error
@@ -19,6 +20,7 @@
 //                        > ParallelizableFunc is a function that can be called concurrently with other instances
 //                        > of this function type.
 //                             ^^^ definition local 0
+//                                 kind Variable
 //                                 display_name ctx
 //                                 signature_documentation
 //                                 > var ctx Context
@@ -30,6 +32,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/Parallel().
   func Parallel(ctx context.Context, fns ...ParallelizableFunc) error {
 //     ^^^^^^^^ definition 0.1.test `sg/testdata`/Parallel().
+//              kind Function
 //              display_name Parallel
 //              signature_documentation
 //              > func Parallel(ctx context.Context, fns ...ParallelizableFunc) error
@@ -37,18 +40,21 @@
 //              > Parallel invokes each of the given parallelizable functions in their own goroutines and
 //              > returns the first error to occur. This method will block until all goroutines have returned.
 //              ^^^ definition local 1
+//                  kind Variable
 //                  display_name ctx
 //                  signature_documentation
 //                  > var ctx Context
 //                  ^^^^^^^ reference github.com/golang/go/src go1.22 context/
 //                          ^^^^^^^ reference github.com/golang/go/src go1.22 context/Context#
 //                                   ^^^ definition local 2
+//                                       kind Variable
 //                                       display_name fns
 //                                       signature_documentation
 //                                       > var fns []ParallelizableFunc
 //                                          ^^^^^^^^^^^^^^^^^^ reference 0.1.test `sg/testdata`/ParallelizableFunc#
    var wg sync.WaitGroup
 //     ^^ definition local 3
+//        kind Variable
 //        display_name wg
 //        signature_documentation
 //        > var wg WaitGroup
@@ -56,6 +62,7 @@
 //             ^^^^^^^^^ reference github.com/golang/go/src go1.22 sync/WaitGroup#
    errs := make(chan error, len(fns))
 // ^^^^ definition local 4
+//      kind Variable
 //      display_name errs
 //      signature_documentation
 //      > var errs chan error
@@ -63,6 +70,7 @@
   
    for _, fn := range fns {
 //        ^^ definition local 5
+//           kind Variable
 //           display_name fn
 //           signature_documentation
 //           > var fn ParallelizableFunc
@@ -73,6 +81,7 @@
   
     go func(fn ParallelizableFunc) {
 //          ^^ definition local 6
+//             kind Variable
 //             display_name fn
 //             signature_documentation
 //             > var fn ParallelizableFunc
@@ -94,6 +103,7 @@
   
    for err := range errs {
 //     ^^^ definition local 7
+//         kind Variable
 //         display_name err
 //         signature_documentation
 //         > var err error

--- a/internal/testdata/snapshots/output/testdata/typealias.go
+++ b/internal/testdata/snapshots/output/testdata/typealias.go
@@ -9,6 +9,7 @@
   // Type aliased doc
   type SecretBurger = secret.Burger
 //     ^^^^^^^^^^^^ definition 0.1.test `sg/testdata`/SecretBurger#
+//                  kind TypeAlias
 //                  display_name SecretBurger
 //                  signature_documentation
 //                  > type SecretBurger = secret.Burger
@@ -19,11 +20,13 @@
   
   type BadBurger = struct {
 //     ^^^^^^^^^ definition 0.1.test `sg/testdata`/BadBurger#
+//               kind TypeAlias
 //               display_name BadBurger
 //               signature_documentation
 //               > type BadBurger = struct{ Field string }
    Field string
 // ^^^^^ definition 0.1.test `sg/testdata`/BadBurger#Field.
+//       kind Field
 //       display_name Field
 //       signature_documentation
 //       > struct field Field string

--- a/internal/testdata/snapshots/output/testdata/typeswitch.go
+++ b/internal/testdata/snapshots/output/testdata/typeswitch.go
@@ -4,15 +4,18 @@
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/Switch().
   func Switch(interfaceValue interface{}) bool {
 //     ^^^^^^ definition 0.1.test `sg/testdata`/Switch().
+//            kind Function
 //            display_name Switch
 //            signature_documentation
 //            > func Switch(interfaceValue interface{}) bool
 //            ^^^^^^^^^^^^^^ definition local 0
+//                           kind Variable
 //                           display_name interfaceValue
 //                           signature_documentation
 //                           > var interfaceValue interface{}
    switch concreteValue := interfaceValue.(type) {
 //        ^^^^^^^^^^^^^ definition local 1
+//                      kind Variable
 //                      display_name concreteValue
 //                         ^^^^^^^^^^^^^^ reference local 0
    case int:

--- a/internal/testdata/snapshots/output/testspecial/foo.go
+++ b/internal/testdata/snapshots/output/testspecial/foo.go
@@ -1,5 +1,6 @@
   package testspecial
 //        ^^^^^^^^^^^ definition 0.1.test `sg/testspecial`/
+//                    kind Package
 //                    display_name testspecial
 //                    signature_documentation
 //                    > package testspecial
@@ -7,6 +8,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/testspecial`/Foo().
   func Foo() {}
 //     ^^^ definition 0.1.test `sg/testspecial`/Foo().
+//         kind Function
 //         display_name Foo
 //         signature_documentation
 //         > func Foo()

--- a/internal/testdata/snapshots/output/testspecial/foo_other_test.go
+++ b/internal/testdata/snapshots/output/testspecial/foo_other_test.go
@@ -1,5 +1,6 @@
   package testspecial_test
 //        ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testspecial_test`/
+//                         kind Package
 //                         display_name testspecial_test
 //                         signature_documentation
 //                         > package testspecial_test
@@ -15,6 +16,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/testspecial_test`/TestFoo_Blackbox().
   func TestFoo_Blackbox(*testing.T) { testspecial.Foo() }
 //     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testspecial_test`/TestFoo_Blackbox().
+//                      kind Function
 //                      display_name TestFoo_Blackbox
 //                      signature_documentation
 //                      > func TestFoo_Blackbox(*testing.T)

--- a/internal/testdata/snapshots/output/testspecial/foo_test.go
+++ b/internal/testdata/snapshots/output/testspecial/foo_test.go
@@ -4,6 +4,7 @@
 //⌄ enclosing_range_start 0.1.test `sg/testspecial`/TestFoo_Whitebox().
   func TestFoo_Whitebox() { Foo() }
 //     ^^^^^^^^^^^^^^^^ definition 0.1.test `sg/testspecial`/TestFoo_Whitebox().
+//                      kind Function
 //                      display_name TestFoo_Whitebox
 //                      signature_documentation
 //                      > func TestFoo_Whitebox()

--- a/internal/visitors/visitor_file.go
+++ b/internal/visitors/visitor_file.go
@@ -354,6 +354,7 @@ func (v *fileVisitor) ToScipDocument() *scip.Document {
 
 		if obj := local.Obj; obj != nil {
 			symbolInfo.DisplayName = obj.Name()
+			symbolInfo.Kind = symbols.KindForObject(obj)
 			// Skip SignatureDocumentation for type-switch locals because
 			// multiple case clauses share the same obj.Pos(), making the
 			// type recorded in caseClauses nondeterministic.


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/scip-go/issues/176