### PR TITLE
Fix panic on bare `PkgName` identifier references

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,8 +82,11 @@
             bad=$(
               # Snapshot outputs are generated with modified
               # indentation for alignment with annotations.
+              # pr261's input intentionally keeps an "unused" import
+              # to reproduce a panic on a bare PkgName ident.
               find . -name '*.go' \
                 -not -path '*/testdata/snapshots/output/*' \
+                -not -path '*/testdata/snapshots/input/pr261/*' \
                 -exec ${pkgs.gotools}/bin/goimports -l {} +
             )
             if [ -n "$bad" ]; then

--- a/internal/testdata/snapshots/input/pr261/README.md
+++ b/internal/testdata/snapshots/input/pr261/README.md
@@ -1,0 +1,8 @@
+# Bare `PkgName` identifier
+
+`var _ = sort` is malformed Go but the parser accepts it and the type checker
+still records `info.Uses[sort] = *types.PkgName`. Well-formed code routes such
+uses through the `*ast.SelectorExpr` handler in `visitor_file.go`; a bare ident
+slips past it into the generic reference path and previously hit the
+`panic("should never lookup PkgName ...")` assertion in `lookup.go`. The visitor
+now skips bare `*types.PkgName` references instead of crashing.

--- a/internal/testdata/snapshots/input/pr261/README.md
+++ b/internal/testdata/snapshots/input/pr261/README.md
@@ -1,8 +1,12 @@
 # Bare `PkgName` identifier
 
-`var _ = sort` is malformed Go but the parser accepts it and the type checker
-still records `info.Uses[sort] = *types.PkgName`. Well-formed code routes such
-uses through the `*ast.SelectorExpr` handler in `visitor_file.go`; a bare ident
-slips past it into the generic reference path and previously hit the
-`panic("should never lookup PkgName ...")` assertion in `lookup.go`. The visitor
-now skips bare `*types.PkgName` references instead of crashing.
+`var _ = sort` is syntactically valid Go but ill-typed; the compiler rejects it
+with `use of package sort not in selector`. The parser still accepts it and the
+type checker, run in best-effort mode by `packages.Load`, still records
+`info.Uses[sort] = *types.PkgName`.
+
+Well-typed code routes such uses through the `*ast.SelectorExpr` handler in
+`visitor_file.go`; a bare ident slips past it into the generic reference path
+and previously hit the `panic("should never lookup PkgName ...")` assertion in
+`lookup.go`. The visitor now skips bare `*types.PkgName` references instead of
+crashing.

--- a/internal/testdata/snapshots/input/pr261/bare_pkg.go
+++ b/internal/testdata/snapshots/input/pr261/bare_pkg.go
@@ -1,0 +1,5 @@
+package pr261
+
+import "sort"
+
+var _ = sort

--- a/internal/testdata/snapshots/input/pr261/go.mod
+++ b/internal/testdata/snapshots/input/pr261/go.mod
@@ -1,0 +1,3 @@
+module sg/pr261
+
+go 1.23

--- a/internal/testdata/snapshots/output/pr261/bare_pkg.go
+++ b/internal/testdata/snapshots/output/pr261/bare_pkg.go
@@ -1,0 +1,12 @@
+  package pr261
+//        ^^^^^ definition 0.1.test `sg/pr261`/
+//              kind Package
+//              display_name pr261
+//              signature_documentation
+//              > package pr261
+  
+  import "sort"
+//        ^^^^ reference github.com/golang/go/src go1.22 sort/
+  
+  var _ = sort
+  

--- a/internal/visitors/visitor_file.go
+++ b/internal/visitors/visitor_file.go
@@ -225,6 +225,10 @@ func (v *fileVisitor) Visit(n ast.Node) ast.Visitor {
 		// Emit Reference
 		ref := info.Uses[node]
 		if ref != nil {
+			if _, ok := ref.(*types.PkgName); ok {
+				return v
+			}
+
 			var (
 				symbol     string
 				deprecated bool


### PR DESCRIPTION
`var _ = sort` (after `import "sort"`) is syntactically valid Go but ill-typed; the compiler rejects it with `use of package sort not in selector`. The parser still accepts it and the type checker, run in best-effort mode by `packages.Load`, still records `info.Uses[sort] = *types.PkgName`.

Well-typed code always wraps such uses in a `*ast.SelectorExpr` which the visitor handles separately; a bare ident slips past it into `GetSymbolOfObject` and trips its `should never lookup PkgName ...` assertion.

Skip bare `*types.PkgName` references in the file visitor so ill-typed source no longer crashes the indexer.