### PR TITLE
fix: Quit panicking on named types over error

### DIFF
--- a/internal/lookup/lookup.go
+++ b/internal/lookup/lookup.go
@@ -151,13 +151,7 @@ func (p *Global) GetSymbolOfObject(obj types.Object) (*scip.SymbolInformation, b
 		case *types.Builtin:
 			return nil, false, nil
 		case *types.Func:
-			if orig := obj.Origin(); orig != nil {
-				name := orig.FullName()
-				switch name {
-				case "(error).Error":
-					return nil, false, nil
-				}
-			}
+			return nil, false, nil
 		}
 
 		panic(fmt.Sprintf("failed to create symbol for builtin obj: %T %+v | %s", obj, obj, obj.Id()))

--- a/internal/testdata/snapshots/input/pr258/consumer.go
+++ b/internal/testdata/snapshots/input/pr258/consumer.go
@@ -1,0 +1,11 @@
+package consumer
+
+import "github.com/example/deplib"
+
+var Sentinel deplib.CustomErr
+
+func New() deplib.CustomErr { return nil }
+
+type Wrapper struct {
+	Err deplib.CustomErr
+}

--- a/internal/testdata/snapshots/input/pr258/deplib/errors.go
+++ b/internal/testdata/snapshots/input/pr258/deplib/errors.go
@@ -1,0 +1,3 @@
+package deplib
+
+type CustomErr error

--- a/internal/testdata/snapshots/input/pr258/deplib/go.mod
+++ b/internal/testdata/snapshots/input/pr258/deplib/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/deplib
+
+go 1.22

--- a/internal/testdata/snapshots/input/pr258/go.mod
+++ b/internal/testdata/snapshots/input/pr258/go.mod
@@ -1,0 +1,7 @@
+module sg/pr258
+
+go 1.22
+
+require github.com/example/deplib v0.0.0
+
+replace github.com/example/deplib => ./deplib

--- a/internal/testdata/snapshots/output/pr258/consumer.go
+++ b/internal/testdata/snapshots/output/pr258/consumer.go
@@ -1,0 +1,46 @@
+  package consumer
+//        ^^^^^^^^ definition 0.1.test `sg/pr258`/
+//                 kind Package
+//                 display_name consumer
+//                 signature_documentation
+//                 > package consumer
+  
+  import "github.com/example/deplib"
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^ reference github.com/example/deplib 0.1.test `github.com/example/deplib`/
+  
+  var Sentinel deplib.CustomErr
+//    ^^^^^^^^ definition 0.1.test `sg/pr258`/Sentinel.
+//             kind Variable
+//             display_name Sentinel
+//             signature_documentation
+//             > var Sentinel deplib.CustomErr
+//             ^^^^^^ reference github.com/example/deplib 0.1.test `github.com/example/deplib`/
+//                    ^^^^^^^^^ reference github.com/example/deplib 0.1.test `github.com/example/deplib`/CustomErr#
+  
+//⌄ enclosing_range_start 0.1.test `sg/pr258`/New().
+  func New() deplib.CustomErr { return nil }
+//     ^^^ definition 0.1.test `sg/pr258`/New().
+//         kind Function
+//         display_name New
+//         signature_documentation
+//         > func New() deplib.CustomErr
+//           ^^^^^^ reference github.com/example/deplib 0.1.test `github.com/example/deplib`/
+//                  ^^^^^^^^^ reference github.com/example/deplib 0.1.test `github.com/example/deplib`/CustomErr#
+//                                         ⌃ enclosing_range_end 0.1.test `sg/pr258`/New().
+  
+  type Wrapper struct {
+//     ^^^^^^^ definition 0.1.test `sg/pr258`/Wrapper#
+//             kind Struct
+//             display_name Wrapper
+//             signature_documentation
+//             > type Wrapper struct{ Err deplib.CustomErr }
+   Err deplib.CustomErr
+// ^^^ definition 0.1.test `sg/pr258`/Wrapper#Err.
+//     kind Field
+//     display_name Err
+//     signature_documentation
+//     > struct field Err deplib.CustomErr
+//     ^^^^^^ reference github.com/example/deplib 0.1.test `github.com/example/deplib`/
+//            ^^^^^^^^^ reference github.com/example/deplib 0.1.test `github.com/example/deplib`/CustomErr#
+  }
+  


### PR DESCRIPTION
A panic breaks indexing for any module whose package graph contains a defined type whose underlying type is the built-in `error` interface e.g., `type CustomErr error`. The crash fires during implementation-relationship extraction.

When scip-go walks a dependency's exported types and computes their method sets, the inherited `Error` method on a user-defined wrapper over `error` surfaces as a function whose enclosing package is `nil` but whose receiver has been rebound to the user-defined name `CustomErr`. The guard in `GetSymbolOfObject` recognized only the literal universe receiver, so the rebound form fell through to an unconditional panic.

This change unconditionally skips any function with a `nil` enclosing package during symbol lookup. The only such functions today are methods inherited from universe-block interfaces, which scip-go does not emit symbols for in any case, matching its existing behavior for direct `Error` calls on plain `error`-typed values.