### PR TITLE
Attach `scip-go` arguments to the generated index

### DIFF
--- a/cmd/scip-go/main.go
+++ b/cmd/scip-go/main.go
@@ -95,7 +95,27 @@ func makeOptions(shared *SharedFlags) (config.IndexOpts, error) {
 		slog.Info("Skipping tests")
 	}
 
-	return config.New(moduleRoot, shared.ModuleVersion, modulePath, shared.GoVersion, isStdLib, shared.SkipImplementations, shared.SkipTests, shared.PackagePatterns), nil
+	driver, isPackagesDriverSet := os.LookupEnv("GOPACKAGESDRIVER")
+	if isPackagesDriverSet {
+		if driver == "off" {
+			isPackagesDriverSet = false
+		} else {
+			slog.Info("GOPACKAGESDRIVER", "driver", driver)
+		}
+	}
+
+	return config.IndexOpts{
+		ModuleRoot:            moduleRoot,
+		ModuleVersion:         shared.ModuleVersion,
+		ModulePath:            modulePath,
+		GoStdlibVersion:       shared.GoVersion,
+		IsIndexingStdlib:      isStdLib,
+		SkipImplementations:   shared.SkipImplementations,
+		SkipTests:             shared.SkipTests,
+		PackagePatterns:       shared.PackagePatterns,
+		Arguments:             os.Args[1:],
+		IsGoPackagesDriverSet: isPackagesDriverSet,
+	}, nil
 }
 
 func (cmd *IndexCmd) Run() error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,10 +1,5 @@
 package config
 
-import (
-	"os"
-	"path/filepath"
-)
-
 type IndexOpts struct {
 	ModuleRoot    string
 	ModuleVersion string
@@ -25,26 +20,7 @@ type IndexOpts struct {
 
 	// Package patterns to index
 	PackagePatterns []string
-}
 
-func New(ModuleRoot, ModuleVersion, ModulePath, GoStdlibVersion string, IsIndexingStdlib bool, SkipImplementations bool, SkipTests bool, PackagePatterns []string) IndexOpts {
-	ModuleRoot, err := filepath.Abs(ModuleRoot)
-	if err != nil {
-		panic(err)
-	}
-
-	driver := os.Getenv("GOPACKAGESDRIVER")
-	isGoPackagesDriverSet := driver != "" && driver != "off"
-
-	return IndexOpts{
-		ModuleRoot:            ModuleRoot,
-		ModuleVersion:         ModuleVersion,
-		ModulePath:            ModulePath,
-		GoStdlibVersion:       GoStdlibVersion,
-		SkipImplementations:   SkipImplementations,
-		SkipTests:             SkipTests,
-		IsIndexingStdlib:      IsIndexingStdlib,
-		PackagePatterns:       PackagePatterns,
-		IsGoPackagesDriverSet: isGoPackagesDriverSet,
-	}
+	// Arguments passed to the CLI
+	Arguments []string
 }

--- a/internal/index/scip.go
+++ b/internal/index/scip.go
@@ -5,6 +5,7 @@ import (
 	"go/ast"
 	"log/slog"
 	"maps"
+	"net/url"
 	"slices"
 	"sort"
 	"strings"
@@ -80,14 +81,15 @@ func ListMissing(opts config.IndexOpts) (missing []string, err error) {
 func Index(writer func(proto.Message) error, opts config.IndexOpts) error {
 	// Emit Metadata.
 	//   NOTE: Must be the first field emitted
+	projectRoot := url.URL{Scheme: "file", Path: opts.ModuleRoot}
 	if err := writer(&scip.Metadata{
-		Version: 0,
+		Version: scip.ProtocolVersion_UnspecifiedProtocolVersion,
 		ToolInfo: &scip.ToolInfo{
 			Name:      "scip-go",
 			Version:   ScipGoVersion,
-			Arguments: []string{},
+			Arguments: opts.Arguments,
 		},
-		ProjectRoot:          "file://" + opts.ModuleRoot,
+		ProjectRoot:          projectRoot.String(),
 		TextDocumentEncoding: scip.TextEncoding_UTF8,
 	}); err != nil {
 		return err


### PR DESCRIPTION
Helpful for debugging customer issues