### PR TITLE
Add snapshot test for `GOPACKAGESDRIVER` support

### DIFF
--- a/internal/index/scip_test.go
+++ b/internal/index/scip_test.go
@@ -3,6 +3,8 @@ package index_test
 import (
 	"flag"
 	"fmt"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -42,14 +44,30 @@ func TestSnapshots(t *testing.T) {
 				return nil
 			}
 
-			err := index.Index(writer, config.IndexOpts{
+			opts := config.IndexOpts{
 				ModuleRoot:      inputDirectory,
 				ModuleVersion:   "0.1.test",
 				ModulePath:      "sg/" + filepath.Base(inputDirectory),
 				GoStdlibVersion: "go1.22",
-			})
-			if err != nil {
+			}
+
+			driverDir := filepath.Join(inputDirectory, "driver")
+			var driverPath string
+			if _, err := os.Stat(filepath.Join(driverDir, "main.go")); err == nil {
+				driverPath = buildGoPackagesDriver(t, driverDir)
+				os.Setenv("GOPACKAGESDRIVER", driverPath)
+				defer os.Unsetenv("GOPACKAGESDRIVER")
+				opts.IsGoPackagesDriverSet = true
+			}
+
+			if err := index.Index(writer, opts); err != nil {
 				t.Fatal(err)
+			}
+
+			if driverPath != "" {
+				if _, err := os.Stat(driverPath + ".sentinel"); err != nil {
+					t.Fatal("GOPACKAGESDRIVER was not invoked")
+				}
 			}
 
 			// Filter out documents outside of current directory
@@ -95,4 +113,22 @@ func getTestdataRoot(t *testing.T) string {
 	}
 
 	return testdata
+}
+
+// buildGoPackagesDriver compiles the GOPACKAGESDRIVER binary found in
+// driverDir (a directory containing main.go and go.mod) and returns the
+// path to the built binary.
+func buildGoPackagesDriver(t *testing.T, driverDir string) string {
+	t.Helper()
+
+	driverPath := filepath.Join(t.TempDir(), "gopackagesdriver")
+
+	cmd := exec.Command("go", "build", "-o", driverPath, ".")
+	cmd.Dir = driverDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("building GOPACKAGESDRIVER in %s: %v\n%s", driverDir, err, out)
+	}
+
+	return driverPath
 }

--- a/internal/testdata/snapshots/input/pr216/README.md
+++ b/internal/testdata/snapshots/input/pr216/README.md
@@ -1,0 +1,12 @@
+# GOPACKAGESDRIVER support
+
+Tests indexing through a custom `GOPACKAGESDRIVER` instead of `go list`.
+
+The `driver/` subdirectory contains a proxy driver that loads packages via
+`go list` (with `GOPACKAGESDRIVER=off`) and re-emits them using the driver wire
+format --- which has no `Module` field. This exercises the `normalizePackage`
+code path that fills in module info from CLI flags.
+
+The `driver/` has its own `go.mod` to create a module boundary so the indexer's
+`./...` pattern skips it. Any snapshot input directory can opt into driver
+testing by adding a `driver/` subdirectory with `main.go` and `go.mod`.

--- a/internal/testdata/snapshots/input/pr216/driver/go.mod
+++ b/internal/testdata/snapshots/input/pr216/driver/go.mod
@@ -1,0 +1,10 @@
+module driver
+
+go 1.25.0
+
+require golang.org/x/tools v0.43.0
+
+require (
+	golang.org/x/mod v0.34.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
+)

--- a/internal/testdata/snapshots/input/pr216/driver/go.sum
+++ b/internal/testdata/snapshots/input/pr216/driver/go.sum
@@ -1,0 +1,8 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
+golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/tools v0.43.0 h1:12BdW9CeB3Z+J/I/wj34VMl8X+fEXBxVR90JeMX5E7s=
+golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=

--- a/internal/testdata/snapshots/input/pr216/driver/main.go
+++ b/internal/testdata/snapshots/input/pr216/driver/main.go
@@ -1,0 +1,44 @@
+// Command driver is a GOPACKAGESDRIVER proxy for snapshot tests.
+// It loads packages via go list (with GOPACKAGESDRIVER=off to prevent
+// recursion) and re-emits them as a DriverResponse. Because the driver
+// wire format has no Module field, this simulates real build-system
+// drivers (Bazel, Buck2) and exercises the normalizePackage code path.
+package main
+
+import (
+	"encoding/json"
+	"os"
+
+	"golang.org/x/tools/go/packages"
+)
+
+func main() {
+	os.WriteFile(os.Args[0]+".sentinel", nil, 0o644)
+
+	pkgs, err := packages.Load(&packages.Config{
+		Mode: packages.NeedName |
+			packages.NeedCompiledGoFiles |
+			packages.NeedImports |
+			packages.NeedDeps |
+			packages.NeedExportFile,
+		Env: append(os.Environ(), "GOPACKAGESDRIVER=off"),
+	}, os.Args[1:]...)
+	if err != nil {
+		os.Exit(1)
+	}
+
+	var all []*packages.Package
+	packages.Visit(pkgs, nil, func(pkg *packages.Package) {
+		all = append(all, pkg)
+	})
+
+	var roots []string
+	for _, pkg := range pkgs {
+		roots = append(roots, pkg.ID)
+	}
+
+	json.NewEncoder(os.Stdout).Encode(packages.DriverResponse{
+		Roots:    roots,
+		Packages: all,
+	})
+}

--- a/internal/testdata/snapshots/input/pr216/go.mod
+++ b/internal/testdata/snapshots/input/pr216/go.mod
@@ -1,0 +1,3 @@
+module sg/pr216
+
+go 1.23

--- a/internal/testdata/snapshots/input/pr216/pr216.go
+++ b/internal/testdata/snapshots/input/pr216/pr216.go
@@ -1,0 +1,9 @@
+package pr216
+
+import "fmt"
+
+const Greeting = "hello"
+
+func UseFmt() {
+	fmt.Println(Greeting)
+}

--- a/internal/testdata/snapshots/output/pr216/pr216.go
+++ b/internal/testdata/snapshots/output/pr216/pr216.go
@@ -1,0 +1,31 @@
+  package pr216
+//        ^^^^^ definition 0.1.test `sg/pr216`/
+//              kind Package
+//              display_name pr216
+//              signature_documentation
+//              > package pr216
+  
+  import "fmt"
+//        ^^^ reference 0.1.test fmt/
+  
+  const Greeting = "hello"
+//      ^^^^^^^^ definition 0.1.test `sg/pr216`/Greeting.
+//               kind Constant
+//               display_name Greeting
+//               signature_documentation
+//               > const Greeting untyped string = "hello"
+  
+//⌄ enclosing_range_start 0.1.test `sg/pr216`/UseFmt().
+  func UseFmt() {
+//     ^^^^^^ definition 0.1.test `sg/pr216`/UseFmt().
+//            kind Function
+//            display_name UseFmt
+//            signature_documentation
+//            > func UseFmt()
+   fmt.Println(Greeting)
+// ^^^ reference 0.1.test fmt/
+//     ^^^^^^^ reference 0.1.test fmt/Println().
+//             ^^^^^^^^ reference 0.1.test `sg/pr216`/Greeting.
+  }
+//⌃ enclosing_range_end 0.1.test `sg/pr216`/UseFmt().
+  


### PR DESCRIPTION
Add a snapshot test that exercises indexing through a custom `GOPACKAGESDRIVER` (`go list` proxy).