### PR TITLE
Report max RSS and CPU usage in `index` summary

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -112,7 +112,9 @@ jobs:
 
       - name: Run scip-go
         working-directory: target
-        run: scip-go -o "$GITHUB_WORKSPACE/index.scip" -VV
+        run: |
+          /usr/bin/time -v -o "$GITHUB_WORKSPACE/metrics.txt" \
+            scip-go -o "$GITHUB_WORKSPACE/index.scip" -VV
 
       - name: Validate index
         working-directory: target
@@ -127,6 +129,16 @@ jobs:
           scip print --json "$GITHUB_WORKSPACE/index.scip" \
             | jq -e --arg f "${{ matrix.expect_file }}" \
                 'any(.documents[]; .relative_path == $f)'
+
+      - name: Report resource usage
+        run: |
+          {
+            echo "### scip-go: ${{ matrix.name }}"
+            echo '```'
+            grep -E 'Maximum resident|User time|System time|Percent of CPU' \
+              "$GITHUB_WORKSPACE/metrics.txt"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   fingerprint-sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@v22
+        with:
+          summarize: false
       - uses: DeterminateSystems/magic-nix-cache-action@v13
       - run: nix flake check
       - run: nix build .#scip-go
@@ -34,6 +36,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@v22
+        with:
+          summarize: false
       - uses: DeterminateSystems/magic-nix-cache-action@v13
       - run: nix build .#docker
 


### PR DESCRIPTION
Wrap the indexer invocation in `/usr/bin/time -v` and dump the relevant lines to the GitHub step summary.

In the case of this particular PR you can see the data in the workflow summary here: https://github.com/scip-code/scip-go/actions/runs/25102504656?pr=241 (requires scrolling down).

I've also disabled Nix cache summaries as I do not find them very useful and they clutter the output.