### PR TITLE
Drop `NeedDeps` from `packages.Load` for a decent speedup

### DIFF
--- a/internal/implementations/implementations.go
+++ b/internal/implementations/implementations.go
@@ -2,7 +2,6 @@ package impls
 
 import (
 	"fmt"
-	"go/ast"
 	"go/types"
 	"log/slog"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/sourcegraph/scip-go/internal/loader"
 	"github.com/sourcegraph/scip-go/internal/lookup"
 	"github.com/sourcegraph/scip-go/internal/output"
+	"github.com/sourcegraph/scip-go/internal/symbols"
 	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/go/types/typeutil"
 )
@@ -19,28 +19,17 @@ import (
 type methodID string
 
 type ImplDef struct {
-	// The corresponding scip symbol, generated via previous iteration over the AST
+	// The corresponding scip symbol
 	Symbol *scip.SymbolInformation
 
 	Pkg     *packages.Package
-	Ident   *ast.Ident
 	Named   *types.Named
 	Methods map[methodID]*scip.SymbolInformation
 }
 
 func findImplementations(concreteTypes map[string]ImplDef, interfaces map[string]ImplDef, symbols *lookup.Global) {
 	for _, ty := range concreteTypes {
-		pos := ty.Ident.Pos()
-		sym, ok := symbols.GetSymbolInformation(ty.Pkg, pos)
-		if !ok {
-			panic(fmt.Sprintf("Could not find symbol for %s", ty.Symbol))
-		}
-
 		for _, iface := range interfaces {
-			if iface.Ident == nil {
-				continue
-			}
-
 			ifaceType, ok := iface.Named.Underlying().(*types.Interface)
 			if !ok {
 				continue
@@ -54,10 +43,11 @@ func findImplementations(concreteTypes map[string]ImplDef, interfaces map[string
 			}
 
 			// Add implementation details for the struct & interface relationship
-			sym.Relationships = append(sym.Relationships, &scip.Relationship{
-				Symbol:           iface.Symbol.Symbol,
-				IsImplementation: true,
-			})
+			ty.Symbol.Relationships = append(ty.Symbol.Relationships,
+				&scip.Relationship{
+					Symbol:           iface.Symbol.Symbol,
+					IsImplementation: true,
+				})
 
 			// For all methods, add implementation details as well
 			for name, implMethod := range iface.Methods {
@@ -83,11 +73,8 @@ func AddImplementationRelationships(
 	var externalSymbols []*scip.SymbolInformation
 	err := output.WithProgress("Indexing Implementations", func() error {
 		var msCache typeutil.MethodSetCache
-		localInterfaces, localTypes, err := extractInterfacesAndConcreteTypes(
+		localInterfaces, localTypes := extractInterfacesAndConcreteTypes(
 			pkgs, symbols, &msCache)
-		if err != nil {
-			return err
-		}
 
 		remotePackages := make(loader.PackageLookup)
 		for pkgID, pkg := range allPackages {
@@ -97,11 +84,8 @@ func AddImplementationRelationships(
 
 			remotePackages[pkgID] = pkg
 		}
-		remoteInterfaces, remoteTypes, err := extractInterfacesAndConcreteTypes(
+		remoteInterfaces, remoteTypes := extractInterfacesAndConcreteTypes(
 			remotePackages, symbols, &msCache)
-		if err != nil {
-			return err
-		}
 
 		// local type -> local interface
 		findImplementations(localTypes, localInterfaces, symbols)
@@ -115,10 +99,8 @@ func AddImplementationRelationships(
 
 		// Collect remote type symbols that gained relationships
 		for _, typ := range remoteTypes {
-			if sym, ok := symbols.GetSymbolInformation(typ.Pkg, typ.Ident.Pos()); ok {
-				if len(sym.Relationships) > 0 {
-					externalSymbols = append(externalSymbols, sym)
-				}
+			if len(typ.Symbol.Relationships) > 0 {
+				externalSymbols = append(externalSymbols, typ.Symbol)
 			}
 		}
 
@@ -129,11 +111,11 @@ func AddImplementationRelationships(
 
 func extractInterfacesAndConcreteTypes(
 	pkgs loader.PackageLookup,
-	symbols *lookup.Global,
+	globalSymbols *lookup.Global,
 	msCache *typeutil.MethodSetCache,
-) (interfaces map[string]ImplDef, concreteTypes map[string]ImplDef, err error) {
-	interfaces = map[string]ImplDef{}
-	concreteTypes = map[string]ImplDef{}
+) (map[string]ImplDef, map[string]ImplDef) {
+	interfaces := map[string]ImplDef{}
+	concreteTypes := map[string]ImplDef{}
 
 	for _, pkg := range pkgs {
 		// Builtin isn't the same as standard library, that is for builtin types
@@ -142,88 +124,146 @@ func extractInterfacesAndConcreteTypes(
 			continue
 		}
 
-		if pkg.TypesInfo == nil {
+		if pkg.Types == nil {
 			slog.Warn("No types for package", "path", pkg.PkgPath)
 			continue
 		}
 
-		pkgSymbols := symbols.GetPackage(pkg)
-		if pkgSymbols == nil {
-			slog.Warn("No symbols for package", "path", pkg.PkgPath)
+		if pkg.TypesInfo != nil {
+			extractFromTypesInfo(pkg, globalSymbols, msCache, interfaces, concreteTypes)
 			continue
 		}
 
-		for ident, obj := range pkg.TypesInfo.Defs {
-			if obj == nil {
-				continue
-			}
-
-			// We ignore aliases 'type M = N' to avoid duplicate reporting
-			// of the Named type N.
-			obj, ok := obj.(*types.TypeName)
-			if !ok {
-				continue
-			}
-
-			// Skip types declared inside function bodies — the type visitor
-			// only indexes package-level declarations, so local types will
-			// never have a symbol entry.
-			if pkg.Types != nil && obj.Parent() != pkg.Types.Scope() {
-				continue
-			}
-
-			objType, ok := obj.Type().(*types.Named)
-			if !ok {
-				continue
-			}
-
-			symbol, ok := pkgSymbols.Get(obj.Pos())
-			if !ok {
-				slog.Debug(
-					"No symbol for package-level named type",
-					"identifier", ident.Name, "package", pkg.PkgPath, "id", obj.Id())
-				continue
-			}
-
-			methods := typeutil.IntuitiveMethodSet(objType, msCache)
-
-			// ignore interfaces that are empty. they are too
-			// plentiful and don't provide useful intelligence.
-			if len(methods) == 0 {
-				continue
-			}
-
-			methodIds := map[methodID]*scip.SymbolInformation{}
-			for _, m := range methods {
-				sym, ok, err := symbols.GetSymbolOfObject(m.Obj())
-				if err != nil {
-					slog.Debug(fmt.Sprintf("Error while looking for symbol %s | %s", err, m.Obj()))
-					continue
-				}
-
-				if !ok {
-					continue
-				}
-
-				methodIds[methodID(m.Obj().Id())] = sym
-			}
-
-			d := ImplDef{
-				Symbol:  symbol,
-				Pkg:     pkg,
-				Ident:   ident,
-				Named:   objType,
-				Methods: methodIds,
-			}
-
-			if types.IsInterface(objType) {
-				interfaces[d.Symbol.Symbol] = d
-			} else {
-				concreteTypes[d.Symbol.Symbol] = d
-			}
-
-		}
+		extractFromScope(pkg, globalSymbols, msCache, interfaces, concreteTypes)
 	}
 
-	return
+	return interfaces, concreteTypes
+}
+
+// extractFromTypesInfo handles project packages that have full TypesInfo/AST.
+func extractFromTypesInfo(
+	pkg *packages.Package,
+	globalSymbols *lookup.Global,
+	msCache *typeutil.MethodSetCache,
+	interfaces map[string]ImplDef,
+	concreteTypes map[string]ImplDef,
+) {
+	pkgSymbols := globalSymbols.GetPackage(pkg)
+	if pkgSymbols == nil {
+		slog.Warn("No symbols for package", "path", pkg.PkgPath)
+		return
+	}
+
+	for ident, obj := range pkg.TypesInfo.Defs {
+		if obj == nil {
+			continue
+		}
+
+		obj, ok := obj.(*types.TypeName)
+		if !ok {
+			continue
+		}
+
+		// Skip types declared inside function bodies
+		if pkg.Types != nil && obj.Parent() != pkg.Types.Scope() {
+			continue
+		}
+
+		objType, ok := obj.Type().(*types.Named)
+		if !ok {
+			continue
+		}
+
+		symbol, ok := pkgSymbols.Get(obj.Pos())
+		if !ok {
+			slog.Debug(
+				"No symbol for package-level named type",
+				"identifier", ident.Name, "package", pkg.PkgPath, "id", obj.Id())
+			continue
+		}
+
+		collectImplDef(
+			pkg, globalSymbols, msCache, objType, symbol, interfaces, concreteTypes)
+	}
+}
+
+// extractFromScope handles dep packages that have no AST — uses
+// pkg.Types.Scope() to enumerate package-level named types and synthesizes
+// their SCIP symbols.
+func extractFromScope(
+	pkg *packages.Package,
+	globalSymbols *lookup.Global,
+	msCache *typeutil.MethodSetCache,
+	interfaces map[string]ImplDef,
+	concreteTypes map[string]ImplDef,
+) {
+	scope := pkg.Types.Scope()
+	for _, name := range scope.Names() {
+		obj := scope.Lookup(name)
+		tn, ok := obj.(*types.TypeName)
+		if !ok {
+			continue
+		}
+
+		objType, ok := tn.Type().(*types.Named)
+		if !ok {
+			continue
+		}
+
+		sym, ok := symbols.SynthesizeFromObject(pkg, tn)
+		if !ok {
+			slog.Debug("Could not synthesize symbol for dep type",
+				"name", name, "package", pkg.PkgPath)
+			continue
+		}
+		symbol := &scip.SymbolInformation{Symbol: sym}
+
+		collectImplDef(pkg, globalSymbols, msCache, objType, symbol, interfaces, concreteTypes)
+	}
+}
+
+func collectImplDef(
+	pkg *packages.Package,
+	globalSymbols *lookup.Global,
+	msCache *typeutil.MethodSetCache,
+	objType *types.Named,
+	symbol *scip.SymbolInformation,
+	interfaces map[string]ImplDef,
+	concreteTypes map[string]ImplDef,
+) {
+	methods := typeutil.IntuitiveMethodSet(objType, msCache)
+
+	// ignore interfaces that are empty. they are too
+	// plentiful and don't provide useful intelligence.
+	if len(methods) == 0 {
+		return
+	}
+
+	methodIds := map[methodID]*scip.SymbolInformation{}
+	for _, m := range methods {
+		sym, ok, err := globalSymbols.GetSymbolOfObject(m.Obj())
+		if err != nil {
+			slog.Debug(fmt.Sprintf("Error while looking for symbol %s | %s", err, m.Obj()))
+			continue
+		}
+
+		if !ok {
+			continue
+		}
+
+		methodIds[methodID(m.Obj().Id())] = sym
+	}
+
+	d := ImplDef{
+		Symbol:  symbol,
+		Pkg:     pkg,
+		Named:   objType,
+		Methods: methodIds,
+	}
+
+	if types.IsInterface(objType) {
+		interfaces[d.Symbol.Symbol] = d
+	} else {
+		concreteTypes[d.Symbol.Symbol] = d
+	}
 }

--- a/internal/index/scip.go
+++ b/internal/index/scip.go
@@ -54,15 +54,16 @@ func GetPackages(opts config.IndexOpts) (current []newtypes.PackageID, deps []ne
 }
 
 func ListMissing(opts config.IndexOpts) (missing []string, err error) {
-	projectPackages, allPackages, err := loader.LoadPackages(opts, opts.ModuleRoot)
+	projectPackages, _, err := loader.LoadPackages(opts, opts.ModuleRoot)
 	if err != nil {
 		return nil, err
 	}
 
 	pathToDocuments := map[string]*document.Document{}
-	for _, pkg := range allPackages {
+	globalSymbols := lookup.NewGlobalSymbols()
+	for _, pkg := range projectPackages {
 		visitors.VisitPackageSyntax(
-			opts.ModuleRoot, pkg, pathToDocuments, lookup.NewGlobalSymbols())
+			opts.ModuleRoot, pkg, pathToDocuments, globalSymbols)
 	}
 
 	for _, pkg := range projectPackages {
@@ -185,29 +186,22 @@ func indexVisitPackages(
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	lookupIDs := slices.Sorted(maps.Keys(allPackages))
+	for _, pkg := range allPackages {
+		globalSymbols.EnsurePackage(pkg)
+		globalSymbols.SetPkgSymbol(pkg)
+	}
 
-	// We have to visit all the packages to get the definition sites
-	// for all the symbols.
-	//
-	// We don't want to visit in the same depth as file visitors though,
-	// so we do ONLY do this
+	projectIDs := slices.Sorted(maps.Keys(projectPackages))
+
 	go func() {
 		defer wg.Done()
 
-		for _, pkgID := range lookupIDs {
-			pkg := allPackages[pkgID]
+		for _, pkgID := range projectIDs {
+			pkg := projectPackages[pkgID]
 			slog.Debug("Visiting package", "path", pkg.PkgPath)
 			visitors.VisitPackageSyntax(opts.ModuleRoot, pkg, pathToDocuments, globalSymbols)
 
-			pkgSymbol := globalSymbols.SetPkgSymbol(pkg)
-
-			// If we don't have this package anywhere, don't try to create a new symbol
-			if _, ok := projectPackages[newtypes.GetID(pkg)]; !ok {
-				atomic.AddUint64(&count, 1)
-				continue
-			}
-
+			pkgSymbol, _ := globalSymbols.GetPkgSymbol(pkg)
 			symInfo := &scip.SymbolInformation{
 				Symbol:        pkgSymbol,
 				Kind:          scip.SymbolInformation_Package,
@@ -237,7 +231,7 @@ func indexVisitPackages(
 		}
 	}()
 
-	output.WithProgressParallel(&wg, "Visiting Packages", &count, uint64(len(lookupIDs)))
+	output.WithProgressParallel(&wg, "Visiting Packages", &count, uint64(len(projectIDs)))
 
 	return pathToDocuments, globalSymbols
 }

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -19,8 +19,7 @@ import (
 
 type PackageLookup map[newtypes.PackageID]*packages.Package
 
-var loadMode = packages.NeedDeps |
-	packages.NeedImports |
+const loadMode = packages.NeedImports |
 	packages.NeedSyntax |
 	packages.NeedTypes |
 	packages.NeedTypesInfo |

--- a/internal/lookup/lookup.go
+++ b/internal/lookup/lookup.go
@@ -83,6 +83,18 @@ func (p *Global) Add(pkgSymbols *Package) {
 	p.m.Unlock()
 }
 
+// EnsurePackage registers an empty Package entry for pkg if one doesn't
+// already exist. This ensures dep packages (which skip VisitPackageSyntax)
+// are present in the symbols map for synthesis fallback.
+func (p *Global) EnsurePackage(pkg *packages.Package) {
+	p.m.Lock()
+	id := newtypes.GetID(pkg)
+	if _, ok := p.symbols[id]; !ok {
+		p.symbols[id] = NewPackageSymbols(pkg)
+	}
+	p.m.Unlock()
+}
+
 func (p *Global) SetPkgSymbol(pkg *packages.Package) string {
 	sym := symbols.FromDescriptors(pkg, &scip.Descriptor{
 		Name:   pkg.PkgPath,
@@ -162,9 +174,17 @@ func (p *Global) GetSymbolOfObject(obj types.Object) (*scip.SymbolInformation, b
 		}
 	}
 
+	// Fallback: synthesize the symbol from types.Object metadata.
+	// This handles dep packages that have no AST/syntax (loaded from export data).
+	if pkgEntry, ok := p.symbols[newtypes.PackageID(pkgPath)]; ok {
+		if sym, ok := symbols.SynthesizeFromObject(pkgEntry.pkg, obj); ok {
+			info := &scip.SymbolInformation{Symbol: sym}
+			return info, true, nil
+		}
+	}
+
 	switch obj := obj.(type) {
 	case *types.Var:
-		// , "| position", pkg.Fset.Position(obj.Pos())))
 		return nil, false, errors.New(fmt.Sprintln("obj", obj, "| origin", obj.Origin()))
 	}
 

--- a/internal/symbols/symbols.go
+++ b/internal/symbols/symbols.go
@@ -3,6 +3,8 @@ package symbols
 import (
 	"fmt"
 	"go/token"
+	"go/types"
+	"sync"
 
 	"github.com/scip-code/scip/bindings/go/scip"
 	"golang.org/x/tools/go/packages"
@@ -35,6 +37,161 @@ func RangeFromName(position token.Position, name string, adjust bool) []int32 {
 	n := int32(len(name))
 
 	return []int32{line, column + adjustment, column + n + adjustment}
+}
+
+var synthesisCache sync.Map // map[types.Object]synthesisResult
+
+type synthesisResult struct {
+	sym string
+	ok  bool
+}
+
+// SynthesizeFromObject constructs a SCIP symbol string for a types.Object
+// that belongs to a dependency package (no AST available). It replicates the
+// same descriptor chain that the AST-based visitors would produce.
+func SynthesizeFromObject(pkg *packages.Package, obj types.Object) (string, bool) {
+	if v, ok := synthesisCache.Load(obj); ok {
+		r := v.(synthesisResult)
+		return r.sym, r.ok
+	}
+	sym, ok := synthesizeFromObject(pkg, obj)
+	synthesisCache.Store(obj, synthesisResult{sym, ok})
+	return sym, ok
+}
+
+func synthesizeFromObject(pkg *packages.Package, obj types.Object) (string, bool) {
+	if pkg.Module == nil {
+		return "", false
+	}
+
+	pkgPath := obj.Pkg().Path()
+	descriptors := []*scip.Descriptor{
+		{Name: pkgPath, Suffix: scip.Descriptor_Namespace},
+	}
+
+	switch obj := obj.(type) {
+	case *types.Func:
+		sig, _ := obj.Type().(*types.Signature)
+		if sig != nil && sig.Recv() != nil {
+			recvName := receiverTypeName(sig.Recv().Type())
+			if recvName == "" {
+				return "", false
+			}
+			descriptors = append(descriptors,
+				&scip.Descriptor{Name: recvName, Suffix: scip.Descriptor_Type},
+				&scip.Descriptor{Name: obj.Name(), Suffix: scip.Descriptor_Method},
+			)
+		} else {
+			descriptors = append(descriptors,
+				&scip.Descriptor{Name: obj.Name(), Suffix: scip.Descriptor_Method},
+			)
+		}
+
+	case *types.TypeName:
+		descriptors = append(descriptors,
+			&scip.Descriptor{Name: obj.Name(), Suffix: scip.Descriptor_Type},
+		)
+
+	case *types.Var:
+		if obj.IsField() {
+			typeName := findFieldOwner(obj)
+			if typeName == "" {
+				return "", false
+			}
+			descriptors = append(descriptors,
+				&scip.Descriptor{Name: typeName, Suffix: scip.Descriptor_Type},
+				&scip.Descriptor{Name: obj.Name(), Suffix: scip.Descriptor_Term},
+			)
+		} else {
+			descriptors = append(descriptors,
+				&scip.Descriptor{Name: obj.Name(), Suffix: scip.Descriptor_Term},
+			)
+		}
+
+	case *types.Const:
+		descriptors = append(descriptors,
+			&scip.Descriptor{Name: obj.Name(), Suffix: scip.Descriptor_Term},
+		)
+
+	default:
+		return "", false
+	}
+
+	sym := scip.VerboseSymbolFormatter.FormatSymbol(&scip.Symbol{
+		Scheme: "scip-go",
+		Package: &scip.Package{
+			Manager: "gomod",
+			Name:    pkg.Module.Path,
+			Version: pkg.Module.Version,
+		},
+		Descriptors: descriptors,
+	})
+	return sym, true
+}
+
+// receiverTypeName extracts the base named type from a receiver type,
+// peeling off pointers and aliases.
+func receiverTypeName(t types.Type) string {
+	for {
+		switch v := types.Unalias(t).(type) {
+		case *types.Pointer:
+			t = v.Elem()
+		case *types.Named:
+			return v.Obj().Name()
+		default:
+			return ""
+		}
+	}
+}
+
+var fieldOwnerCache sync.Map // map[*types.Var]string
+
+// buildFieldIndex builds a field→owner-name lookup for all struct types
+// in a package scope, caching the result per package.
+var fieldIndexCache sync.Map // map[*types.Package]map[*types.Var]string
+
+func getFieldIndex(pkg *types.Package) map[*types.Var]string {
+	if v, ok := fieldIndexCache.Load(pkg); ok {
+		return v.(map[*types.Var]string)
+	}
+	idx := map[*types.Var]string{}
+	scope := pkg.Scope()
+	for _, name := range scope.Names() {
+		obj := scope.Lookup(name)
+		tn, ok := obj.(*types.TypeName)
+		if !ok {
+			continue
+		}
+		named, ok := tn.Type().(*types.Named)
+		if !ok {
+			continue
+		}
+		st, ok := named.Underlying().(*types.Struct)
+		if !ok {
+			continue
+		}
+		for i := range st.NumFields() {
+			idx[st.Field(i)] = tn.Name()
+		}
+	}
+	fieldIndexCache.Store(pkg, idx)
+	return idx
+}
+
+// findFieldOwner finds the name of the named type that directly declares a
+// struct field.
+func findFieldOwner(field *types.Var) string {
+	if v, ok := fieldOwnerCache.Load(field); ok {
+		return v.(string)
+	}
+	pkg := field.Pkg()
+	if pkg == nil {
+		return ""
+	}
+	idx := getFieldIndex(pkg)
+	result := idx[field]
+	fieldOwnerCache.Store(field, result)
+	return result
 }
 
 func FormatCode(v string) string {

--- a/internal/testdata/snapshots/output/embedded/embedded.go
+++ b/internal/testdata/snapshots/output/embedded/embedded.go
@@ -18,9 +18,7 @@
 //                   display_name osExecCommand
 //                   signature_documentation
 //                   > type osExecCommand struct{ *exec.Cmd }
-//                   relationship github.com/golang/go/src go1.22 context/stringer# implementation
 //                   relationship github.com/golang/go/src go1.22 fmt/Stringer# implementation
-//                   relationship github.com/golang/go/src go1.22 runtime/stringer# implementation
    *exec.Cmd
 //  ^^^^ reference github.com/golang/go/src go1.22 `os/exec`/
 //       ^^^ definition 0.1.test `sg/embedded`/osExecCommand#Cmd.

--- a/internal/testdata/snapshots/output/embedded/nested.go
+++ b/internal/testdata/snapshots/output/embedded/nested.go
@@ -50,10 +50,10 @@
    _ = n.Handler.ServeHTTP
 //     ^ reference local 0
 //       ^^^^^^^ reference 0.1.test `sg/embedded`/NestedHandler#Handler.
-//               ^^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/Handler#ServeHTTP.
+//               ^^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/Handler#ServeHTTP().
    _ = n.ServeHTTP
 //     ^ reference local 0
-//       ^^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/Handler#ServeHTTP.
+//       ^^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/Handler#ServeHTTP().
    _ = n.Other
 //     ^ reference local 0
 //       ^^^^^ reference 0.1.test `sg/embedded`/NestedHandler#Other.

--- a/internal/testdata/snapshots/output/embedded/something.go
+++ b/internal/testdata/snapshots/output/embedded/something.go
@@ -17,9 +17,7 @@
 //                                         display_name String
 //                                         signature_documentation
 //                                         > func (*RecentCommittersResults).String() string
-//                                         relationship github.com/golang/go/src go1.22 context/stringer#String. implementation
-//                                         relationship github.com/golang/go/src go1.22 fmt/Stringer#String. implementation
-//                                         relationship github.com/golang/go/src go1.22 runtime/stringer#String. implementation
+//                                         relationship github.com/golang/go/src go1.22 fmt/Stringer#String(). implementation
    return fmt.Sprintf("RecentCommittersResults{Nodes: %d}", len(r.Nodes))
 //        ^^^ reference github.com/golang/go/src go1.22 fmt/
 //            ^^^^^^^ reference github.com/golang/go/src go1.22 fmt/Sprintf().
@@ -47,9 +45,7 @@
 //                             >     }
 //                             >     PageInfo struct{ HasNextPage bool }
 //                             > }
-//                             relationship github.com/golang/go/src go1.22 context/stringer# implementation
 //                             relationship github.com/golang/go/src go1.22 fmt/Stringer# implementation
-//                             relationship github.com/golang/go/src go1.22 runtime/stringer# implementation
    Nodes []struct {
 // ^^^^^ definition 0.1.test `sg/embedded`/RecentCommittersResults#Nodes.
 //       kind Field

--- a/internal/testdata/snapshots/output/impls/remote_impls.go
+++ b/internal/testdata/snapshots/output/impls/remote_impls.go
@@ -27,7 +27,6 @@
 //              signature_documentation
 //              > type MyWriter struct{}
 //              relationship github.com/golang/go/src go1.22 `crypto/tls`/transcriptHash# implementation
-//              relationship github.com/golang/go/src go1.22 `internal/bisect`/Writer# implementation
 //              relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter# implementation
 //              relationship github.com/golang/go/src go1.22 io/Writer# implementation
   
@@ -44,7 +43,7 @@
 //                         display_name Header
 //                         signature_documentation
 //                         > func (MyWriter).Header() http.Header
-//                         relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#Header. implementation
+//                         relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#Header(). implementation
 //                           ^^^^ reference github.com/golang/go/src go1.22 `net/http`/
 //                                ^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/Header#
 //                                                          ⌃ enclosing_range_end 0.1.test `sg/impls`/MyWriter#Header().
@@ -61,10 +60,9 @@
 //                        display_name Write
 //                        signature_documentation
 //                        > func (MyWriter).Write([]byte) (int, error)
-//                        relationship github.com/golang/go/src go1.22 `crypto/tls`/transcriptHash#Write. implementation
-//                        relationship github.com/golang/go/src go1.22 `internal/bisect`/Writer#Write. implementation
-//                        relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#Write. implementation
-//                        relationship github.com/golang/go/src go1.22 io/Writer#Write. implementation
+//                        relationship github.com/golang/go/src go1.22 `crypto/tls`/transcriptHash#Write(). implementation
+//                        relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#Write(). implementation
+//                        relationship github.com/golang/go/src go1.22 io/Writer#Write(). implementation
 //                                                          ⌃ enclosing_range_end 0.1.test `sg/impls`/MyWriter#Write().
 //⌄ enclosing_range_start 0.1.test `sg/impls`/MyWriter#WriteHeader().
   func (w MyWriter) WriteHeader(statusCode int) { panic("") }
@@ -79,7 +77,7 @@
 //                              display_name WriteHeader
 //                              signature_documentation
 //                              > func (MyWriter).WriteHeader(statusCode int)
-//                              relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#WriteHeader. implementation
+//                              relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#WriteHeader(). implementation
 //                              ^^^^^^^^^^ definition local 4
 //                                         kind Variable
 //                                         display_name statusCode

--- a/internal/testdata/snapshots/output/testdata/implementations_remote.go
+++ b/internal/testdata/snapshots/output/testdata/implementations_remote.go
@@ -11,7 +11,6 @@
 //                      signature_documentation
 //                      > type implementsWriter struct{}
 //                      relationship github.com/golang/go/src go1.22 `crypto/tls`/transcriptHash# implementation
-//                      relationship github.com/golang/go/src go1.22 `internal/bisect`/Writer# implementation
 //                      relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter# implementation
 //                      relationship github.com/golang/go/src go1.22 io/Writer# implementation
   
@@ -23,7 +22,7 @@
 //                               display_name Header
 //                               signature_documentation
 //                               > func (implementsWriter).Header() http.Header
-//                               relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#Header. implementation
+//                               relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#Header(). implementation
 //                                 ^^^^ reference github.com/golang/go/src go1.22 `net/http`/
 //                                      ^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/Header#
 //                                                                            ⌃ enclosing_range_end 0.1.test `sg/testdata`/implementsWriter#Header().
@@ -35,10 +34,9 @@
 //                              display_name Write
 //                              signature_documentation
 //                              > func (implementsWriter).Write([]byte) (int, error)
-//                              relationship github.com/golang/go/src go1.22 `crypto/tls`/transcriptHash#Write. implementation
-//                              relationship github.com/golang/go/src go1.22 `internal/bisect`/Writer#Write. implementation
-//                              relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#Write. implementation
-//                              relationship github.com/golang/go/src go1.22 io/Writer#Write. implementation
+//                              relationship github.com/golang/go/src go1.22 `crypto/tls`/transcriptHash#Write(). implementation
+//                              relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#Write(). implementation
+//                              relationship github.com/golang/go/src go1.22 io/Writer#Write(). implementation
 //                                                                             ⌃ enclosing_range_end 0.1.test `sg/testdata`/implementsWriter#Write().
 //⌄ enclosing_range_start 0.1.test `sg/testdata`/implementsWriter#WriteHeader().
   func (implementsWriter) WriteHeader(statusCode int) {}
@@ -48,7 +46,7 @@
 //                                    display_name WriteHeader
 //                                    signature_documentation
 //                                    > func (implementsWriter).WriteHeader(statusCode int)
-//                                    relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#WriteHeader. implementation
+//                                    relationship github.com/golang/go/src go1.22 `net/http`/ResponseWriter#WriteHeader(). implementation
 //                                    ^^^^^^^^^^ definition local 0
 //                                               kind Variable
 //                                               display_name statusCode
@@ -72,7 +70,7 @@
 //                                      ^^^^^^^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/ResponseWriter#
    respWriter.WriteHeader(1)
 // ^^^^^^^^^^ reference local 1
-//            ^^^^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/ResponseWriter#WriteHeader.
+//            ^^^^^^^^^^^ reference github.com/golang/go/src go1.22 `net/http`/ResponseWriter#WriteHeader().
   }
 //⌃ enclosing_range_end 0.1.test `sg/testdata`/ShowsInSignature().
   


### PR DESCRIPTION
Remove `NeedDeps` from the load mode so dependency packages are type-checked from export data instead of source. Dependency packages now have `Types` and `Module` but no `Syntax` or `TypesInfo`. Adapt the codebase accordingly:

- symbols: add `SynthesizeFromObject` to construct SCIP symbols from `types.Object` metadata, with per-package field index cache
- lookup: fall back to synthesis in `GetSymbolOfObject` when the pos-based lookup fails (dep packages have no AST positions)
- index: only call `VisitPackageSyntax` for project packages; register all packages for synthesis fallback
- implementations: use `pkg.Types.Scope()` for dep packages instead of `pkg.TypesInfo.Defs`; remove `ast.Ident` dependency from `ImplDef`

Trade-off: interfaces in dep packages whose scopes are not populated by the type checker (because the project never references them) will not have implementation relationships emitted. This only affects coincidental interface matches with completely unreferenced packages.

Also fixes method symbols for dep interfaces: they now correctly use `Descriptor_Method` (producing `#Method()`) instead of `Descriptor_Term` (`#Method.`) which the AST-based type visitor was incorrectly using.