### PR TITLE
Remove unused `pkgLookup` from `fileVisitor`

### DIFF
--- a/internal/index/scip.go
+++ b/internal/index/scip.go
@@ -141,7 +141,6 @@ func Index(writer func(proto.Message) error, opts config.IndexOpts) error {
 					doc,
 					pkg,
 					file,
-					allPackages,
 					pkgSymbols,
 					globalSymbols,
 				)

--- a/internal/visitors/visitor_file.go
+++ b/internal/visitors/visitor_file.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 
 	"github.com/scip-code/scip-go/internal/document"
-	"github.com/scip-code/scip-go/internal/loader"
 	"github.com/scip-code/scip-go/internal/lookup"
 	"github.com/scip-code/scip-go/internal/newtypes"
 	"github.com/scip-code/scip-go/internal/symbols"
@@ -20,7 +19,6 @@ func NewFileVisitor(
 	doc *document.Document,
 	pkg *packages.Package,
 	file *ast.File,
-	pkgLookup loader.PackageLookup,
 	pkgSymbols *lookup.Package,
 	globalSymbols *lookup.Global,
 ) *fileVisitor {
@@ -40,7 +38,6 @@ func NewFileVisitor(
 		doc:           doc,
 		pkg:           pkg,
 		file:          file,
-		pkgLookup:     pkgLookup,
 		locals:        map[token.Pos]lookup.Local{},
 		pkgSymbols:    pkgSymbols,
 		globalSymbols: globalSymbols,
@@ -60,9 +57,6 @@ type fileVisitor struct {
 	// Current file information
 	pkg  *packages.Package
 	file *ast.File
-
-	// soething
-	pkgLookup loader.PackageLookup
 
 	// local definition position to symbol and its type information
 	locals map[token.Pos]lookup.Local


### PR DESCRIPTION
The `allPackages` map was passed to `NewFileVisitor` but never read from the struct field.