### PR TITLE
Defer `hasSameRepoRoot` call

### DIFF
--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -228,8 +228,8 @@ func normalizePackage(opts *config.IndexOpts, pkg *packages.Package) *packages.P
 	}
 
 	if pkg.Module.Version == "" {
-		if hasSameRepoRoot(pkg.Module.Path, opts.ModulePath) ||
-			isNestedDir(pkg.Module.Dir, opts.ModuleRoot) {
+		if isNestedDir(pkg.Module.Dir, opts.ModuleRoot) ||
+			hasSameRepoRoot(pkg.Module.Path, opts.ModulePath) {
 			pkg.Module.Version = opts.ModuleVersion
 		} else {
 			slog.Debug(fmt.Sprintf(


### PR DESCRIPTION
On my machine this decreases Kubernetes indexing time from >7m to ~20s.