### PR TITLE
Drop `goimports` exception

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,11 +82,8 @@
             bad=$(
               # Snapshot outputs are generated with modified
               # indentation for alignment with annotations.
-              # pr261's input intentionally keeps an "unused" import
-              # to reproduce a panic on a bare PkgName ident.
               find . -name '*.go' \
                 -not -path '*/testdata/snapshots/output/*' \
-                -not -path '*/testdata/snapshots/input/pr261/*' \
                 -exec ${pkgs.gotools}/bin/goimports -l {} +
             )
             if [ -n "$bad" ]; then

--- a/internal/testdata/snapshots/input/pr261/bare_pkg.go
+++ b/internal/testdata/snapshots/input/pr261/bare_pkg.go
@@ -2,4 +2,8 @@ package pr261
 
 import "sort"
 
+// Legitimate use so goimports doesn't strip the import.
+var _ = sort.Slice
+
+// Bare PkgName reference that triggered the panic.
 var _ = sort

--- a/internal/testdata/snapshots/output/pr261/bare_pkg.go
+++ b/internal/testdata/snapshots/output/pr261/bare_pkg.go
@@ -8,5 +8,11 @@
   import "sort"
 //        ^^^^ reference github.com/golang/go/src go1.22 sort/
   
+  // Legitimate use so goimports doesn't strip the import.
+  var _ = sort.Slice
+//        ^^^^ reference github.com/golang/go/src go1.22 sort/
+//             ^^^^^ reference github.com/golang/go/src go1.22 sort/Slice().
+  
+  // Bare PkgName reference that triggered the panic.
   var _ = sort
   


### PR DESCRIPTION
PR #261 added an exception in `flake.nix` for the pr261 repro because its `import "sort"` was unused and `goimports` would strip it (breaking the repro).

Add a legitimate `sort.Slice` reference alongside the bare `var _ = sort`. The legitimate use keeps `goimports` happy; the bare ident still tickles the original `should never lookup PkgName ...` assertion, so the test still fails without the visitor fix. The flake-level exception is no longer needed and is removed.